### PR TITLE
Slim CLAUDE.md and move Claude Code config into .claude/

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,24 @@
+# `.claude/`
+
+Project-specific guidance and tooling for Claude Code in this repo.
+
+## Contents
+
+- [`architecture.md`](architecture.md) — repository layout, namespace convention,
+  onion dependency rules. Detailed reference; the top-level `CLAUDE.md` only points here.
+- [`agents/`](agents/) — custom subagents available via the Agent tool.
+  - [`ada.md`](agents/ada.md) — **ADA**, the in-game assistant. Game knowledge only
+    (recipes, ratios, milestone unlocks, building specs, layout tips). Not for code work.
+
+## Adding things later
+
+- New agent → drop a markdown file in `agents/` with YAML frontmatter (`name`,
+  `description`, `tools`). Keep the description action-oriented so Claude knows when
+  to delegate to it.
+- New shared context file → add it here at the top level and link from this README.
+- Slash commands → `commands/<name>.md` (create the folder when first needed).
+- Hooks / settings → `settings.json` or `settings.local.json` (the latter is
+  gitignored for personal overrides).
+
+Keep this folder lightweight. Anything architecturally significant belongs in an ADR
+under `docs/adr/`, not here.

--- a/.claude/agents/ada.md
+++ b/.claude/agents/ada.md
@@ -1,0 +1,72 @@
+---
+name: ada
+description: In-game Satisfactory assistant. Use for any question about the game itself — recipes, byproducts, building specs, power/throughput math, milestone & MAM unlocks, alternate recipe trade-offs, belt/pipe limits, optimal ratios, layout suggestions, and "what should I build next" advice. NOT for editing the ERP planner's code or architecture — that is regular engineering work and stays on the main agent.
+tools: Read, Grep, Glob, WebFetch, WebSearch
+---
+
+You are **ADA** — FICSIT's onboard Artificial Directory and Assistant — embedded in
+Chris's ERP.Satisfactory project as his in-game knowledge advisor.
+
+## Who you help and what for
+
+Chris is a FICSIT pioneer planning factories. He asks you questions like:
+- "What's the best alternate recipe for steel beams at this stage?"
+- "How much copper ore per minute do I need for 240 wire?"
+- "What unlocks at Tier 5, and is it worth rushing?"
+- "I have 600 iron ore/min — what's the highest-tier output I can sustain?"
+- "Sloppy alternate or pure recipe — when does each win?"
+
+Your job is to answer those *accurately*, with the numbers, and with a recommendation.
+
+## Your character
+
+Lean lightly into ADA's in-game voice — warm, corporate-cheerful, FICSIT-flavoured —
+without parodying it. A single greeting line is plenty; do not pad every response with
+flavour. Chris is direct and pragmatic, and so are you.
+
+Examples of *light* flavour that's fine to keep:
+- "Pioneer, the optimal ratio is …"
+- "FICSIT recommends …"
+- A closing line is unnecessary; let the numbers be the answer.
+
+If the answer is a calculation, **show the working** in one or two short lines so Chris
+can sanity-check, then state the result.
+
+## Where to find ground truth
+
+1. **The game catalogue ingested by this project.** The `Satisfactory.Catalog` module
+   (`src/Satisfactory/Catalog/`) parses Satisfactory's `Docs.json` at runtime — items,
+   recipes, buildings, throughputs. When Chris asks about a recipe or building, prefer
+   reading the parser/types in that module over guessing from training data. Look at
+   `DocsJsonParser.cs` and `ParsedCatalog.cs` to understand the shape of the data.
+2. **The official Satisfactory wiki** (`satisfactory.wiki.gg`). Use `WebFetch` for
+   specific pages (recipes, items, milestones) and `WebSearch` when you don't yet know
+   the URL. Cite the page you used.
+3. **Your own knowledge.** Acceptable for general gameplay strategy and well-established
+   facts (belt tier speeds, miner throughput tiers, common ratios). For *exact numbers*
+   on recipes, alternates, or balance changes, verify against #1 or #2 — Satisfactory's
+   numbers shift between updates and Chris is on whichever version his `Docs.json`
+   reflects.
+
+If you're uncertain whether a number is current, say so and offer to check the wiki or
+the catalogue.
+
+## What you do *not* do
+
+- **Do not edit code.** You have no Edit/Write tools by design. If Chris asks for a code
+  change to the ERP planner, tell him this is engineering work and the main agent
+  should handle it.
+- **Do not invent recipes, alternates, milestone unlocks, or numbers.** If you can't
+  verify a specific value, say "let me check" and look it up, or say you don't know.
+- **Do not lecture.** Chris has thousands of hours in this game. Skip the "Satisfactory
+  is a factory-building game…" preamble. Get to the answer.
+
+## Format
+
+- Lead with the answer.
+- Then the working / supporting details.
+- Then, if relevant, a short recommendation ("at this tier, X beats Y because …").
+- Numbers in `code` ticks. Item and building names in **bold** on first mention is fine
+  but not required.
+
+Keep responses tight. A ratio question deserves three lines, not a wall of text.

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -1,0 +1,65 @@
+# Architecture reference
+
+Detailed conventions for working in this repo. The load-bearing *decisions* live in
+[`docs/adr/`](../docs/adr/README.md) — this file is the day-to-day reference.
+
+## Load-bearing decisions (see ADRs for context)
+
+- [.NET 10](../docs/adr/0001-use-dotnet-10.md),
+  [Blazor](../docs/adr/0002-use-blazor-for-ui.md),
+  [.NET Aspire](../docs/adr/0003-use-dotnet-aspire-for-orchestration.md) for orchestration.
+- [Onion Architecture](../docs/adr/0004-use-onion-architecture.md) +
+  [CQRS](../docs/adr/0005-use-cqrs.md) in the application layer.
+- [Wolverine](../docs/adr/0006-use-wolverine-as-mediator.md) is the in-process mediator —
+  **do not reach for MediatR**.
+- [Backlog on GitHub](../docs/adr/0007-track-backlog-on-github.md): epics → milestones,
+  user stories → issues.
+- [Game catalogue ingested at runtime](../docs/adr/0009-runtime-ingestion-of-game-catalogue.md)
+  from `Docs.json` via a [game-agnostic contract](../docs/adr/0010-game-agnostic-catalogue-contract.md).
+
+## Repository layout
+
+```
+src/
+  AppHost/              .NET Aspire orchestrator
+  ApiService/           Backend HTTP API (composes Application + Infrastructure)
+  Web/                  Blazor frontend (composes Application + Infrastructure)
+  ServiceDefaults/      Shared Aspire host defaults
+  ERP/                  The standalone ERP/planning module (Onion layers below)
+    Domain/             ERP.Domain      — entities, value objects, domain events
+    Application/        ERP.Application — CQRS handlers dispatched via Wolverine
+    Infrastructure/     ERP.Infrastructure — persistence, adapters
+  Satisfactory/         Game-specific module — ERP "piggybacks" on this for game data
+    Catalog/            Satisfactory.Catalog — items, recipes, buildings catalogue
+test/
+  ERP/
+    Domain.Tests/
+    Application.Tests/
+docs/
+  adr/                  Architecture Decision Records
+```
+
+## Folder / namespace convention
+
+Folder names drop the full namespace prefix. The parent folder denotes the bounded
+context — e.g. `src/ERP/Domain` → `ERP.Domain.csproj` → namespace `ERP.Domain`.
+
+If we ever add a CRM module, it lives in `src/CRM/...` with namespace `CRM.*`.
+
+## Onion dependency rules
+
+- `ERP.Domain` depends on **nothing**.
+- `ERP.Application` depends on `ERP.Domain`.
+- `ERP.Infrastructure` depends on `ERP.Application` (+ Domain + `Satisfactory.Catalog`).
+- Hosts (`Web`, `ApiService`) depend on `ERP.Application` + `ERP.Infrastructure`.
+- `AppHost` depends on `ApiService` + `Web` (Aspire orchestration only).
+
+When adding new code, place it in the **innermost** layer that satisfies its
+dependencies. Domain logic must not leak into Infrastructure or Web.
+
+## Build & run
+
+```powershell
+dotnet build ERP.Satisfactory.sln
+dotnet run --project src/AppHost
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,77 +1,15 @@
-# ERP.Satisfactory — Claude guidance
+# ERP.Satisfactory
 
-This repository is an ERP-style production-planning system for the game *Satisfactory*.
-The number-one objective is **helping the user plan a factory based on the inputs they
-have and the outputs they need.**
+ERP-style production planner for the game *Satisfactory*. Primary objective:
+**help the user plan a factory based on the inputs they have and the outputs they need.**
 
-## Architecture
+## Where things live
 
-All architecturally significant decisions live in [`docs/adr/`](docs/adr/README.md) as
-Architecture Decision Records. Read the ADR index before making structural changes —
-these decisions are the source of truth for *why* the codebase looks the way it does.
-
-If you make a new architecturally significant decision, **add a new ADR** (copy
-[`0000-template.md`](docs/adr/0000-template.md), give it the next sequential number,
-and update the index in `docs/adr/README.md`). Never silently change a decision recorded
-in an ADR — supersede it with a new one.
-
-Quick summary of the load-bearing decisions (see ADRs for context):
-
-- [.NET 10](docs/adr/0001-use-dotnet-10.md), [Blazor](docs/adr/0002-use-blazor-for-ui.md),
-  [.NET Aspire](docs/adr/0003-use-dotnet-aspire-for-orchestration.md) for orchestration.
-- [Onion Architecture](docs/adr/0004-use-onion-architecture.md) +
-  [CQRS](docs/adr/0005-use-cqrs.md) in the application layer.
-- [Wolverine](docs/adr/0006-use-wolverine-as-mediator.md) is the in-process mediator —
-  **do not reach for MediatR**.
-- [Backlog on GitHub](docs/adr/0007-track-backlog-on-github.md): epics → milestones,
-  user stories → issues.
-
-## Repository layout
-
-```
-src/
-  AppHost/              .NET Aspire orchestrator
-  ApiService/           Backend HTTP API (composes Application + Infrastructure)
-  Web/                  Blazor frontend (composes Application + Infrastructure)
-  ServiceDefaults/      Shared Aspire host defaults
-  ERP/                  The standalone ERP/planning module (Onion layers below)
-    Domain/             ERP.Domain      — entities, value objects, domain events
-    Application/        ERP.Application — CQRS handlers dispatched via Wolverine
-    Infrastructure/     ERP.Infrastructure — persistence, adapters
-  Satisfactory/         Game-specific module — ERP "piggybacks" on this for game data
-    Catalog/            Satisfactory.Catalog — items, recipes, buildings catalogue
-test/
-  ERP/
-    Domain.Tests/
-    Application.Tests/
-docs/
-  adr/                  Architecture Decision Records
-```
-
-**Folder/namespace convention:** folder names drop the full namespace prefix. The
-parent folder denotes the bounded context (e.g. `src/ERP/Domain` →
-`ERP.Domain.csproj` → namespace `ERP.Domain`). If we ever add a CRM module, it lives
-in `src/CRM/...` with namespace `CRM.*`.
-
-## Onion dependency rules
-
-- `ERP.Domain` depends on **nothing**.
-- `ERP.Application` depends on `ERP.Domain`.
-- `ERP.Infrastructure` depends on `ERP.Application` (+ Domain + `Satisfactory.Catalog`).
-- Hosts (`Web`, `ApiService`) depend on `ERP.Application` + `ERP.Infrastructure`.
-- `AppHost` depends on `ApiService` + `Web` (Aspire orchestration only).
-
-When adding new code, place it in the **innermost** layer that satisfies its
-dependencies. Domain logic must not leak into Infrastructure or Web.
-
-## Backlog
-
-Work is tracked on GitHub:
-- **Epics** are GitHub milestones.
-- **User stories** are GitHub issues, assigned to the matching milestone.
-
-When introducing new work, prefer creating an issue over piling things into a single
-session.
+- **Architecture decisions** — [`docs/adr/`](docs/adr/README.md). Read the index before
+  making structural changes; supersede with a new ADR when introducing one.
+- **Project conventions for Claude** — [`.claude/`](.claude/README.md): repo layout,
+  onion rules, build & run, custom agents (incl. the in-game **ADA** assistant).
+- **Backlog** — GitHub: epics = milestones, user stories = issues.
 
 ## Build & run
 


### PR DESCRIPTION
## Summary
- CLAUDE.md becomes a thin pointer (77 → 15 lines); repo layout, onion rules, and other Claude-specific conventions move under `.claude/`
- Adds `.claude/README.md`, `.claude/architecture.md`, and a custom `ada` agent definition (in-game ADA assistant)
- No code or build changes — Claude Code tooling only

## Test plan
- [x] Working tree clean after commit
- [ ] Confirm CLAUDE.md still gives Claude enough top-level guidance to find the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)