### PR TITLE
Fail loudly on unsupported Docs.json versions (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ Restart the app to pick up a new game version (no live reload yet).
 
 **Supported game versions:** the parser is regression-tested against fixtures
 shaped like Update 8 and 1.0. Future versions should still parse — unknown
-fields are ignored, and the parser warns rather than crashes on malformed entries.
-If a new version is rejected, capture a minimal fixture from it and add a test
-case under `test/Satisfactory/Catalog.Tests/Fixtures/`.
+fields are ignored and the parser warns rather than crashes on malformed entries.
+If a new version renames every native class we know about (`FGItemDescriptor`,
+`FGBuildableManufacturer`, `FGRecipe`), the parser fails loudly with a clear
+error rather than silently returning an empty catalogue. When that happens,
+capture a minimal fixture and add a test case under
+`test/Satisfactory/Catalog.Tests/Fixtures/`.
 
 ## Architecture
 

--- a/src/Satisfactory/Catalog/DocsJsonParser.cs
+++ b/src/Satisfactory/Catalog/DocsJsonParser.cs
@@ -110,10 +110,13 @@ public static class DocsJsonParser
         var buildings = new List<Building>();
         var recipeBlocks = new List<JsonElement>();
         var warnings = new List<string>();
+        var totalBlocks = 0;
+        var recognizedBlocks = 0;
 
         // First pass: items + buildings. Recipes are deferred so we can resolve building references.
         foreach (var block in root.EnumerateArray())
         {
+            totalBlocks++;
             if (!block.TryGetProperty("NativeClass", out var nativeClassEl) ||
                 !block.TryGetProperty("Classes", out var classesEl) ||
                 classesEl.ValueKind != JsonValueKind.Array)
@@ -126,6 +129,7 @@ public static class DocsJsonParser
 
             if (ItemNativeClasses.Contains(typeName))
             {
+                recognizedBlocks++;
                 var isRaw = RawResourceNativeClasses.Contains(typeName);
                 foreach (var entry in classesEl.EnumerateArray())
                 {
@@ -139,6 +143,7 @@ public static class DocsJsonParser
             }
             else if (BuildingNativeClasses.Contains(typeName))
             {
+                recognizedBlocks++;
                 foreach (var entry in classesEl.EnumerateArray())
                 {
                     if (TryParseBuilding(entry, warnings) is { } building)
@@ -147,8 +152,21 @@ public static class DocsJsonParser
             }
             else if (RecipeNativeClasses.Contains(typeName))
             {
+                recognizedBlocks++;
                 recipeBlocks.Add(classesEl);
             }
+        }
+
+        // If we saw blocks but recognized none of them, the file shape is wrong
+        // OR the game has renamed every native class we know about. Either way,
+        // the planner can't use this catalogue — fail loudly instead of silently
+        // returning an empty result.
+        if (totalBlocks > 0 && recognizedBlocks == 0)
+        {
+            throw new FormatException(
+                $"Docs.json has {totalBlocks} block(s) but none of their NativeClass entries " +
+                "match a known FGItemDescriptor / FGBuildableManufacturer / FGRecipe class. " +
+                "This usually means an unsupported game version — capture a fixture and add a test.");
         }
 
         // Second pass: recipes (now that we know the buildings).

--- a/test/Satisfactory/Catalog.Tests/DocsJsonParserTests.cs
+++ b/test/Satisfactory/Catalog.Tests/DocsJsonParserTests.cs
@@ -93,6 +93,17 @@ public class DocsJsonParserTests
     }
 
     [Fact]
+    public void Throws_When_All_NativeClasses_Are_Unrecognised()
+    {
+        // Simulates a future game version where every NativeClass we know about has
+        // been renamed (FGItemDescriptor → FGItemDescriptorV2, FGRecipe → FGRecipeV2, …).
+        // The parser must fail loudly rather than silently produce an empty catalogue.
+        var ex = Assert.Throws<FormatException>(
+            () => DocsJsonParser.Parse(ReadFixture("unsupported_version.json")));
+        Assert.Contains("unsupported game version", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Reads_Utf16_Bom_Encoded_Stream()
     {
         // Satisfactory ships Docs.json as UTF-16 LE on Windows.

--- a/test/Satisfactory/Catalog.Tests/Fixtures/unsupported_version.json
+++ b/test/Satisfactory/Catalog.Tests/Fixtures/unsupported_version.json
@@ -1,0 +1,21 @@
+[
+  {
+    "NativeClass": "/Script/CoreUObject.Class'/Script/FactoryGame.FGItemDescriptorV2'",
+    "Classes": [
+      { "ClassName": "Desc_IronOre_C", "mDisplayName": "Iron Ore" }
+    ]
+  },
+  {
+    "NativeClass": "/Script/CoreUObject.Class'/Script/FactoryGame.FGRecipeV2'",
+    "Classes": [
+      {
+        "ClassName": "Recipe_IngotIron_C",
+        "mDisplayName": "Iron Ingot",
+        "mIngredients": "((ItemClass=\"/Game/.../Desc_IronOre.Desc_IronOre_C\",Amount=1))",
+        "mProduct":     "((ItemClass=\"/Game/.../Desc_IronIngot.Desc_IronIngot_C\",Amount=1))",
+        "mManufactoringDuration": "2.000000",
+        "mProducedIn": "(\"/Game/.../Build_SmelterMk1.Build_SmelterMk1_C\")"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Adds a guard in `DocsJsonParser` that throws `FormatException` if the file has blocks but none of their `NativeClass` entries match a known FG class (item / building / recipe). Previously this silently returned an empty catalogue.
- New fixture `unsupported_version.json` simulating renamed native classes (`FGItemDescriptorV2`, `FGRecipeV2`).
- New test `Throws_When_All_NativeClasses_Are_Unrecognised` (18 tests pass, was 17).
- README "Supported game versions" updated to describe the new fail-loud behaviour.

This closes out the **Catalogue Ingestion** milestone — Update 8 and 1.0 fixtures are already covered by existing tests; this PR delivers the remaining acceptance bullet ("an unknown future version produces a clear error, not a silent partial parse").

## Test plan
- [x] `dotnet test test/Satisfactory/Catalog.Tests/...` — all 18 pass
- [x] Existing fixtures (update8, update10, malformed) still pass — the guard only fires when **zero** native classes are recognised, so the malformed fixture (which still has FGItemDescriptor + FGRecipe blocks) is unaffected
- [ ] Manual: aim app at a real Docs.json — still loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)