### PR TITLE
feat(parser): bind miner→node + recipe → building (#35, partial)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ baseline-*.png
 themed-*.png
 bespoke-*.png
 map-*.png
+35-*.png
+aspire-*.png

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -57,10 +57,11 @@ app.MapPost("/catalogue/configure", (ConfigureCatalogueRequest request, ICatalog
     }
 });
 
-app.MapGet("/factory/state", (IFactoryStateProvider provider) => FactoryStateView.From(provider));
+app.MapGet("/factory/state", (IFactoryStateProvider provider, ICatalogProvider catalog) =>
+    FactoryStateView.From(provider, catalog));
 
-app.MapGet("/factory/state.geojson", (IFactoryStateProvider provider) =>
-    Results.Json(FactoryStateGeoJson.From(provider), contentType: "application/geo+json"));
+app.MapGet("/factory/state.geojson", (IFactoryStateProvider provider, ICatalogProvider catalog) =>
+    Results.Json(FactoryStateGeoJson.From(provider, catalog), contentType: "application/geo+json"));
 
 app.MapGet("/factory/saves", () =>
     SaveFileResolver.EnumerateDetectedSaves()
@@ -68,7 +69,8 @@ app.MapGet("/factory/saves", () =>
         .ToList());
 
 app.MapPost("/factory/ingest", async (
-    IngestSaveRequest request, IMessageBus bus, IFactoryStateProvider provider, ILoggerFactory loggerFactory) =>
+    IngestSaveRequest request, IMessageBus bus, IFactoryStateProvider provider,
+    ICatalogProvider catalog, ILoggerFactory loggerFactory) =>
 {
     if (string.IsNullOrWhiteSpace(request.SavePath))
         return Results.BadRequest(new { error = "SavePath is required." });
@@ -80,7 +82,7 @@ app.MapPost("/factory/ingest", async (
         sw.Stop();
         loggerFactory.CreateLogger("FactoryIngestEndpoint")
             .LogInformation("Ingested save in {Elapsed}ms", sw.ElapsedMilliseconds);
-        return Results.Ok(FactoryStateView.From(provider));
+        return Results.Ok(FactoryStateView.From(provider, catalog));
     }
     catch (FileNotFoundException ex)
     {
@@ -138,18 +140,27 @@ public sealed record SaveMetadataView(
 
 public sealed record CountView(string Key, int Count);
 
+/// <summary>One row in the "buildings by type × recipe" table on /factory/ingest.</summary>
+public sealed record BuildingGroupView(
+    string Building,
+    string? Recipe,
+    string? RecipeName,
+    int Count);
+
 public sealed record FactoryStateView(
     bool IsLoaded,
     string? Source,
     SaveMetadataView? Save,
     IReadOnlyList<CountView> Miners,
-    IReadOnlyList<CountView> Buildings,
+    int MinersBoundToNode,
+    IReadOnlyList<BuildingGroupView> Buildings,
+    int BuildingsWithRecipe,
     IReadOnlyList<CountView> Belts,
     IReadOnlyList<CountView> Generators,
     int ResourceNodeCount,
     IReadOnlyList<string> Warnings)
 {
-    public static FactoryStateView From(IFactoryStateProvider provider)
+    public static FactoryStateView From(IFactoryStateProvider provider, ICatalogProvider catalog)
     {
         var state = provider.Current;
         var meta = provider.IsLoaded
@@ -170,11 +181,20 @@ public sealed record FactoryStateView(
                 .Select(g => new CountView(g.Key, g.Count()))
                 .OrderBy(c => c.Key, StringComparer.Ordinal)
                 .ToList(),
+            MinersBoundToNode: state.Miners.Count(m => !string.IsNullOrEmpty(m.ResourceNodeReference)),
             Buildings: state.Buildings
-                .GroupBy(b => b.Building.Value)
-                .Select(g => new CountView(g.Key, g.Count()))
-                .OrderByDescending(c => c.Count)
+                .GroupBy(b => (Building: b.Building.Value, Recipe: b.Recipe?.Value))
+                .Select(g => new BuildingGroupView(
+                    Building: g.Key.Building,
+                    Recipe: g.Key.Recipe,
+                    RecipeName: g.Key.Recipe is { Length: > 0 } r
+                        ? catalog.FindRecipe(new RecipeId(r))?.Name
+                        : null,
+                    Count: g.Count()))
+                .OrderBy(b => b.Building, StringComparer.Ordinal)
+                .ThenByDescending(b => b.Count)
                 .ToList(),
+            BuildingsWithRecipe: state.Buildings.Count(b => b.Recipe is not null),
             Belts: state.Belts
                 .GroupBy(b => b.Tier.ToString())
                 .Select(g => new CountView(g.Key, g.Count()))
@@ -226,7 +246,7 @@ public sealed record FactoryStateGeoJson(
     IReadOnlyList<GeoFeature> Features,
     Dictionary<string, object?> Metadata)
 {
-    public static FactoryStateGeoJson From(IFactoryStateProvider provider)
+    public static FactoryStateGeoJson From(IFactoryStateProvider provider, ICatalogProvider catalog)
     {
         var s = provider.Current;
         var features = new List<GeoFeature>();
@@ -249,6 +269,10 @@ public sealed record FactoryStateGeoJson(
             features.Add(GeoFeature.Make("building", b.Building.Value, b.Position, new()
             {
                 ["recipe"] = b.Recipe?.Value,
+                ["recipeName"] = b.Recipe is { Value: { Length: > 0 } } id
+                    ? catalog.FindRecipe(id)?.Name
+                    : null,
+                ["clockSpeed"] = b.ClockSpeed,
             }));
 
         foreach (var belt in s.Belts)

--- a/src/ERP/Domain/ProductionBuilding.cs
+++ b/src/ERP/Domain/ProductionBuilding.cs
@@ -2,12 +2,12 @@ namespace ERP.Domain;
 
 /// <summary>
 /// A placed factory building that runs a recipe (smelter, constructor,
-/// assembler, foundry, manufacturer, refinery, …). RecipeId is unset for v1 —
-/// recipe binding requires deeper property-tree parsing and is tracked as a
-/// follow-up on milestone #12.
+/// assembler, foundry, manufacturer, refinery, …). <see cref="ClockSpeed"/>
+/// is 1.0 for default (100%); overclocked machines go up to 2.5.
 /// </summary>
 public sealed record ProductionBuilding(
     string Reference,
     BuildingId Building,
     Position Position,
-    RecipeId? Recipe);
+    RecipeId? Recipe,
+    decimal ClockSpeed = 1.0m);

--- a/src/Satisfactory/Save/PropertyExtensions.cs
+++ b/src/Satisfactory/Save/PropertyExtensions.cs
@@ -1,0 +1,53 @@
+using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
+
+namespace Satisfactory.Save;
+
+/// <summary>
+/// Convenience accessors over <see cref="ComponentObject.Properties"/>.
+///
+/// In v1.2+ the fork normalises every property into a single
+/// <see cref="RawProperty"/> shape with typed slots (FloatValue,
+/// ObjectValue, StringValue, …). These helpers walk by name and pull the
+/// expected slot, returning <c>null</c> when absent. Mirrors what
+/// fork-side issue #6 proposes adding directly on <c>ComponentObject</c>.
+/// </summary>
+public static class PropertyExtensions
+{
+    /// <summary>Reads a float property by name (e.g. <c>mCurrentPotential</c>).</summary>
+    public static float? TryGetFloat(this ComponentObject actor, string name)
+        => FindRaw(actor, name)?.FloatValue;
+
+    /// <summary>Reads an object reference's <c>PathName</c> by name.</summary>
+    public static string? TryGetObjectPath(this ComponentObject actor, string name)
+        => FindRaw(actor, name)?.ObjectValue?.PathName;
+
+    /// <summary>Reads a string / name property by name.</summary>
+    public static string? TryGetString(this ComponentObject actor, string name)
+        => FindRaw(actor, name)?.StringValue;
+
+    /// <summary>Reads an int property by name.</summary>
+    public static int? TryGetInt(this ComponentObject actor, string name)
+        => FindRaw(actor, name)?.IntValue;
+
+    /// <summary>
+    /// Returns the trailing class segment of a class path
+    /// (e.g. <c>/Game/.../Desc_OreIron.Desc_OreIron_C</c> → <c>Desc_OreIron_C</c>).
+    /// Returns the input unchanged when it doesn't contain a <c>'.'</c>.
+    /// </summary>
+    public static string? ShortClassName(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        var dot = path.LastIndexOf('.');
+        return dot < 0 ? path : path[(dot + 1)..];
+    }
+
+    private static RawProperty? FindRaw(ComponentObject actor, string name)
+    {
+        foreach (var p in actor.Properties)
+        {
+            if (p is RawProperty raw && p.Name == name) return raw;
+        }
+        return null;
+    }
+}

--- a/src/Satisfactory/Save/SaveFileReader.cs
+++ b/src/Satisfactory/Save/SaveFileReader.cs
@@ -7,9 +7,7 @@ namespace Satisfactory.Save;
 /// <summary>
 /// Parses a Satisfactory <c>.sav</c> file via the patched
 /// <c>SatisfactorySaveNet</c> fork and projects the result into game-agnostic
-/// domain entities. v1 returns counts + positions only; deeper property
-/// extraction (recipe binding, miner→node linkage, belt endpoints) is tracked
-/// as a follow-up on milestone #12.
+/// domain entities.
 /// </summary>
 public sealed class SaveFileReader
 {
@@ -48,12 +46,25 @@ public sealed class SaveFileReader
 
             if (BuildingIdentifiers.MinerTier(typePath) is { } tier)
             {
-                miners.Add(new Miner(reference, tier, position, ResourceNodeReference: null));
+                // `mExtractableResource` (not `mExtractResourceNode`) is the live binding
+                // from the miner to the resource node it's pulling from.
+                var nodeRef = actor.TryGetObjectPath("mExtractableResource");
+                miners.Add(new Miner(reference, tier, position, ResourceNodeReference: nodeRef));
             }
             else if (BuildingIdentifiers.IsProductionBuilding(typePath))
             {
                 var buildingId = new BuildingId(BuildingIdentifiers.ShortName(typePath));
-                buildings.Add(new ProductionBuilding(reference, buildingId, position, Recipe: null));
+                var recipePath = actor.TryGetObjectPath("mCurrentRecipe");
+                var recipeId = PropertyExtensions.ShortClassName(recipePath) is { Length: > 0 } recipeShort
+                    ? new RecipeId(recipeShort)
+                    : (RecipeId?)null;
+                // `mCurrentPotential` only appears in the save when overclocked away
+                // from default 1.0 — default-clock machines have no value serialized.
+                var clock = actor.TryGetFloat("mCurrentPotential");
+                buildings.Add(new ProductionBuilding(
+                    reference, buildingId, position,
+                    Recipe: recipeId,
+                    ClockSpeed: clock is null ? 1.0m : (decimal)clock.Value));
             }
             else if (BuildingIdentifiers.BeltTier(typePath) is { } beltTier)
             {
@@ -65,6 +76,11 @@ public sealed class SaveFileReader
             }
             else if (BuildingIdentifiers.IsResourceNode(typePath))
             {
+                // Resource class (e.g. Desc_OreIron_C) and purity are *blueprint
+                // class defaults* on the resource-node actor — they're not
+                // instance-serialized into the save. Surfacing them requires a
+                // separate catalogue/blueprint lookup keyed by node coordinates
+                // (deferred — out of scope for the v1.2 .sav parser).
                 resourceNodes.Add(new ResourceNode(reference, Resource: null, NodePurity.Unknown, position));
             }
         }

--- a/src/Web/Components/Pages/FactoryIngest.razor
+++ b/src/Web/Components/Pages/FactoryIngest.razor
@@ -36,6 +36,12 @@ else
             <div class="col-md-6">
                 <h5>Miners <span class="text-muted small">by tier</span></h5>
                 @CountTable(state.Miners, "No miners.")
+                @if (state.Miners.Count > 0)
+                {
+                    <p class="small text-muted mt-1">
+                        @state.MinersBoundToNode / @state.Miners.Sum(m => m.Count) bound to a resource node.
+                    </p>
+                }
             </div>
             <div class="col-md-6">
                 <h5>Belts <span class="text-muted small">by tier</span></h5>
@@ -56,10 +62,12 @@ else
 
         <div class="row mt-3">
             <div class="col-12">
-                <h5>Production buildings <span class="text-muted small">by type</span></h5>
-                @CountTable(state.Buildings, "No production buildings.")
+                <h5>Production buildings <span class="text-muted small">by type × recipe</span></h5>
+                @BuildingTable(state.Buildings, "No production buildings.")
                 <p class="small text-muted mt-1">
-                    Clock speed and bound recipe are not yet extracted — tracked as a follow-up to milestone #12.
+                    @state.BuildingsWithRecipe / @state.Buildings.Sum(b => b.Count) bound to a recipe.
+                    Clock speed comes through as 100% for default-clocked machines (the game only serializes
+                    overclocked values).
                 </p>
             </div>
         </div>
@@ -196,9 +204,10 @@ else
             if (result.Success && result.State is not null)
             {
                 state = result.State;
+                var totalMiners = result.State.Miners.Sum(m => m.Count);
                 var totalBuildings = result.State.Buildings.Sum(b => b.Count);
-                message = $"Loaded {result.State.Miners.Sum(m => m.Count)} miners, "
-                    + $"{totalBuildings} buildings, {result.State.Belts.Sum(b => b.Count)} belts.";
+                var totalBelts = result.State.Belts.Sum(b => b.Count);
+                message = $"Loaded {totalMiners} miners, {totalBuildings} buildings, {totalBelts} belts.";
                 messageIsError = false;
             }
             else
@@ -238,6 +247,49 @@ else
                 {
                     <tr>
                         <td><code>@row.Key</code></td>
+                        <td class="text-end">@row.Count.ToString("N0")</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    };
+
+    private static RenderFragment BuildingTable(IReadOnlyList<BuildingGroupViewModel> rows, string emptyLabel) => __builder =>
+    {
+        if (rows.Count == 0)
+        {
+            <p class="text-muted small mb-0">@emptyLabel</p>
+            return;
+        }
+
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th scope="col">Building</th>
+                    <th scope="col">Recipe</th>
+                    <th scope="col" class="text-end">Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in rows)
+                {
+                    <tr>
+                        <td><code>@row.Building</code></td>
+                        <td>
+                            @if (row.RecipeName is not null)
+                            {
+                                <span>@row.RecipeName</span>
+                                <small class="text-muted ms-1">(<code>@row.Recipe</code>)</small>
+                            }
+                            else if (row.Recipe is not null)
+                            {
+                                <code>@row.Recipe</code>
+                            }
+                            else
+                            {
+                                <span class="text-muted small">— idle —</span>
+                            }
+                        </td>
                         <td class="text-end">@row.Count.ToString("N0")</td>
                     </tr>
                 }

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -101,12 +101,20 @@ public sealed record SaveMetadataViewModel(
 
 public sealed record CountViewModel(string Key, int Count);
 
+public sealed record BuildingGroupViewModel(
+    string Building,
+    string? Recipe,
+    string? RecipeName,
+    int Count);
+
 public sealed record FactoryStateViewModel(
     bool IsLoaded,
     string? Source,
     SaveMetadataViewModel? Save,
     IReadOnlyList<CountViewModel> Miners,
-    IReadOnlyList<CountViewModel> Buildings,
+    int MinersBoundToNode,
+    IReadOnlyList<BuildingGroupViewModel> Buildings,
+    int BuildingsWithRecipe,
     IReadOnlyList<CountViewModel> Belts,
     IReadOnlyList<CountViewModel> Generators,
     int ResourceNodeCount,

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -252,10 +252,16 @@ function popupHtml(feature) {
         `<div class="fx-popup-title">${escapeHtml(p.category)}</div>`,
         `<div class="fx-popup-kind">${escapeHtml(shortName(p.kind))}</div>`,
     ];
-    const skip = new Set(['category', 'kind']);
+    // For production buildings, surface the human-readable recipe name first.
+    if (p.recipeName) {
+        rows.push(`<div class="fx-popup-row"><span>recipe</span><span>${escapeHtml(p.recipeName)}</span></div>`);
+    }
+    const skip = new Set(['category', 'kind', 'recipeName']);
     for (const [k, v] of Object.entries(p)) {
         if (skip.has(k) || v == null) continue;
-        rows.push(`<div class="fx-popup-row"><span>${escapeHtml(k)}</span><code>${escapeHtml(String(v))}</code></div>`);
+        // Shorten verbose object-ref paths (e.g. resourceNode) to the trailing segment.
+        const display = typeof v === 'string' && v.includes('.') ? shortName(v) : String(v);
+        rows.push(`<div class="fx-popup-row"><span>${escapeHtml(k)}</span><code>${escapeHtml(display)}</code></div>`);
     }
     return `<div class="fx-popup">${rows.join('')}</div>`;
 }

--- a/test/Satisfactory/Save.Tests/SaveFileReaderParityTests.cs
+++ b/test/Satisfactory/Save.Tests/SaveFileReaderParityTests.cs
@@ -4,7 +4,7 @@ namespace Satisfactory.Save.Tests;
 
 /// <summary>
 /// End-to-end parity check: parse a real v1.2 save and confirm the adapter's
-/// counts line up with the human-curated stocktake. Gated on the
+/// shape lines up with what's actually in the file. Gated on the
 /// <c>ERP_SATISFACTORY_SAVE_PATH</c> env var or auto-detect — passes silently
 /// when no save is available so CI doesn't fail on developers without one.
 /// When the env var points at a directory the resolver picks the most-recent
@@ -30,10 +30,21 @@ public class SaveFileReaderParityTests
         Assert.NotEqual(0, state.Save.SaveVersion);
         Assert.NotEqual(0, state.Save.BuildVersion);
         Assert.NotEmpty(state.Save.SessionName);
-
-        // We expect some world content in any real save — at least one
-        // resource node. Asserting specific miner/smelter counts would pin
-        // this test to one particular save snapshot.
         Assert.NotEmpty(state.ResourceNodes);
+
+        // #35 — deep-parsed fields. Conditional because the Pedestal test
+        // fixture has resource nodes but no miners / no buildings.
+        if (state.Miners.Count > 0)
+        {
+            Assert.Contains(state.Miners, m => !string.IsNullOrEmpty(m.ResourceNodeReference));
+        }
+
+        if (state.Buildings.Count > 0)
+        {
+            Assert.Contains(state.Buildings, b => b.Recipe is not null);
+            // All buildings default to 1.0 clock speed (only overclocked ones
+            // serialize a value); assert default clock is plausible.
+            Assert.All(state.Buildings, b => Assert.InRange(b.ClockSpeed, 0.01m, 2.5m));
+        }
     }
 }

--- a/tools/SatisfactorySaveNet.Poc/Program.cs
+++ b/tools/SatisfactorySaveNet.Poc/Program.cs
@@ -70,7 +70,87 @@ Console.WriteLine("=== Generators by kind ===");
 foreach (var g in s.Generators.GroupBy(g => g.Kind).OrderBy(g => g.Key))
     Console.WriteLine($"  {g.Key}: {g.Count()}");
 
+Console.WriteLine();
+Console.WriteLine("=== RAW PROPERTY DUMP (one sample per actor type) ===");
+var save2 = SatisfactorySaveNet.SaveFileSerializer.Instance.Deserialize(savePath);
+if (save2.Body is SatisfactorySaveNet.Abstracts.Model.BodyV8 b2)
+{
+    var actors = b2.Levels.SelectMany(l => l.Objects).OfType<SatisfactorySaveNet.Abstracts.Model.ActorObject>().ToList();
+    DumpActor(actors.FirstOrDefault(a => a.TypePath?.Contains("Build_MinerMk1_C") == true), "Miner");
+    DumpActor(actors.FirstOrDefault(a => a.TypePath?.Contains("Build_SmelterMk1_C") == true), "Smelter");
+    DumpActor(actors.FirstOrDefault(a => a.TypePath?.Contains("Build_ConstructorMk1_C") == true), "Constructor");
+    DumpActor(actors.FirstOrDefault(a => a.TypePath?.Contains("BP_ResourceNode_C") == true), "ResourceNode (BP_ResourceNode_C)");
+    DumpActor(actors.FirstOrDefault(a => a.TypePath?.Contains("BP_ResourceDeposit_C") == true), "ResourceDeposit");
+}
+
+Console.WriteLine();
+Console.WriteLine("=== Resource nodes by purity ===");
+foreach (var g in s.ResourceNodes.GroupBy(n => n.Purity).OrderBy(g => g.Key))
+    Console.WriteLine($"  {g.Key}: {g.Count()}");
+
+Console.WriteLine();
+Console.WriteLine("=== Resource nodes by resource (top 10) ===");
+foreach (var g in s.ResourceNodes
+    .Where(n => n.Resource is not null)
+    .GroupBy(n => n.Resource!.Value)
+    .OrderByDescending(g => g.Count())
+    .Take(10))
+    Console.WriteLine($"  {g.Count(),5}  {g.Key}");
+
+Console.WriteLine();
+Console.WriteLine("=== Miners with bound resource node ===");
+var minerNodeBound = s.Miners.Count(m => !string.IsNullOrEmpty(m.ResourceNodeReference));
+Console.WriteLine($"  {minerNodeBound} / {s.Miners.Count}");
+
+Console.WriteLine();
+Console.WriteLine("=== Buildings by clock speed bucket ===");
+foreach (var g in s.Buildings.GroupBy(b => ClockBucket(b.ClockSpeed)).OrderBy(g => g.Key))
+    Console.WriteLine($"  {g.Key}: {g.Count()}");
+
+Console.WriteLine();
+Console.WriteLine("=== Buildings with bound recipe ===");
+var buildingsWithRecipe = s.Buildings.Count(b => b.Recipe is not null);
+Console.WriteLine($"  {buildingsWithRecipe} / {s.Buildings.Count}");
+Console.WriteLine("  Top 5 recipes:");
+foreach (var g in s.Buildings.Where(b => b.Recipe is not null)
+    .GroupBy(b => b.Recipe!.Value).OrderByDescending(g => g.Count()).Take(5))
+    Console.WriteLine($"    {g.Count(),3}  {g.Key}");
+
 return 0;
+
+static string ClockBucket(decimal cs)
+{
+    if (cs == 1.0m) return "100% (default)";
+    if (cs < 0.5m) return $"< 50% ({cs:P0})";
+    if (cs < 1.0m) return $"underclocked ({cs:P0})";
+    return $"overclocked ({cs:P0})";
+}
+
+static void DumpActor(SatisfactorySaveNet.Abstracts.Model.ActorObject? actor, string label)
+{
+    Console.WriteLine();
+    if (actor is null) { Console.WriteLine($"  [{label}] none found."); return; }
+    Console.WriteLine($"  [{label}] TypePath={actor.TypePath}");
+    Console.WriteLine($"    Properties ({actor.Properties.Count}):");
+    foreach (var p in actor.Properties)
+    {
+        var t = p.GetType().Name;
+        string v = "(?)";
+        if (p is SatisfactorySaveNet.Abstracts.Model.Properties.RawProperty r)
+        {
+            t = $"Raw[{r.Type}]";
+            if (r.ObjectValue is { } ov) v = $"obj:\"{ov.PathName}\"";
+            else if (r.FloatValue is { } fv) v = $"float:{fv}";
+            else if (r.StringValue is { } sv) v = $"str:\"{sv}\"";
+            else if (r.IntValue is { } iv) v = $"int:{iv}";
+            else if (r.BoolValue is { } bv) v = $"bool:{bv}";
+            else if (r.LongValue is { } lv) v = $"long:{lv}";
+            else if (r.SByteValue is { } sbv) v = $"sbyte:{sbv}";
+            else v = $"(BinarySize={r.BinarySize}, no typed slot)";
+        }
+        Console.WriteLine($"      {p.Name,-40}  {t,-30}  {v}");
+    }
+}
 
 static string? FindLatestSave(string dir)
 {


### PR DESCRIPTION
Walks \`actor.Properties\` in SaveFileReader and pulls the deep fields that issue #35 asked for. **Two of the five fields work fully, three turned out to be blueprint-class defaults the save file doesn't carry.**

## Fully populated now

| Field | From | Test save result |
|---|---|---|
| \`Miner.ResourceNodeReference\` | \`mExtractableResource\` (issue had \`mExtractResourceNode\` — wrong name) | 19/19 miners bound |
| \`ProductionBuilding.Recipe\` | \`mCurrentRecipe\` | 67/67 bound. Resolves to human names via \`ICatalogProvider.FindRecipe\` (e.g. \`Recipe_IngotIron_C\` → "Iron Ingot") |
| \`ProductionBuilding.ClockSpeed\` | \`mCurrentPotential\` when present | All 1.0 in the test save (game only serializes non-default values) |

## Not populated, with rationale

- **\`ResourceNode.Resource\`** and **\`ResourceNode.Purity\`** are *blueprint class defaults*, not instance-serialized properties. The resource node actor in the save carries only \`mResourcesLeft\` — no \`mPurity\`, no \`mResourceClass\`. Surfacing them requires a separate catalogue/blueprint lookup keyed by node position. Out of scope for this PR; will cut a follow-up issue.

## Implementation notes

- New \`PropertyExtensions\` wraps v1.2+ \`RawProperty\` (the fork unified all property types under a single \`RawProperty\` with typed slots — \`FloatValue\`, \`ObjectValue\`, \`StringValue\` — rather than separate \`FloatProperty\`/\`ObjectProperty\` subclasses).
- \`FactoryStateView.From\` now takes \`ICatalogProvider\` for recipe-name resolution.
- New \`BuildingGroupView\` exposes Building × Recipe × RecipeName × Count.
- \`FactoryIngest.razor\` renders the new shape — recipes show "Iron Plate" alongside \`Recipe_IronPlate_C\`. Summary lines: "N/M bound to a resource node", "N/M bound to a recipe".
- Map popup surfaces \`recipeName\` first, shortens object-ref paths to trailing segments.
- Parity test strengthened conditionally (Pedestal fixture has no factory content, so it skips those assertions; Beta Game asserts them).

## Verified

The per-recipe building breakdown matches Chris's stocktake exactly:
- 16 Smelters → Iron Ingot, 4 → Copper Ingot
- 14 Constructors → Iron Rod, 9 → Screws, 8 → Iron Plate, 4 → Concrete, 2 → Wire, 1 → Cable, etc.
- 4 Assemblers → Reinforced Iron Plate
- 19/19 miners bound to their resource nodes

## Test plan

- [ ] CI: Lint + Build & Test green
- [ ] Open \`/factory/ingest\` → ingest \`Beta Game_autosave_1.sav\` → Production buildings table shows Building × Recipe rows
- [ ] Open \`/factory/map\` → click a smelter → popup shows recipe name "Iron Ingot" not just \`Recipe_IngotIron_C\`
- [ ] Auto-release fires on merge → \`v0.1.x\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)