### PR TITLE
chore(map): strip procedural backdrop, keep wiki maps + none

### DIFF
--- a/docs/adr/0015-map-backdrops-fair-use.md
+++ b/docs/adr/0015-map-backdrops-fair-use.md
@@ -72,3 +72,13 @@ don't apply.
 - Adding a fourth map (e.g. resource-overlay, infrastructure) is a
   data drop + one entry in the `MAP_BACKDROPS` table in
   `factory-map.js` and one radio option in Settings.
+
+## Update — procedural backdrop removed (2026-05-13)
+
+The procedural option referenced above was shipped and then removed
+shortly after. The IDW Z-sample heightfield produced a recognisably
+"blurry blob" result that no user would prefer over a wiki map, and
+maintaining ~200 lines of interpolation + colormap + hillshading code
+for an unused fallback wasn't worth it. The three wiki backdrops plus
+"none" remain. If a procedural option is wanted again later, the prior
+implementation lives in git history at commit `0368b2d`.

--- a/src/Web/Components/Pages/Settings.razor
+++ b/src/Web/Components/Pages/Settings.razor
@@ -66,16 +66,14 @@ else
         <option value="terrain">Terrain (wiki)</option>
         <option value="biome">Biome (wiki)</option>
         <option value="water">Water (wiki)</option>
-        <option value="procedural">Procedural (from save data)</option>
         <option value="none">None (dark canvas)</option>
     </select>
     <div class="form-text">
-        Three of these backdrops are sourced from the
+        Backdrops are sourced from the
         <a href="https://satisfactory.wiki.gg/" target="_blank" rel="noreferrer">Satisfactory Fandom wiki</a>
         under fair-use terms for non-commercial fan tools — see
         <a href="https://github.com/ChrisonSimtian/ERP.Satisfactory/blob/main/docs/adr/0015-map-backdrops-fair-use.md"
             target="_blank" rel="noreferrer">ADR-0015</a>.
-        The "procedural" option generates a topographic surface from your save's resource-node Z samples (no Coffee Stain assets).
         @if (!string.IsNullOrEmpty(mapMessage))
         {
             <span class="text-success ms-2">@mapMessage</span>

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -193,22 +193,18 @@ function buildCategoryLayers(featureCollection) {
 // -------------------------------------------------------------------------
 // Backdrops
 //
-// Several user-selectable options (ADR-0015):
-// - terrain / biome / water: wiki-sourced game maps from
-//   /lib/maps/{terrain.jpg, biome.jpg, water.png}
-// - procedural: IDW heightfield from resource-node Z samples
-//   (kept as a fallback for modded maps or users who prefer it)
-// - none: no backdrop, dark canvas only
+// User-selectable wiki-sourced game maps (ADR-0015) or no backdrop:
+// - terrain / biome / water: /lib/maps/{terrain.jpg, biome.jpg, water.png}
+// - none: dark canvas only
 //
-// Selection is persisted in localStorage under 'erp-map-backdrop'.
-// Default: 'terrain'.
+// Selection persisted in localStorage under 'erp-map-backdrop'.
+// Default: 'terrain'. Per-image bounds calibration is tracked in #43.
 // -------------------------------------------------------------------------
 
 const MAP_BACKDROPS = {
     'terrain': { kind: 'image', src: '/lib/maps/terrain.jpg', label: 'Terrain (wiki)' },
     'biome':   { kind: 'image', src: '/lib/maps/biome.jpg',   label: 'Biome (wiki)' },
     'water':   { kind: 'image', src: '/lib/maps/water.png',   label: 'Water (wiki)' },
-    'procedural': { kind: 'procedural', label: 'Procedural (from save data)' },
     'none':    { kind: 'none', label: 'None (dark canvas)' },
 };
 const DEFAULT_BACKDROP = 'terrain';
@@ -225,26 +221,11 @@ function addBackdrop(featureCollection) {
     const choice = readBackdropChoice();
     const backdrop = MAP_BACKDROPS[choice];
     if (!backdrop || backdrop.kind === 'none') return;
-
-    if (backdrop.kind === 'image') {
-        addImageBackdrop(featureCollection, backdrop.src);
-        return;
-    }
-    if (backdrop.kind === 'procedural') {
-        addTopographicBackdrop(featureCollection);
-        return;
-    }
+    if (backdrop.kind === 'image') addImageBackdrop(featureCollection, backdrop.src);
 }
 
 function addImageBackdrop(featureCollection, imageSrc) {
-    const samples = collectElevationSamples(featureCollection);
-    // Use the same padded resource-node extent as the procedural backdrop
-    // so markers align with the image. Wiki maps cover (approximately) the
-    // playable world, which is what the resource nodes inhabit.
-    const ext = samples.length >= 3
-        ? computeUnrealExtent(samples, 0.15)
-        : { minX: -400000, maxX: 400000, minY: -400000, maxY: 400000 };
-
+    const ext = resourceNodeExtent(featureCollection, 0.15);
     const sw = unrealToLatLng(ext.minX, ext.maxY);
     const ne = unrealToLatLng(ext.maxX, ext.minY);
     backdropLayer = L.imageOverlay(imageSrc, [sw, ne], {
@@ -255,51 +236,21 @@ function addImageBackdrop(featureCollection, imageSrc) {
     backdropLayer.addTo(map);
 }
 
-function addTopographicBackdrop(featureCollection) {
-    const samples = collectElevationSamples(featureCollection);
-    if (samples.length < 3) {
-        // Not enough samples for IDW — skip backdrop, map will just be
-        // dark canvas.
-        return;
-    }
-
-    // Wider canvas extent than the data so the map doesn't end abruptly
-    // at the outermost resource node. Pad by ~15%.
-    const ext = computeUnrealExtent(samples, 0.15);
-    const RES = 192;
-    const canvas = renderHeightCanvas(samples, ext, RES);
-
-    const sw = unrealToLatLng(ext.minX, ext.maxY); // south-west on Leaflet
-    const ne = unrealToLatLng(ext.maxX, ext.minY); // north-east
-    const bounds = [sw, ne];
-
-    backdropLayer = L.imageOverlay(canvas.toDataURL('image/png'), bounds, {
-        interactive: false,
-        opacity: 1.0,
-        className: 'fx-topo-backdrop',
-    });
-    backdropLayer.addTo(map);
-}
-
-function collectElevationSamples(featureCollection) {
-    const samples = [];
+function resourceNodeExtent(featureCollection, padFraction) {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    let count = 0;
     for (const f of featureCollection.features) {
         if (f.properties?.category !== 'resource-node') continue;
         const [x, y] = f.geometry.coordinates;
-        const z = f.properties.z;
-        if (typeof z !== 'number' || !Number.isFinite(z)) continue;
-        samples.push([x, y, z]);
-    }
-    return samples;
-}
-
-function computeUnrealExtent(samples, padFraction) {
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const [x, y] of samples) {
         if (x < minX) minX = x;
         if (y < minY) minY = y;
         if (x > maxX) maxX = x;
         if (y > maxY) maxY = y;
+        count++;
+    }
+    if (count < 3) {
+        // Fallback to nominal Satisfactory world bounds.
+        return { minX: -400000, maxX: 400000, minY: -400000, maxY: 400000 };
     }
     const padX = (maxX - minX) * padFraction;
     const padY = (maxY - minY) * padFraction;
@@ -307,184 +258,6 @@ function computeUnrealExtent(samples, padFraction) {
         minX: minX - padX, maxX: maxX + padX,
         minY: minY - padY, maxY: maxY + padY,
     };
-}
-
-function renderHeightCanvas(samples, ext, res) {
-    // Spatial hash for fast nearest-neighbour queries. Buckets cover the
-    // extent in BUCKET × BUCKET cells; each bucket holds the indices of
-    // samples that fall inside it.
-    const BUCKETS = 16;
-    const cellW = (ext.maxX - ext.minX) / BUCKETS;
-    const cellH = (ext.maxY - ext.minY) / BUCKETS;
-    const buckets = Array.from({ length: BUCKETS * BUCKETS }, () => []);
-    for (let i = 0; i < samples.length; i++) {
-        const [x, y] = samples[i];
-        const bx = clamp(Math.floor((x - ext.minX) / cellW), 0, BUCKETS - 1);
-        const by = clamp(Math.floor((y - ext.minY) / cellH), 0, BUCKETS - 1);
-        buckets[by * BUCKETS + bx].push(i);
-    }
-
-    // First pass: interpolate Z per pixel via IDW (k=6, power=2) against
-    // the up-to-9-bucket neighbourhood. Track min/max for the colormap.
-    const heights = new Float32Array(res * res);
-    let zMin = Infinity, zMax = -Infinity;
-    for (let py = 0; py < res; py++) {
-        const sy = ext.minY + ((py + 0.5) / res) * (ext.maxY - ext.minY);
-        const by = clamp(Math.floor((sy - ext.minY) / cellH), 0, BUCKETS - 1);
-        for (let px = 0; px < res; px++) {
-            const sx = ext.minX + ((px + 0.5) / res) * (ext.maxX - ext.minX);
-            const bx = clamp(Math.floor((sx - ext.minX) / cellW), 0, BUCKETS - 1);
-            const z = idwAtPoint(sx, sy, samples, buckets, bx, by, BUCKETS, 6);
-            heights[py * res + px] = z;
-            if (z < zMin) zMin = z;
-            if (z > zMax) zMax = z;
-        }
-    }
-
-    // Hillshading — compute slope normals using the heights grid and
-    // dot with a NW-from-above light direction.
-    const canvas = document.createElement('canvas');
-    canvas.width = res;
-    canvas.height = res;
-    const ctx = canvas.getContext('2d');
-    const img = ctx.createImageData(res, res);
-    const data = img.data;
-    const zRange = (zMax - zMin) || 1;
-
-    // Light direction (normalised): from NW at 45° altitude.
-    const lx = -0.6, ly = 0.6, lz = 0.6;
-    const lLen = Math.hypot(lx, ly, lz);
-    const Lx = lx / lLen, Ly = ly / lLen, Lz = lz / lLen;
-
-    // Slope exaggeration — Unreal Z is in centimetres, span ~50k cm
-    // (500 m), but the grid pixel size is much smaller (~400 cm per
-    // pixel here). Without exaggeration the surface looks flat.
-    const slopeScale = 8.0 / zRange;
-
-    for (let py = 0; py < res; py++) {
-        for (let px = 0; px < res; px++) {
-            const i = py * res + px;
-            const z = heights[i];
-            const t = (z - zMin) / zRange;
-            const base = elevationColor(t);
-
-            // Sobel-ish gradient for hillshade.
-            const zL = heights[i - (px > 0 ? 1 : 0)];
-            const zR = heights[i + (px < res - 1 ? 1 : 0)];
-            const zU = heights[i - (py > 0 ? res : 0)];
-            const zD = heights[i + (py < res - 1 ? res : 0)];
-            const dzdx = (zR - zL) * slopeScale;
-            const dzdy = (zD - zU) * slopeScale;
-            // Surface normal ~ (-dzdx, -dzdy, 1) normalised.
-            const nx = -dzdx, ny = -dzdy, nz = 1;
-            const nLen = Math.hypot(nx, ny, nz) || 1;
-            let shade = (nx * Lx + ny * Ly + nz * Lz) / nLen;
-            shade = Math.max(0.55, Math.min(1.15, 0.85 + shade * 0.45));
-
-            const r = clamp(base[0] * shade, 0, 255) | 0;
-            const g = clamp(base[1] * shade, 0, 255) | 0;
-            const b = clamp(base[2] * shade, 0, 255) | 0;
-            const o = i * 4;
-            data[o + 0] = r;
-            data[o + 1] = g;
-            data[o + 2] = b;
-            data[o + 3] = 255;
-        }
-    }
-    ctx.putImageData(img, 0, 0);
-    return canvas;
-}
-
-function idwAtPoint(x, y, samples, buckets, bx, by, BUCKETS, k) {
-    // Gather candidates from up to 9 neighbouring buckets.
-    const cand = [];
-    for (let dy = -1; dy <= 1; dy++) {
-        const yy = by + dy;
-        if (yy < 0 || yy >= BUCKETS) continue;
-        for (let dx = -1; dx <= 1; dx++) {
-            const xx = bx + dx;
-            if (xx < 0 || xx >= BUCKETS) continue;
-            const bucket = buckets[yy * BUCKETS + xx];
-            for (let i = 0; i < bucket.length; i++) cand.push(bucket[i]);
-        }
-    }
-
-    // Expand to 5×5 buckets if too few candidates (edges, sparse areas).
-    if (cand.length < k) {
-        cand.length = 0;
-        for (let dy = -2; dy <= 2; dy++) {
-            const yy = by + dy;
-            if (yy < 0 || yy >= BUCKETS) continue;
-            for (let dx = -2; dx <= 2; dx++) {
-                const xx = bx + dx;
-                if (xx < 0 || xx >= BUCKETS) continue;
-                const bucket = buckets[yy * BUCKETS + xx];
-                for (let i = 0; i < bucket.length; i++) cand.push(bucket[i]);
-            }
-        }
-    }
-
-    // Fall back to full scan if still nothing nearby — rare, edges only.
-    if (cand.length === 0) {
-        for (let i = 0; i < samples.length; i++) cand.push(i);
-    }
-
-    // Partial selection of k nearest. For small k vs N (k=6, N=20-50 per
-    // bucket window) a sort is fine.
-    const distSq = new Array(cand.length);
-    for (let i = 0; i < cand.length; i++) {
-        const s = samples[cand[i]];
-        const dx = s[0] - x, dy = s[1] - y;
-        distSq[i] = dx * dx + dy * dy;
-    }
-    const order = cand.map((_, i) => i).sort((a, b) => distSq[a] - distSq[b]);
-    const take = Math.min(k, order.length);
-
-    let sumW = 0, sumWz = 0;
-    for (let i = 0; i < take; i++) {
-        const idx = order[i];
-        const d2 = distSq[idx];
-        if (d2 < 1) return samples[cand[idx]][2]; // exact hit
-        const w = 1 / d2; // power=2
-        sumW += w;
-        sumWz += w * samples[cand[idx]][2];
-    }
-    return sumWz / sumW;
-}
-
-// Color ramp for normalised elevation [0..1].
-// Stops chosen to look "Satisfactory-natural" — dark water, sand at shore,
-// rich grass mid-elevation, brown rock, snow on peaks. Returns [r, g, b].
-const ELEVATION_STOPS = [
-    [0.00, [22, 38, 58]],     // deep water
-    [0.18, [40, 78, 110]],    // shallow water
-    [0.22, [195, 175, 115]],  // beach / sand
-    [0.32, [120, 145, 75]],   // light grass
-    [0.55, [70, 105, 55]],    // forest
-    [0.75, [110, 95, 75]],    // brown rock
-    [0.88, [150, 145, 140]],  // light rock
-    [1.00, [235, 235, 245]],  // snow
-];
-
-function elevationColor(t) {
-    t = clamp(t, 0, 1);
-    for (let i = 1; i < ELEVATION_STOPS.length; i++) {
-        const [t1, c1] = ELEVATION_STOPS[i];
-        if (t <= t1) {
-            const [t0, c0] = ELEVATION_STOPS[i - 1];
-            const u = (t - t0) / (t1 - t0 || 1);
-            return [
-                c0[0] + (c1[0] - c0[0]) * u,
-                c0[1] + (c1[1] - c0[1]) * u,
-                c0[2] + (c1[2] - c0[2]) * u,
-            ];
-        }
-    }
-    return ELEVATION_STOPS[ELEVATION_STOPS.length - 1][1];
-}
-
-function clamp(v, lo, hi) {
-    return v < lo ? lo : v > hi ? hi : v;
 }
 
 function tooltipText(feature) {


### PR DESCRIPTION
Per session-end audit — the procedural Z-sample backdrop shipped briefly in v0.1.7 alongside the three wiki maps. Result looked like a blurry blob compared to the real imagery and no user would pick it. Drop the ~200 lines of IDW + hillshading + colormap; keep the four useful options (terrain / biome / water / none).

Prior implementation lives at commit \`0368b2d\` if a procedural fallback is ever wanted again (e.g. for modded maps).

## Diff summary

- \`factory-map.js\`: −245 / +21. Single \`resourceNodeExtent\` helper replaces the elevation-sample machinery.
- \`Settings.razor\`: dropped the "procedural" dropdown option + tightened help text.
- \`ADR-0015\`: appended a dated "Update — procedural backdrop removed" note pointing at the prior commit.

## Test plan

- [ ] CI green
- [ ] Open \`/factory/map\` → terrain backdrop still renders cleanly (was the default, unchanged path)
- [ ] Open \`/settings\` → "Procedural" option gone; "Terrain (wiki)" / "Biome (wiki)" / "Water (wiki)" / "None (dark canvas)" remain
- [ ] Auto-release fires on merge → v0.1.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)