### PR TITLE
feat(web): MudBlazor — Phase 2 (layout + nav + own theme toggle)

### DIFF
--- a/src/Web/Components/App.razor
+++ b/src/Web/Components/App.razor
@@ -13,7 +13,8 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet />
     <script>
-        // Apply persisted theme before paint to avoid a flash.
+        // Apply persisted theme before first paint to avoid a flash. Blazor (MainLayout)
+        // takes over as soon as the circuit boots — this is just the pre-hydration nudge.
         (function () {
             try {
                 var saved = localStorage.getItem('erp-theme');
@@ -22,34 +23,17 @@
                 }
             } catch (_) { /* localStorage may be unavailable */ }
         })();
-        function syncThemeButton() {
-            var current = document.documentElement.getAttribute('data-bs-theme') || 'dark';
-            var btn = document.getElementById('theme-toggle-btn');
-            if (btn) btn.textContent = current === 'dark' ? '☀ Light' : '☾ Dark';
-        }
-        function toggleTheme() {
-            var current = document.documentElement.getAttribute('data-bs-theme') || 'dark';
-            var next = current === 'dark' ? 'light' : 'dark';
-            document.documentElement.setAttribute('data-bs-theme', next);
-            try { localStorage.setItem('erp-theme', next); } catch (_) { }
-            syncThemeButton();
-            // Notify MudBlazor's IsDarkMode binding (wired up in MainLayout).
-            window.dispatchEvent(new CustomEvent('erp-theme-change', { detail: next }));
-        }
-        // Layout components subscribe to theme changes via this bridge —
-        // pass a DotNetObjectReference, get callbacks on every toggle.
-        window.erpRegisterThemeChange = function (dotNetRef) {
-            var handler = function (e) { dotNetRef.invokeMethodAsync('OnThemeChanged', e.detail); };
-            window.addEventListener('erp-theme-change', handler);
-            return handler;
+        // Two-way bridge between MudBlazor's IsDarkMode (C# source of truth) and
+        // Bootstrap's data-bs-theme attribute (still needed during the phased migration
+        // for pages that haven't moved to MudBlazor primitives yet). MainLayout calls
+        // erpSetTheme on toggle and erpReadInitialTheme once on init.
+        window.erpSetTheme = function (theme) {
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            try { localStorage.setItem('erp-theme', theme); } catch (_) { }
         };
         window.erpReadInitialTheme = function () {
             return document.documentElement.getAttribute('data-bs-theme') || 'dark';
         };
-        // Sync the button text on initial load and after every Blazor enhanced
-        // navigation (the button gets re-rendered, so we need to re-sync).
-        document.addEventListener('DOMContentLoaded', syncThemeButton);
-        document.addEventListener('enhancedload', syncThemeButton);
     </script>
 </head>
 

--- a/src/Web/Components/Layout/MainLayout.razor
+++ b/src/Web/Components/Layout/MainLayout.razor
@@ -1,32 +1,45 @@
 @inherits LayoutComponentBase
-@implements IAsyncDisposable
 @inject IJSRuntime JS
 
-<MudThemeProvider Theme="FicsitTheme.Instance" IsDarkMode="isDarkMode" />
+<MudThemeProvider Theme="FicsitTheme.Instance" IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-<div class="page">
-    <div class="sidebar">
+<MudLayout Class="fx-layout">
+    <MudDrawer @bind-Open="_drawerOpen"
+               Variant="DrawerVariant.Responsive"
+               Anchor="Anchor.Left"
+               Elevation="0"
+               ClipMode="DrawerClipMode.Never"
+               Width="250px"
+               Breakpoint="Breakpoint.Sm"
+               Class="fx-drawer">
         <NavMenu />
-    </div>
+    </MudDrawer>
 
-    <main>
-        <div class="top-row">
-            <span class="status-strip" aria-hidden="true">SYSTEM ONLINE</span>
-            <button id="theme-toggle-btn" type="button" class="theme-toggle" onclick="toggleTheme()"
-                title="Toggle light / dark mode">
-                ☀ Light
-            </button>
-        </div>
+    <MudAppBar Elevation="0" Dense="true" Color="Color.Transparent" Class="fx-appbar">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu"
+                       OnClick="@(() => _drawerOpen = !_drawerOpen)"
+                       Color="Color.Inherit"
+                       title="Toggle navigation"
+                       Class="fx-menu-toggle" />
+        <span class="status-strip" aria-hidden="true">SYSTEM ONLINE</span>
+        <MudSpacer />
+        <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+                       OnClick="ToggleTheme"
+                       Color="Color.Inherit"
+                       title="Toggle light / dark mode"
+                       Class="fx-theme-toggle" />
+    </MudAppBar>
+
+    <MudMainContent Class="fx-main">
         <div class="hazard-tape thin" aria-hidden="true"></div>
-
         <article class="content px-4">
             @Body
         </article>
-    </main>
-</div>
+    </MudMainContent>
+</MudLayout>
 
 <div id="blazor-error-ui">
     An unhandled error has occurred.
@@ -35,38 +48,29 @@
 </div>
 
 @code {
-    private bool isDarkMode = true;
-    private DotNetObjectReference<MainLayout>? selfRef;
+    private bool _isDarkMode = true;
+    private bool _drawerOpen = true;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
-        selfRef = DotNetObjectReference.Create(this);
+
+        // The pre-paint script in App.razor may have set data-bs-theme from localStorage
+        // before Blazor booted. Pick that up so MudBlazor's IsDarkMode matches.
         var initial = await JS.InvokeAsync<string>("erpReadInitialTheme");
-        var nextDark = !string.Equals(initial, "light", StringComparison.Ordinal);
-        await JS.InvokeVoidAsync("erpRegisterThemeChange", selfRef);
-        if (nextDark != isDarkMode)
+        var darkInitial = !string.Equals(initial, "light", StringComparison.Ordinal);
+        if (darkInitial != _isDarkMode)
         {
-            isDarkMode = nextDark;
+            _isDarkMode = darkInitial;
             StateHasChanged();
         }
     }
 
-    [JSInvokable]
-    public Task OnThemeChanged(string theme)
+    private async Task ToggleTheme()
     {
-        var nextDark = !string.Equals(theme, "light", StringComparison.Ordinal);
-        if (nextDark != isDarkMode)
-        {
-            isDarkMode = nextDark;
-            StateHasChanged();
-        }
-        return Task.CompletedTask;
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        selfRef?.Dispose();
-        return ValueTask.CompletedTask;
+        _isDarkMode = !_isDarkMode;
+        // One-way C# → DOM/localStorage. Bootstrap-themed pages still read data-bs-theme
+        // until they migrate off Bootstrap (Phase 3+).
+        await JS.InvokeVoidAsync("erpSetTheme", _isDarkMode ? "dark" : "light");
     }
 }

--- a/src/Web/Components/Layout/MainLayout.razor.css
+++ b/src/Web/Components/Layout/MainLayout.razor.css
@@ -1,61 +1,14 @@
 /* =========================================================================
-   MainLayout — sidebar + main content surface, with hazard-tape strip.
+   MainLayout — FICSIT decorations layered onto MudLayout/MudAppBar/
+   MudDrawer/MudMainContent. The structural rules (page, sidebar, top-row,
+   responsive collapse) that lived here previously are now MudBlazor's job;
+   only decorations and the global error UI remain in scoped CSS. MudBlazor
+   class overrides live in wwwroot/app.css so they apply consistently
+   regardless of where MudBlazor renders the markup.
    ========================================================================= */
 
-.page {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-}
-
-main {
-    flex: 1;
-    background-color: var(--bs-body-bg);
-    display: flex;
-    flex-direction: column;
-}
-
-.sidebar {
-    background:
-        linear-gradient(180deg, #0F0F14 0%, #1A1A21 50%, #261D14 100%);
-    border-right: 1px solid var(--fx-border);
-    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.35);
-    position: relative;
-}
-
-/* Faint vertical "rivet line" on the sidebar's inner edge. */
-.sidebar::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 2px;
-    bottom: 0;
-    background-image: repeating-linear-gradient(
-        180deg,
-        transparent 0,
-        transparent 18px,
-        rgba(250, 149, 73, 0.35) 18px,
-        rgba(250, 149, 73, 0.35) 20px);
-    pointer-events: none;
-}
-
-.top-row {
-    background:
-        linear-gradient(180deg, var(--fx-bg-panel) 0%, var(--fx-bg) 100%);
-    border-bottom: 1px solid var(--fx-border-soft);
-    justify-content: flex-end;
-    height: 2.6rem;
-    display: flex;
-    align-items: center;
-    padding: 0 1.25rem;
-    gap: 0.75rem;
-}
-
-/* Pulsing "SYSTEM ONLINE" indicator, top-left of the top-row. */
+/* SYSTEM ONLINE pulse indicator, top-left of the app bar. */
 .status-strip {
-    margin-right: auto;
     font-family: 'Bahnschrift', 'Cascadia Mono', 'Consolas', monospace;
     font-size: 0.7rem;
     letter-spacing: 0.18em;
@@ -81,6 +34,8 @@ main {
     50%      { opacity: 0.45; }
 }
 
+/* Blazor's unhandled-error banner. Stays hidden until the framework unhides
+   it on a circuit error. */
 #blazor-error-ui {
     background: var(--fx-danger);
     color: #1B1B1F;
@@ -91,7 +46,7 @@ main {
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;
     position: fixed;
     width: 100%;
-    z-index: 1000;
+    z-index: 2000;
 }
 
 #blazor-error-ui .dismiss {
@@ -99,28 +54,4 @@ main {
     position: absolute;
     right: 0.75rem;
     top: 0.5rem;
-}
-
-@media (min-width: 641px) {
-    .page {
-        flex-direction: row;
-    }
-
-    .sidebar {
-        width: 250px;
-        min-height: 100vh;
-        position: sticky;
-        top: 0;
-    }
-
-    .top-row {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-    }
-
-    .top-row, article {
-        padding-left: 2rem !important;
-        padding-right: 1.5rem !important;
-    }
 }

--- a/src/Web/Components/Layout/NavMenu.razor
+++ b/src/Web/Components/Layout/NavMenu.razor
@@ -13,38 +13,20 @@
     <div class="brand-sub">PRODUCTION SUITE</div>
 </div>
 
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
-
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="nav flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="fx-icon fx-icon-home" aria-hidden="true"></span> Home
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="planner">
-                <span class="fx-icon fx-icon-wrench" aria-hidden="true"></span> Planner
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="factory/ingest">
-                <span class="fx-icon fx-icon-gear" aria-hidden="true"></span> Factory state
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="factory/map">
-                <span class="fx-icon fx-icon-map" aria-hidden="true"></span> Factory map
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="settings">
-                <span class="fx-icon fx-icon-screwdriver" aria-hidden="true"></span> Settings
-            </NavLink>
-        </div>
-    </nav>
-</div>
+<MudNavMenu Class="fx-nav">
+    <MudNavLink Href="" Match="NavLinkMatch.All">
+        <span class="fx-icon fx-icon-inline fx-icon-home" aria-hidden="true"></span> Home
+    </MudNavLink>
+    <MudNavLink Href="planner">
+        <span class="fx-icon fx-icon-inline fx-icon-wrench" aria-hidden="true"></span> Planner
+    </MudNavLink>
+    <MudNavLink Href="factory/ingest">
+        <span class="fx-icon fx-icon-inline fx-icon-gear" aria-hidden="true"></span> Factory state
+    </MudNavLink>
+    <MudNavLink Href="factory/map">
+        <span class="fx-icon fx-icon-inline fx-icon-map" aria-hidden="true"></span> Factory map
+    </MudNavLink>
+    <MudNavLink Href="settings">
+        <span class="fx-icon fx-icon-inline fx-icon-screwdriver" aria-hidden="true"></span> Settings
+    </MudNavLink>
+</MudNavMenu>

--- a/src/Web/Components/Layout/NavMenu.razor.css
+++ b/src/Web/Components/Layout/NavMenu.razor.css
@@ -1,27 +1,11 @@
 /* =========================================================================
-   NavMenu — FICSIT-branded sidebar with bespoke SVG icons.
+   NavMenu — FICSIT brand block at the top of MudDrawer, with bespoke SVG
+   icons. Nav-link styling lives in wwwroot/app.css against MudBlazor's
+   .mud-nav-link class so it applies wherever the nav is rendered.
+
+   The hand-rolled mobile toggle, nav-scrollable, and navbar-toggler that
+   lived here are now MudDrawer's responsibility (DrawerVariant.Responsive).
    ========================================================================= */
-
-.navbar-toggler {
-    appearance: none;
-    cursor: pointer;
-    width: 3.5rem;
-    height: 2.5rem;
-    color: white;
-    position: absolute;
-    top: 0.5rem;
-    right: 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.75rem rgba(255, 255, 255, 0.1);
-}
-
-.navbar-toggler:checked {
-    background-color: rgba(255, 255, 255, 0.5);
-}
-
-/* ------------------------------------------------------------------------
-   Brand block — FICSIT-style header.
-   ------------------------------------------------------------------------ */
 
 .brand-block {
     padding: 0.9rem 1rem 0.6rem 1rem;
@@ -121,71 +105,4 @@
     padding-left: calc(28px + 0.6rem);
     font-family: 'Bahnschrift', sans-serif;
     font-weight: 500;
-}
-
-/* ------------------------------------------------------------------------
-   Nav items — left-bar indicator + hover/active states.
-   ------------------------------------------------------------------------ */
-
-.nav-item {
-    font-size: 0.88rem;
-    padding-bottom: 0.35rem;
-    font-family: 'Bahnschrift', 'Segoe UI Variable', 'Segoe UI', sans-serif;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-}
-
-    .nav-item:first-of-type {
-        padding-top: 1.1rem;
-    }
-
-    .nav-item:last-of-type {
-        padding-bottom: 1rem;
-    }
-
-    .nav-item ::deep a {
-        color: #c4c4ca;
-        border-radius: 4px;
-        height: 2.6rem;
-        display: flex;
-        align-items: center;
-        line-height: 2.6rem;
-        border-left: 3px solid transparent;
-        padding-left: 0.75rem;
-        transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-    }
-
-.nav-item ::deep a.active {
-    background: linear-gradient(90deg, rgba(250, 149, 73, 0.18) 0%, rgba(250, 149, 73, 0.04) 100%);
-    color: #FFB070;
-    border-left-color: #FA9549;
-    box-shadow: inset 0 0 0 1px rgba(250, 149, 73, 0.15);
-}
-
-.nav-item ::deep a:hover {
-    background-color: rgba(250, 149, 73, 0.08);
-    color: #ffffff;
-}
-
-/* Note: bespoke .fx-icon-* classes are defined globally in wwwroot/app.css
-   so they're reachable from Home page cards too. */
-
-.nav-scrollable {
-    display: none;
-}
-
-.navbar-toggler:checked ~ .nav-scrollable {
-    display: block;
-}
-
-@media (min-width: 641px) {
-    .navbar-toggler {
-        display: none;
-    }
-
-    .nav-scrollable {
-        display: block;
-        height: calc(100vh - 5.5rem);
-        overflow-y: auto;
-    }
 }

--- a/src/Web/wwwroot/app.css
+++ b/src/Web/wwwroot/app.css
@@ -516,3 +516,104 @@ h1:focus { outline: none; }
 .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+/* ------------------------------------------------------------------------
+   MudBlazor integration — Phase 2 of the migration. The framework's
+   primitives (.mud-drawer, .mud-nav-link, .mud-appbar, .mud-icon-button)
+   are restyled here to carry the FICSIT industrial aesthetic. Classes are
+   MudBlazor globals; the .fx-* modifier classes are applied in MainLayout
+   and NavMenu so the overrides only affect the app shell, not page-level
+   uses of the same primitives.
+   ------------------------------------------------------------------------ */
+
+/* MudLayout — let our app's grid + schematic backdrop show through. */
+.mud-layout.fx-layout {
+    background: transparent;
+}
+
+/* Sidebar drawer — same dark gradient the hand-rolled .sidebar used in
+   Phase 1. Stays dark even in light mode (FICSIT aesthetic is dark by
+   default; the brand reads better against dark surfaces). */
+.mud-drawer.fx-drawer {
+    background: linear-gradient(180deg, #0F0F14 0%, #1A1A21 50%, #261D14 100%) !important;
+    border-right: 1px solid var(--fx-border) !important;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.35);
+    color: #c4c4ca;
+    overflow: visible;
+}
+
+.mud-drawer.fx-drawer .mud-drawer-content {
+    background: transparent;
+}
+
+/* Faint vertical "rivet line" on the drawer's inner (right) edge. */
+.mud-drawer.fx-drawer::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 2px;
+    bottom: 0;
+    background-image: repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 18px,
+        rgba(250, 149, 73, 0.35) 18px,
+        rgba(250, 149, 73, 0.35) 20px);
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* App bar — translucent panel gradient under the SYSTEM ONLINE indicator
+   and theme toggle. Hazard tape lives just below in MudMainContent. */
+.mud-appbar.fx-appbar {
+    background: linear-gradient(180deg, var(--fx-bg-panel) 0%, var(--fx-bg) 100%) !important;
+    color: var(--fx-text) !important;
+    border-bottom: 1px solid var(--fx-border-soft);
+    backdrop-filter: none;
+}
+
+[data-bs-theme="light"] .mud-appbar.fx-appbar {
+    background: linear-gradient(180deg, #FAF6EC 0%, #F0EBE0 100%) !important;
+    color: var(--fx-text) !important;
+}
+
+/* Theme toggle — orange-tinted hover, no Material elevation. */
+.mud-icon-button.fx-theme-toggle {
+    color: var(--fx-text) !important;
+}
+
+.mud-icon-button.fx-theme-toggle:hover {
+    background-color: rgba(250, 149, 73, 0.12) !important;
+}
+
+/* Nav links — uppercase Bahnschrift, transparent left-bar that lights up
+   on hover or when the link is the active route. Mirrors the look the
+   hand-rolled .nav-item ::deep a rules carried in Phase 1. */
+.mud-nav-menu.fx-nav .mud-nav-link {
+    color: #c4c4ca;
+    border-left: 3px solid transparent;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-family: 'Bahnschrift', 'Segoe UI Variable', 'Segoe UI', sans-serif;
+    font-size: 0.88rem;
+    min-height: 2.6rem;
+    transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.mud-nav-menu.fx-nav .mud-nav-link:hover {
+    background-color: rgba(250, 149, 73, 0.08);
+    color: #ffffff;
+}
+
+/* MudNavLink applies both "active" and "mud-nav-link-active" when it
+   matches the current route — match either, so we don't depend on which
+   version of MudBlazor renders today. */
+.mud-nav-menu.fx-nav .mud-nav-link.active,
+.mud-nav-menu.fx-nav .mud-nav-link.mud-nav-link-active {
+    background: linear-gradient(90deg, rgba(250, 149, 73, 0.18) 0%, rgba(250, 149, 73, 0.04) 100%);
+    color: #FFB070;
+    border-left-color: #FA9549;
+    box-shadow: inset 0 0 0 1px rgba(250, 149, 73, 0.15);
+}
+


### PR DESCRIPTION
## Stacked PR — depends on #48

This PR is stacked on top of PR #48 (Phase 1). The base branch is set to
\`feature/mudblazor-phase-1\` so the diff shows only Phase 2 changes. Once
#48 lands on main, retarget this PR to main; GitHub keeps the diff stable.

## Summary

Migrates the app shell off the hand-rolled \`.page/.sidebar/.top-row\` markup onto **MudLayout / MudDrawer / MudAppBar / MudMainContent**, and onto **MudNavMenu / MudNavLink** for the nav. Drops the JS-bridge theme toggle workaround Phase 1 introduced and lets MudBlazor own \`IsDarkMode\` directly.

## What changed

- **MainLayout**: \`MudLayout\` wrapping \`MudDrawer\` (Responsive variant, \`ClipMode.Never\`, \`Sm\` breakpoint) + \`MudAppBar\` + \`MudMainContent\`. AppBar carries hamburger (bound to \`_drawerOpen\`), SYSTEM ONLINE indicator, theme toggle (bound to \`_isDarkMode\`, swaps between \`LightMode\` and \`DarkMode\` icons).
- **NavMenu**: brand block stays inline at top of drawer (gear-spin SVG + hazard tape underline preserved). \`MudNavMenu\` / \`MudNavLink\` replace the hand-rolled \`.nav\` and \`NavLink\`. \`fx-icon-*\` spans live inside \`MudNavLink\` ChildContent so the bespoke mask icons survive.
- **App.razor**: dropped \`toggleTheme()\`, \`syncThemeButton()\`, \`erpRegisterThemeChange()\`, the \`erp-theme-change\` event, and the DOMContentLoaded/enhancedload listeners. Kept the pre-paint flash-avoidance block + \`erpReadInitialTheme\`. Added \`erpSetTheme(theme)\` — one-way C# → DOM + localStorage.
- **State**: MainLayout owns \`_isDarkMode\` and \`_drawerOpen\`. The JSInvokable callback + DotNetObjectReference bridge from Phase 1 are gone.
- **CSS**:
  - \`MainLayout.razor.css\`: kept only \`#blazor-error-ui\` + \`status-strip\`. Dropped \`.page\`/\`.sidebar\`/\`.top-row\`/\`main\`.
  - \`NavMenu.razor.css\`: kept the brand-block styles. Dropped \`.navbar-toggler\`, \`.nav-scrollable\`, \`.nav-item ::deep a\`, and the mobile-collapse \`@media\` block.
  - \`app.css\`: added a MudBlazor integration section. Re-targets the FICSIT aesthetic onto \`.mud-drawer\` (dark gradient + rivet line), \`.mud-appbar\` (transparent panel + light-mode variant), \`.mud-nav-link\` (uppercase Bahnschrift, orange hover + active gradient with left-bar indicator), \`.mud-icon-button\` (orange-tinted hover). \`.fx-*\` modifier classes scope the overrides to the app shell only.

## Verification

- ✅ \`./build.sh Test\` green (Restore + Compile + InstallPlaywrightBrowsers + Test, ~78s).
- ✅ \`./build.sh Format\` green.
- ✅ Manual run + Playwright:
  - **Desktop dark**: brand, hazard tape, status LED, rivet line, nav-link active all match Phase 1's look (screenshots in \`test/ui-tests/phase2-*.png\`).
  - **Light mode toggle**: MudAppBar flips, MudAutocomplete flips, page surface flips to parchment. Sidebar stays dark intentionally.
  - **Mobile (375×667)**: drawer auto-collapses, hamburger reopens it as an overlay with full brand + nav.
  - **Persistence**: localStorage \`erp-theme\` is read on init, theme persists across reloads.

## What's next

- **Phase 3** — page-level migrations: \`#11\` recipe catalogue grid (\`MudDataGrid\`), Planner steps table, FactoryIngest tables, Settings form controls.
- **Phase 4** — drop Bootstrap entirely, add the MudBlazor adoption ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)