### PR TITLE
ci: skip Web.UiTests on the free GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,12 @@ jobs:
           dotnet-version: 8.0.x
           global-json-file: global.json
 
-      - name: Build & Test
-        run: ./build.sh Test
+      - name: Build & Test (no UI)
+        # Web.UiTests is excluded in CI — Playwright's --with-deps chromium
+        # install (sudo apt-get + ~150MB browser download) is too heavy for the
+        # free GitHub Actions runner. Run `./build.sh Test` locally to include
+        # the UI tests. Re-enabling on CI is a one-line change here.
+        run: ./build.sh TestNoUi
 
       - name: Upload TRX test results
         if: always()

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,7 +31,8 @@
         "InstallPlaywrightBrowsers",
         "Release",
         "Restore",
-        "Test"
+        "Test",
+        "TestNoUi"
       ]
     },
     "Verbosity": {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -89,7 +89,7 @@ class Build : NukeBuild
         });
 
     Target Test => _ => _
-        .Description("Runs all xUnit test projects, emits TRX results to artifacts/test-results/.")
+        .Description("Runs ALL xUnit test projects including Web.UiTests (drives Chromium via Playwright). Use locally; CI uses TestNoUi instead.")
         .DependsOn(Compile)
         .DependsOn(InstallPlaywrightBrowsers)
         .Executes(() =>
@@ -104,6 +104,28 @@ class Build : NukeBuild
                 .AddLoggers("trx;LogFilePrefix=test")
                 .AddLoggers("console;verbosity=normal"));
             Log.Information("TRX results written to {Dir}", TestResultsDirectory);
+        });
+
+    Target TestNoUi => _ => _
+        .Description("Runs xUnit tests excluding Web.UiTests. Skips the Playwright browser install + system-deps that the free GitHub Actions runner can't comfortably carry.")
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            TestResultsDirectory.CreateOrCleanDirectory();
+            // Filter by FullyQualifiedName — every test in Web.UiTests lives under the
+            // Web.UiTests namespace, so !~ Web.UiTests matches them all. The UiTests
+            // project still compiles but no tests run, so the AspireAppFixture (which
+            // calls Microsoft.Playwright.Program.Main on init) never executes.
+            DotNetTest(s => s
+                .SetProjectFile(Solution)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore()
+                .SetResultsDirectory(TestResultsDirectory)
+                .AddLoggers("trx;LogFilePrefix=test")
+                .AddLoggers("console;verbosity=normal")
+                .SetFilter("FullyQualifiedName!~Web.UiTests"));
+            Log.Information("TRX results written to {Dir} (Web.UiTests excluded — run `./build.sh Test` locally to include them)", TestResultsDirectory);
         });
 
     Target ComputeVersion => _ => _


### PR DESCRIPTION
## Summary

Deactivates the Playwright leg of CI without removing it. The free GitHub Actions runner can't comfortably carry `playwright.ps1 install --with-deps chromium` (sudo apt-get for a chunk of system libs + ~150 MB browser download every run) — slower and flakier than the unit-test value warrants.

- New NUKE target **`TestNoUi`** — same shape as `Test`, minus the `InstallPlaywrightBrowsers` dependency, with a `FullyQualifiedName!~Web.UiTests` xUnit filter. The UiTests project still compiles, just runs zero tests, so the `AspireAppFixture` (which calls `Microsoft.Playwright.Program.Main` on init) never executes either.
- **`Test`** target is unchanged — local devs still get the full suite, including UI. Description updated to point at `TestNoUi` for the CI path.
- **`.github/workflows/ci.yml`** switches the build-and-test step from `./build.sh Test` to `./build.sh TestNoUi`, with a comment about how to re-enable.

Re-enabling on CI is a one-line change (`Test` → `TestNoUi` and back) once a heavier runner is in play.

## Local verification

- `./build.sh TestNoUi` — 7 non-UI tests, ~4 s. No Playwright install.
- `./build.sh Test` — full suite including the 2 Playwright tests on top of the Chromium install.
- `./build.sh Format` — clean.

## Knock-on for the open MudBlazor PRs

PRs [#48](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/48) and [#49](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/49) will need to be rebased onto the new main after this lands, so their CI checks pick up the `TestNoUi` path. They don't touch CI config themselves, so the rebase is purely "fast-forward your base onto the new main commit".

## Test plan

- [x] `./build.sh TestNoUi` green locally (4 s).
- [x] `./build.sh Format` green locally.
- [ ] CI run on this PR comes back green and noticeably faster than the previous `Test`-target runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)