### PR TITLE
feat(web): recipe catalogue page (#11)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -35,6 +35,37 @@ app.MapGet("/catalog/items", (ICatalogProvider catalog) =>
         .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
         .Select(i => new ItemDto(i.Id.Value, i.Name)));
 
+app.MapGet("/catalog/recipes", (ICatalogProvider catalog) =>
+{
+    // Per-minute amounts mirror what /plan returns and what the planner UI displays —
+    // raw per-cycle counts on the wire would force every consumer to multiply by
+    // 60/duration. Recipes with zero duration would be a parser bug, but guard anyway.
+    AmountDto ToPerMinute(ItemAmount a, TimeSpan duration) =>
+        new(a.Item.Value,
+            catalog.FindItem(a.Item)?.Name ?? a.Item.Value,
+            duration.TotalSeconds > 0
+                ? Math.Round(a.Quantity * 60m / (decimal)duration.TotalSeconds, 4)
+                : a.Quantity);
+
+    return catalog.Recipes
+        .OrderBy(r => r.IsAlternate)
+        .ThenBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+        .Select(r =>
+        {
+            var building = catalog.FindBuilding(r.Building);
+            return new RecipeView(
+                r.Id.Value,
+                r.Name,
+                r.Building.Value,
+                building?.Name ?? r.Building.Value,
+                building?.BasePowerMw ?? 0,
+                r.IsAlternate,
+                r.Duration.TotalSeconds,
+                r.Inputs.Select(i => ToPerMinute(i, r.Duration)).ToList(),
+                r.Outputs.Select(o => ToPerMinute(o, r.Duration)).ToList());
+        });
+});
+
 app.MapGet("/catalogue/status", (ICatalogProvider catalog) => catalog.GetStatus());
 
 app.MapPost("/catalogue/configure", (ConfigureCatalogueRequest request, ICatalogProvider catalog) =>
@@ -124,6 +155,17 @@ app.MapDefaultEndpoints();
 app.Run();
 
 public sealed record ItemDto(string Id, string Name);
+
+public sealed record RecipeView(
+    string Id,
+    string Name,
+    string BuildingId,
+    string BuildingName,
+    double BuildingPowerMw,
+    bool IsAlternate,
+    double DurationSeconds,
+    IReadOnlyList<AmountDto> InputsPerMinute,
+    IReadOnlyList<AmountDto> OutputsPerMinute);
 
 public sealed record ConfigureCatalogueRequest(string DocsPath);
 

--- a/src/Web/Components/Layout/NavMenu.razor
+++ b/src/Web/Components/Layout/NavMenu.razor
@@ -20,6 +20,9 @@
     <MudNavLink Href="planner">
         <span class="fx-icon fx-icon-inline fx-icon-wrench" aria-hidden="true"></span> Planner
     </MudNavLink>
+    <MudNavLink Href="recipes" Icon="@Icons.Material.Filled.MenuBook" IconColor="Color.Inherit">
+        Recipes
+    </MudNavLink>
     <MudNavLink Href="factory/ingest">
         <span class="fx-icon fx-icon-inline fx-icon-gear" aria-hidden="true"></span> Factory state
     </MudNavLink>

--- a/src/Web/Components/Pages/Recipes.razor
+++ b/src/Web/Components/Pages/Recipes.razor
@@ -1,0 +1,134 @@
+@page "/recipes"
+@inject PlannerApiClient Api
+
+<PageTitle>Recipes</PageTitle>
+
+<h1>Recipe Catalogue</h1>
+
+<p>Every recipe parsed from your <code>Docs.json</code> — base and alternates. Throughputs are normalised to items per minute at 100% clock speed.</p>
+
+@if (status is { IsLoaded: false })
+{
+    <div class="alert alert-warning">
+        No catalogue loaded yet. <a href="settings">Point the app at your <code>Docs.json</code> in Settings</a> before browsing recipes.
+    </div>
+}
+else if (recipes is null)
+{
+    <p><em>Loading recipes...</em></p>
+}
+else
+{
+    <MudDataGrid T="RecipeView"
+                 Items="recipes"
+                 QuickFilter="@_quickFilter"
+                 Hover="true"
+                 Striped="true"
+                 Dense="true"
+                 Filterable="true"
+                 SortMode="SortMode.Multiple"
+                 FixedHeader="true"
+                 Height="calc(100vh - 240px)"
+                 RowsPerPage="50"
+                 Class="fx-recipes-grid">
+        <ToolBarContent>
+            <MudText Typo="Typo.h6">@recipes.Length recipes (@recipes.Count(r => r.IsAlternate) alternates)</MudText>
+            <MudSpacer />
+            <MudTextField @bind-Value="_search"
+                          Placeholder="Search name, building, input or output…"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search"
+                          Immediate="true"
+                          DebounceInterval="150"
+                          Clearable="true"
+                          Style="max-width: 380px;" />
+        </ToolBarContent>
+
+        <Columns>
+            <PropertyColumn Property="r => r.Name" Title="Recipe" />
+            <TemplateColumn Title="Alt" SortBy="r => r.IsAlternate ? 1 : 0" Filterable="false">
+                <CellTemplate>
+                    @if (context.Item.IsAlternate)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">ALT</MudChip>
+                    }
+                </CellTemplate>
+            </TemplateColumn>
+            <PropertyColumn Property="r => r.BuildingName" Title="Building" Grouping="false" />
+            <TemplateColumn Title="Inputs / min" Sortable="false" Filterable="false">
+                <CellTemplate>
+                    <div class="recipe-amounts">
+                        @foreach (var a in context.Item.InputsPerMinute)
+                        {
+                            <span class="recipe-amount" title="@a.ItemName">
+                                <img src="/assets/icons/items/@(a.ItemId).png"
+                                     onerror="this.style.visibility='hidden'"
+                                     alt="" />
+                                <span class="recipe-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                            </span>
+                        }
+                    </div>
+                </CellTemplate>
+            </TemplateColumn>
+            <TemplateColumn Title="Outputs / min" Sortable="false" Filterable="false">
+                <CellTemplate>
+                    <div class="recipe-amounts">
+                        @foreach (var a in context.Item.OutputsPerMinute)
+                        {
+                            <span class="recipe-amount" title="@a.ItemName">
+                                <img src="/assets/icons/items/@(a.ItemId).png"
+                                     onerror="this.style.visibility='hidden'"
+                                     alt="" />
+                                <span class="recipe-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                            </span>
+                        }
+                    </div>
+                </CellTemplate>
+            </TemplateColumn>
+            <PropertyColumn Property="r => r.DurationSeconds" Title="Cycle (s)" Format="0.##" />
+            <PropertyColumn Property="r => r.BuildingPowerMw" Title="Power (MW)" Format="0.##" />
+        </Columns>
+
+        <PagerContent>
+            <MudDataGridPager T="RecipeView" />
+        </PagerContent>
+
+        <NoRecordsContent>
+            <MudText Typo="Typo.body2" Class="pa-4">No recipes match the current search.</MudText>
+        </NoRecordsContent>
+    </MudDataGrid>
+}
+
+@code {
+    private CatalogueStatusView? status;
+    private RecipeView[]? recipes;
+    private string? _search;
+
+    private Func<RecipeView, bool> _quickFilter => r =>
+    {
+        if (string.IsNullOrWhiteSpace(_search)) return true;
+        var q = _search.Trim();
+        return r.Name.Contains(q, StringComparison.OrdinalIgnoreCase)
+            || r.BuildingName.Contains(q, StringComparison.OrdinalIgnoreCase)
+            || r.InputsPerMinute.Any(a => a.ItemName.Contains(q, StringComparison.OrdinalIgnoreCase))
+            || r.OutputsPerMinute.Any(a => a.ItemName.Contains(q, StringComparison.OrdinalIgnoreCase));
+    };
+
+    private static string FormatRate(decimal rate) =>
+        rate == Math.Floor(rate) ? rate.ToString("0") : rate.ToString("0.##");
+
+    protected override async Task OnInitializedAsync()
+    {
+        status = await Api.GetCatalogueStatusAsync();
+        if (status?.IsLoaded ?? false)
+        {
+            recipes = await Api.GetRecipesAsync();
+        }
+        else
+        {
+            recipes = [];
+        }
+    }
+}

--- a/src/Web/Components/Pages/Recipes.razor.css
+++ b/src/Web/Components/Pages/Recipes.razor.css
@@ -1,0 +1,33 @@
+/* =========================================================================
+   Recipes page — input/output chip cells inside MudDataGrid.
+
+   Items are rendered as flex chips so multi-ingredient recipes wrap onto
+   multiple lines inside the cell instead of overflowing horizontally.
+   ========================================================================= */
+
+.recipe-amounts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.6rem;
+    align-items: center;
+}
+
+.recipe-amount {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    font-size: 0.85rem;
+    line-height: 1.2;
+}
+
+.recipe-amount img {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+    flex: 0 0 20px;
+}
+
+.recipe-amount-text {
+    color: var(--fx-text);
+}

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -7,6 +7,9 @@ public class PlannerApiClient(HttpClient httpClient)
     public async Task<CatalogItem[]> GetItemsAsync(CancellationToken ct = default) =>
         await httpClient.GetFromJsonAsync<CatalogItem[]>("/catalog/items", ct) ?? [];
 
+    public async Task<RecipeView[]> GetRecipesAsync(CancellationToken ct = default) =>
+        await httpClient.GetFromJsonAsync<RecipeView[]>("/catalog/recipes", ct) ?? [];
+
     public async Task<PlanResponse?> ComputePlanAsync(PlanRequest request, CancellationToken ct = default)
     {
         var response = await httpClient.PostAsJsonAsync("/plan", request, ct);
@@ -61,6 +64,17 @@ public class PlannerApiClient(HttpClient httpClient)
 }
 
 public sealed record CatalogItem(string Id, string Name);
+
+public sealed record RecipeView(
+    string Id,
+    string Name,
+    string BuildingId,
+    string BuildingName,
+    double BuildingPowerMw,
+    bool IsAlternate,
+    double DurationSeconds,
+    IReadOnlyList<AmountView> InputsPerMinute,
+    IReadOnlyList<AmountView> OutputsPerMinute);
 
 public sealed record TargetInput(string ItemId, decimal ItemsPerMinute);
 public sealed record AvailabilityInput(string ItemId, decimal ItemsPerMinute);


### PR DESCRIPTION
## Summary

New \`/recipes\` page lists every recipe parsed from \`Docs.json\` on a **MudDataGrid** — sortable + filterable per column, quick-search across recipe name + building + input/output item names, item icons on every ingredient. Closes #11. **First real `MudDataGrid` use in the project** (Phase 3 of the MudBlazor migration plan).

## What's in this PR

**API:**
- New \`GET /catalog/recipes\` endpoint returns each recipe as a \`RecipeView\` with id, name, buildingId + buildingName + buildingPowerMw (resolved via \`catalog.FindBuilding\`), \`isAlternate\`, \`durationSeconds\`, and inputs/outputs converted to items-per-minute. Wire format mirrors \`/plan\` for consistency.
- \`PlannerApiClient.GetRecipesAsync\` + \`RecipeView\` DTO mirror.

**UI:**
- \`/recipes\` page on \`MudDataGrid\` — columns: Recipe / Alt / Building / Inputs/min / Outputs/min / Cycle (s) / Power (MW). 50 rows/page, 238 recipes (105 alternates) on the test catalogue.
- Quick-filter text box uses a \`QuickFilter\` delegate that matches name, building, and ingredient names — so "iron ingot" finds base + alternate iron-ingot recipes AND every recipe that consumes or produces iron ingot.
- Alternates flagged via a small orange \`MudChip\` in the Alt column, ordered after base recipes within each name group.
- Input/output cells render flex-wrapped chips with item icons from \`/assets/icons/items/{id}.png\` (same drop-folder convention as ADR-0016). \`onerror\` fallback hides the \`<img>\` cleanly for the four FICSMAS Day-N items that have no wiki page.

**Navigation:**
- New "Recipes" link in NavMenu, between Planner and Factory state. Uses MudBlazor's Material \`MenuBook\` icon (first nav link in the app not using a bespoke \`fx-icon\` mask — Phase 4 can standardise).

## Verified locally

- ✅ \`./build.sh TestNoUi\` green (7 non-UI tests, 12 s).
- ✅ \`./build.sh Format\` green.
- ✅ Manual run + Playwright at 1280 and 1600 widths:
  - 238 rows render; pagination shows "1-50 of 238".
  - Search "iron ingot" filters down to ~11 matches across base + alternates + consumers + producers.
  - ALT chip shows on alternate recipes (105 of them).
  - Every input/output cell shows the correct item icon at 20 px.
  - Dark/light theme toggle still works (table follows MudBlazor theme).

Screenshots in \`test/ui-tests/recipes-page-*.png\` (local, gitignored).

## Closes
- #11 — Page: browse the recipe catalogue.

## What's next for Phase 3

With MudDataGrid validated, the next slices are migrating existing tables onto it:
- Planner steps table (currently Bootstrap \`<table>\`)
- FactoryIngest tables (Bootstrap \`table-sm\`)
- Settings form controls
- FactoryMap legend / layer toggles to MudCheckBox

🤖 Generated with [Claude Code](https://claude.com/claude-code)