### PR TITLE
feat(web): planner output on MudDataGrid + shared fx-amount chips

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -354,6 +354,7 @@ public sealed record StepDto(
     string RecipeId,
     string RecipeName,
     string BuildingId,
+    string BuildingName,
     decimal BuildingCount,
     IReadOnlyList<AmountDto> Inputs,
     IReadOnlyList<AmountDto> Outputs);
@@ -375,6 +376,7 @@ public sealed record PlanDto(
                 s.Recipe.Id.Value,
                 s.Recipe.Name,
                 s.Recipe.Building.Value,
+                catalog.FindBuilding(s.Recipe.Building)?.Name ?? s.Recipe.Building.Value,
                 Math.Round(s.BuildingCount, 4),
                 s.InputsPerMinute.Select(ToAmount).ToList(),
                 s.OutputsPerMinute.Select(ToAmount).ToList())).ToList(),

--- a/src/Web/Components/Pages/Planner.razor
+++ b/src/Web/Components/Pages/Planner.razor
@@ -113,7 +113,17 @@ else
 @if (plan is not null)
 {
     <hr />
-    <h2>Plan @(plan.IsFeasible ? "✓ feasible" : "⚠ missing inputs")</h2>
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <h2 class="mb-0">Plan</h2>
+        @if (plan.IsFeasible)
+        {
+            <MudChip T="string" Color="Color.Success" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.CheckCircle">Feasible</MudChip>
+        }
+        else
+        {
+            <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Warning">Missing inputs</MudChip>
+        }
+    </div>
 
     @if (plan.Steps.Count == 0)
     {
@@ -121,51 +131,82 @@ else
     }
     else
     {
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Recipe</th>
-                    <th>Building</th>
-                    <th class="text-end">Buildings</th>
-                    <th>Inputs / min</th>
-                    <th>Outputs / min</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var step in plan.Steps)
-                {
-                    <tr>
-                        <td>@step.RecipeName</td>
-                        <td>@step.BuildingId</td>
-                        <td class="text-end">@step.BuildingCount</td>
-                        <td>@string.Join(", ", step.Inputs.Select(i => $"{i.ItemsPerMinute} {i.ItemName}"))</td>
-                        <td>@string.Join(", ", step.Outputs.Select(o => $"{o.ItemsPerMinute} {o.ItemName}"))</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+        <MudDataGrid T="StepView"
+                     Items="plan.Steps"
+                     Hover="true"
+                     Striped="true"
+                     Dense="true"
+                     SortMode="SortMode.Multiple"
+                     Class="fx-plan-grid">
+            <Columns>
+                <PropertyColumn Property="s => s.RecipeName" Title="Recipe" />
+                <PropertyColumn Property="s => s.BuildingName" Title="Building" />
+                <PropertyColumn Property="s => s.BuildingCount" Title="Buildings" Format="0.##" CellStyle="text-align: right;" HeaderStyle="text-align: right;" />
+                <TemplateColumn Title="Inputs / min" Sortable="false" Filterable="false">
+                    <CellTemplate>
+                        <div class="fx-amount-list">
+                            @foreach (var a in context.Item.Inputs)
+                            {
+                                <span class="fx-amount" title="@a.ItemName">
+                                    <img src="/assets/icons/items/@(a.ItemId).png"
+                                         onerror="this.style.visibility='hidden'"
+                                         alt="" />
+                                    <span class="fx-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                                </span>
+                            }
+                        </div>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="Outputs / min" Sortable="false" Filterable="false">
+                    <CellTemplate>
+                        <div class="fx-amount-list">
+                            @foreach (var a in context.Item.Outputs)
+                            {
+                                <span class="fx-amount" title="@a.ItemName">
+                                    <img src="/assets/icons/items/@(a.ItemId).png"
+                                         onerror="this.style.visibility='hidden'"
+                                         alt="" />
+                                    <span class="fx-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                                </span>
+                            }
+                        </div>
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
     }
 
     @if (plan.RawInputsConsumed.Count > 0)
     {
-        <h3>Raw inputs consumed (from sources)</h3>
-        <ul>
+        <h3 class="mt-4">Raw inputs consumed (from sources)</h3>
+        <div class="fx-amount-list">
             @foreach (var amount in plan.RawInputsConsumed)
             {
-                <li>@amount.ItemsPerMinute @amount.ItemName / min</li>
+                <span class="fx-amount" title="@amount.ItemName">
+                    <img src="/assets/icons/items/@(amount.ItemId).png"
+                         onerror="this.style.visibility='hidden'"
+                         alt="" />
+                    <span class="fx-amount-text">@FormatRate(amount.ItemsPerMinute) @amount.ItemName / min</span>
+                </span>
             }
-        </ul>
+        </div>
     }
 
     @if (plan.MissingInputs.Count > 0)
     {
-        <h3 class="text-danger">Missing inputs</h3>
-        <ul class="text-danger">
+        <h3 class="mt-4 text-danger">Missing inputs</h3>
+        <p class="text-muted mb-2"><small>No recipe and no source available.</small></p>
+        <div class="fx-amount-list">
             @foreach (var amount in plan.MissingInputs)
             {
-                <li>@amount.ItemsPerMinute @amount.ItemName / min — no recipe and no source</li>
+                <span class="fx-amount fx-amount-missing" title="@amount.ItemName">
+                    <img src="/assets/icons/items/@(amount.ItemId).png"
+                         onerror="this.style.visibility='hidden'"
+                         alt="" />
+                    <span class="fx-amount-text">@FormatRate(amount.ItemsPerMinute) @amount.ItemName / min</span>
+                </span>
             }
-        </ul>
+        </div>
     }
 }
 
@@ -217,6 +258,9 @@ else
             isComputing = false;
         }
     }
+
+    private static string FormatRate(decimal rate) =>
+        rate == Math.Floor(rate) ? rate.ToString("0") : rate.ToString("0.##");
 
     private Task<IEnumerable<CatalogItem>> SearchItems(string? value, CancellationToken ct)
     {

--- a/src/Web/Components/Pages/Recipes.razor
+++ b/src/Web/Components/Pages/Recipes.razor
@@ -59,14 +59,14 @@ else
             <PropertyColumn Property="r => r.BuildingName" Title="Building" Grouping="false" />
             <TemplateColumn Title="Inputs / min" Sortable="false" Filterable="false">
                 <CellTemplate>
-                    <div class="recipe-amounts">
+                    <div class="fx-amount-list">
                         @foreach (var a in context.Item.InputsPerMinute)
                         {
-                            <span class="recipe-amount" title="@a.ItemName">
+                            <span class="fx-amount" title="@a.ItemName">
                                 <img src="/assets/icons/items/@(a.ItemId).png"
                                      onerror="this.style.visibility='hidden'"
                                      alt="" />
-                                <span class="recipe-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                                <span class="fx-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
                             </span>
                         }
                     </div>
@@ -74,14 +74,14 @@ else
             </TemplateColumn>
             <TemplateColumn Title="Outputs / min" Sortable="false" Filterable="false">
                 <CellTemplate>
-                    <div class="recipe-amounts">
+                    <div class="fx-amount-list">
                         @foreach (var a in context.Item.OutputsPerMinute)
                         {
-                            <span class="recipe-amount" title="@a.ItemName">
+                            <span class="fx-amount" title="@a.ItemName">
                                 <img src="/assets/icons/items/@(a.ItemId).png"
                                      onerror="this.style.visibility='hidden'"
                                      alt="" />
-                                <span class="recipe-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
+                                <span class="fx-amount-text">@FormatRate(a.ItemsPerMinute) @a.ItemName</span>
                             </span>
                         }
                     </div>

--- a/src/Web/Components/Pages/Recipes.razor.css
+++ b/src/Web/Components/Pages/Recipes.razor.css
@@ -1,33 +1,5 @@
 /* =========================================================================
-   Recipes page — input/output chip cells inside MudDataGrid.
-
-   Items are rendered as flex chips so multi-ingredient recipes wrap onto
-   multiple lines inside the cell instead of overflowing horizontally.
+   Recipes page — page-specific styles. Input/output chip styling lives in
+   the shared fx-amount-* classes in wwwroot/app.css (used here, on the
+   planner page, and anywhere else the UI lists "N × item").
    ========================================================================= */
-
-.recipe-amounts {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem 0.6rem;
-    align-items: center;
-}
-
-.recipe-amount {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
-    white-space: nowrap;
-    font-size: 0.85rem;
-    line-height: 1.2;
-}
-
-.recipe-amount img {
-    width: 20px;
-    height: 20px;
-    object-fit: contain;
-    flex: 0 0 20px;
-}
-
-.recipe-amount-text {
-    color: var(--fx-text);
-}

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -85,6 +85,7 @@ public sealed record StepView(
     string RecipeId,
     string RecipeName,
     string BuildingId,
+    string BuildingName,
     decimal BuildingCount,
     IReadOnlyList<AmountView> Inputs,
     IReadOnlyList<AmountView> Outputs);

--- a/src/Web/wwwroot/app.css
+++ b/src/Web/wwwroot/app.css
@@ -617,3 +617,43 @@ h1:focus { outline: none; }
     box-shadow: inset 0 0 0 1px rgba(250, 149, 73, 0.15);
 }
 
+/* ------------------------------------------------------------------------
+   Item-amount chips — used wherever the UI lists "N × item" with an icon,
+   e.g. recipe inputs/outputs, planner step inputs/outputs, raw + missing
+   input lists. Single shared class so all surfaces stay consistent.
+   ------------------------------------------------------------------------ */
+
+.fx-amount-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.6rem;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.fx-amount {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    font-size: 0.85rem;
+    line-height: 1.2;
+}
+
+.fx-amount img {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+    flex: 0 0 20px;
+}
+
+.fx-amount-text {
+    color: var(--fx-text);
+}
+
+.fx-amount.fx-amount-missing .fx-amount-text {
+    color: var(--fx-danger);
+}
+


### PR DESCRIPTION
## Summary

Phase 3.2 of the MudBlazor migration. Swaps the Bootstrap \`<table>\` in the planner's plan-output section for \`MudDataGrid\`, replaces the raw/missing-inputs \`<ul>\` lists with icon chips, and lifts the input/output chip styling out of \`Recipes.razor.css\` into a shared \`app.css\` class so the planner and the recipes page render amounts identically.

## What changed

**Server (ApiService):**
- \`StepDto\` gains \`BuildingName\`, resolved via \`catalog.FindBuilding\` so the planner shows "Constructor" instead of "Build_ConstructorMk1_C".

**Client:**
- \`PlannerApiClient.StepView\` mirrors the new \`BuildingName\` field.
- \`Planner.razor\` plan output rewritten — \`MudDataGrid<StepView>\` with Recipe / Building / Buildings / Inputs/min / Outputs/min columns. Per-step rows show item icons next to every input/output via the shared \`fx-amount\` chip class.
- Feasibility indicator becomes a \`MudChip\` next to the "PLAN" heading — green \`CheckCircle\` for feasible, orange \`Warning\` for missing inputs.
- Raw inputs consumed + missing inputs ULs become flex-wrapped \`fx-amount-list\` of \`fx-amount\` items. Missing inputs use the \`fx-amount-missing\` modifier to colour the text in \`fx-danger\`.
- \`FormatRate\` helper added (mirrors the recipes page) so whole-number rates render as "30" instead of "30.0".

**CSS:**
- \`wwwroot/app.css\` gains a "Item-amount chips" section — \`fx-amount-list\`, \`fx-amount\`, \`fx-amount-text\`, \`fx-amount-missing\`. Single source of truth.
- \`Recipes.razor.css\` trimmed to a pointer comment.
- Recipes.razor templates updated to use the renamed \`fx-*\` classes.

## Verified locally

- ✅ \`./build.sh TestNoUi\` green (7 non-UI tests, 11 s).
- ✅ \`./build.sh Format\` green.
- ✅ Manual run + Playwright: requesting 60 Iron Plate / min shows two-row plan (Iron Plate from Constructor × 3, Iron Ingot from Smelter × 3), "Missing inputs" orange chip next to "PLAN", and the 90 Iron Ore / min missing input rendered in red. Screenshot in \`test/ui-tests/phase3.2-planner-output.png\` (local, gitignored).

## What's next for Phase 3

- **Phase 3.3** — FactoryIngest tables on MudDataGrid (same shape as the planner steps and recipes pages).
- **Phase 3.4** — FactoryMap legend/layer toggles to MudCheckBox.
- **Phase 3.5** — Settings form controls + the remaining Bootstrap bits on the planner (\`Compute\` button, +Add/Remove buttons, number inputs, alert). Intentionally untouched here to keep this PR's scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)