### PR TITLE
feat(web): MudBlazor Phase 3c — FactoryIngest page

### DIFF
--- a/src/Web/Components/Pages/FactoryIngest.razor
+++ b/src/Web/Components/Pages/FactoryIngest.razor
@@ -8,85 +8,85 @@
 
 @if (state is null)
 {
-    <p><em>Loading status...</em></p>
+    <MudText><em>Loading status...</em></MudText>
 }
 else
 {
-    <div class="@StatusAlertClass">
-        <span class="@LedClass" aria-hidden="true"></span>
-        <strong>@StatusHeadline</strong>
+    <MudAlert Severity="@StatusSeverity" Variant="Variant.Outlined" Class="mb-3">
+        <MudText Typo="Typo.subtitle2"><strong>@StatusHeadline</strong></MudText>
         @if (!string.IsNullOrEmpty(state.Source))
         {
-            <div class="small">Source: <code>@state.Source</code></div>
+            <MudText Typo="Typo.caption">Source: <code>@state.Source</code></MudText>
         }
         @if (state.Save is { } save)
         {
-            <div class="small">
+            <MudText Typo="Typo.caption">
                 <strong>@save.SessionName</strong>
                 · save v@(save.SaveVersion) (build @save.BuildVersion)
                 · played @FormatPlayed(save.PlayedSeconds)
                 · saved @save.SaveDateTimeUtc.ToString("u")
-            </div>
+            </MudText>
         }
-    </div>
+    </MudAlert>
 
     @if (state.IsLoaded)
     {
-        <div class="row mt-3">
-            <div class="col-md-6">
-                <h5>Miners <span class="text-muted small">by tier</span></h5>
+        <MudGrid Spacing="3" Class="mt-3">
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.h5" Class="mb-2">Miners <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by tier</MudText></MudText>
                 @CountTable(state.Miners, "No miners.")
                 @if (state.Miners.Count > 0)
                 {
-                    <p class="small text-muted mt-1">
+                    <MudText Typo="Typo.caption" Class="mt-1 d-block">
                         @state.MinersBoundToNode / @state.Miners.Sum(m => m.Count) bound to a resource node.
-                    </p>
+                    </MudText>
                 }
-            </div>
-            <div class="col-md-6">
-                <h5>Belts <span class="text-muted small">by tier</span></h5>
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.h5" Class="mb-2">Belts <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by tier</MudText></MudText>
                 @CountTable(state.Belts, "No belts.")
-            </div>
-        </div>
+            </MudItem>
+        </MudGrid>
 
-        <div class="row mt-3">
-            <div class="col-md-6">
-                <h5>Generators <span class="text-muted small">by kind</span></h5>
+        <MudGrid Spacing="3" Class="mt-3">
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.h5" Class="mb-2">Generators <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by kind</MudText></MudText>
                 @CountTable(state.Generators, "No generators.")
-            </div>
-            <div class="col-md-6">
-                <h5>Resource nodes</h5>
-                <p class="display-6 mb-0">@state.ResourceNodeCount.ToString("N0")</p>
-            </div>
-        </div>
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.h5" Class="mb-2">Resource nodes</MudText>
+                <MudText Class="display-6">@state.ResourceNodeCount.ToString("N0")</MudText>
+            </MudItem>
+        </MudGrid>
 
-        <div class="row mt-3">
-            <div class="col-12">
-                <h5>Production buildings <span class="text-muted small">by type × recipe</span></h5>
+        <MudGrid Spacing="3" Class="mt-3">
+            <MudItem xs="12">
+                <MudText Typo="Typo.h5" Class="mb-2">Production buildings <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by type × recipe</MudText></MudText>
                 @BuildingTable(state.Buildings, "No production buildings.")
-                <p class="small text-muted mt-1">
+                <MudText Typo="Typo.caption" Class="mt-1 d-block">
                     @state.BuildingsWithRecipe / @state.Buildings.Sum(b => b.Count) bound to a recipe.
                     Clock speed comes through as 100% for default-clocked machines (the game only serializes
                     overclocked values).
-                </p>
-            </div>
-        </div>
+                </MudText>
+            </MudItem>
+        </MudGrid>
 
         @if (state.Warnings is { Count: > 0 })
         {
-            <details class="mt-3">
-                <summary>@state.Warnings.Count warning(s) during parse</summary>
-                <ul class="small">
-                    @foreach (var w in state.Warnings.Take(50))
-                    {
-                        <li>@w</li>
-                    }
-                    @if (state.Warnings.Count > 50)
-                    {
-                        <li><em>(@(state.Warnings.Count - 50) more not shown)</em></li>
-                    }
-                </ul>
-            </details>
+            <MudExpansionPanels Elevation="0" Class="mt-3">
+                <MudExpansionPanel Text="@($"{state.Warnings.Count} warning(s) during parse")" Dense="true">
+                    <ul class="small">
+                        @foreach (var w in state.Warnings.Take(50))
+                        {
+                            <li>@w</li>
+                        }
+                        @if (state.Warnings.Count > 50)
+                        {
+                            <li><em>(@(state.Warnings.Count - 50) more not shown)</em></li>
+                        }
+                    </ul>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
         }
     }
 }
@@ -94,34 +94,41 @@ else
 <div class="mt-4">
     @if (detectedSaves is { Length: > 0 })
     {
-        <label class="form-label">Detected save files</label>
-        <select class="form-select" @bind="selectedSavePath" @bind:after="OnDetectedSaveSelected">
-            <option value="">— pick a save —</option>
+        <MudSelect T="string" Value="selectedSavePath" ValueChanged="OnDetectedSaveSelected"
+                   Label="Detected save files"
+                   Variant="Variant.Outlined"
+                   Margin="Margin.Dense"
+                   Dense="true"
+                   Class="mb-1">
+            <MudSelectItem Value="@("")">— pick a save —</MudSelectItem>
             @foreach (var s in detectedSaves)
             {
-                <option value="@s.Path">
+                <MudSelectItem Value="@s.Path">
                     @s.Name · @s.LastWriteTimeUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm") · @FormatSize(s.SizeBytes)
-                </option>
+                </MudSelectItem>
             }
-        </select>
-        <div class="form-text mb-3">
+        </MudSelect>
+        <MudText Typo="Typo.caption" Class="d-block mb-3">
             Found @detectedSaves.Length save(s) under <code>%LocalAppData%\FactoryGame\Saved\SaveGames\</code>.
             Selecting one fills the path field below.
-        </div>
+        </MudText>
     }
 
-    <label class="form-label">Path to a Satisfactory <code>.sav</code> file or a SaveGames directory</label>
-    <input type="text" class="form-control" @bind="pathInput"
-        placeholder="C:\Users\&lt;you&gt;\AppData\Local\FactoryGame\Saved\SaveGames\&lt;steamId&gt;\Beta Game_autosave_0.sav" />
-    <div class="form-text">
+    <MudTextField @bind-Value="pathInput"
+                  Label="Path to a Satisfactory .sav file or a SaveGames directory"
+                  Placeholder="C:\Users\<you>\AppData\Local\FactoryGame\Saved\SaveGames\<steamId>\Beta Game_autosave_0.sav"
+                  Variant="Variant.Outlined"
+                  Margin="Margin.Dense"
+                  Class="mb-1" />
+    <MudText Typo="Typo.caption" Class="d-block mb-2">
         Either point at a specific <code>.sav</code> file or a directory (we'll pick the most-recently-written
         <code>*.sav</code>). Startup resolution order:
         <code>ERP_SATISFACTORY_SAVE_PATH</code> env var → user-saved (this form) →
         <code>FactoryState:Satisfactory:SavePath</code> in <code>appsettings</code> → auto-detect under
         <code>%LocalAppData%\FactoryGame\Saved\SaveGames\</code>.
-    </div>
-    <button class="btn btn-primary mt-2" type="button" @onclick="Ingest"
-        disabled="@(string.IsNullOrWhiteSpace(pathInput) || isIngesting)">
+    </MudText>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Ingest"
+               Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isIngesting)">
         @if (isIngesting)
         {
             <span class="gear-spin" aria-hidden="true"></span>
@@ -131,10 +138,10 @@ else
         {
             <text>Ingest</text>
         }
-    </button>
+    </MudButton>
     @if (!string.IsNullOrEmpty(message))
     {
-        <span class="@MessageClass ms-3">@message</span>
+        <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
     }
 </div>
 
@@ -147,22 +154,14 @@ else
     private bool messageIsError;
     private bool isIngesting;
 
-    private string StatusAlertClass => state is null
-        ? "alert alert-secondary"
-        : state.IsLoaded ? "alert alert-success"
-        : "alert alert-warning";
+    private Severity StatusSeverity => state is null
+        ? Severity.Info
+        : state.IsLoaded ? Severity.Success : Severity.Warning;
 
     private string StatusHeadline => state is null
         ? ""
         : state.IsLoaded ? "Factory state loaded."
         : "No save loaded. Configure your save-file path below.";
-
-    private string LedClass => state is null
-        ? "led"
-        : state.IsLoaded ? "led led-on"
-        : "led led-warn";
-
-    private string MessageClass => messageIsError ? "text-danger" : "text-success";
 
     protected override async Task OnInitializedAsync()
     {
@@ -176,7 +175,6 @@ else
         if (state is { IsLoaded: true, Source: { } source })
         {
             pathInput = source;
-            // Pre-select if this path is one of the detected saves.
             if (detectedSaves.Any(s => string.Equals(s.Path, source, StringComparison.OrdinalIgnoreCase)))
             {
                 selectedSavePath = source;
@@ -184,11 +182,12 @@ else
         }
     }
 
-    private void OnDetectedSaveSelected()
+    private void OnDetectedSaveSelected(string value)
     {
-        if (!string.IsNullOrWhiteSpace(selectedSavePath))
+        selectedSavePath = value;
+        if (!string.IsNullOrWhiteSpace(value))
         {
-            pathInput = selectedSavePath;
+            pathInput = value;
         }
     }
 
@@ -231,15 +230,15 @@ else
     {
         if (rows.Count == 0)
         {
-            <p class="text-muted small mb-0">@emptyLabel</p>
+            <MudText Typo="Typo.caption" Color="Color.Default">@emptyLabel</MudText>
             return;
         }
 
-        <table class="table table-sm">
+        <MudSimpleTable Dense="true" Hover="true" Bordered="false" Elevation="0" Class="fx-mud-table">
             <thead>
                 <tr>
-                    <th scope="col">Type</th>
-                    <th scope="col" class="text-end">Count</th>
+                    <th>Type</th>
+                    <th style="text-align: right;">Count</th>
                 </tr>
             </thead>
             <tbody>
@@ -247,27 +246,27 @@ else
                 {
                     <tr>
                         <td><code>@row.Key</code></td>
-                        <td class="text-end">@row.Count.ToString("N0")</td>
+                        <td style="text-align: right;">@row.Count.ToString("N0")</td>
                     </tr>
                 }
             </tbody>
-        </table>
+        </MudSimpleTable>
     };
 
     private static RenderFragment BuildingTable(IReadOnlyList<BuildingGroupViewModel> rows, string emptyLabel) => __builder =>
     {
         if (rows.Count == 0)
         {
-            <p class="text-muted small mb-0">@emptyLabel</p>
+            <MudText Typo="Typo.caption" Color="Color.Default">@emptyLabel</MudText>
             return;
         }
 
-        <table class="table table-sm">
+        <MudSimpleTable Dense="true" Hover="true" Bordered="false" Elevation="0" Class="fx-mud-table">
             <thead>
                 <tr>
-                    <th scope="col">Building</th>
-                    <th scope="col">Recipe</th>
-                    <th scope="col" class="text-end">Count</th>
+                    <th>Building</th>
+                    <th>Recipe</th>
+                    <th style="text-align: right;">Count</th>
                 </tr>
             </thead>
             <tbody>
@@ -279,7 +278,7 @@ else
                             @if (row.RecipeName is not null)
                             {
                                 <span>@row.RecipeName</span>
-                                <small class="text-muted ms-1">(<code>@row.Recipe</code>)</small>
+                                <MudText HtmlTag="small" Typo="Typo.caption" Color="Color.Default" Class="ms-1">(<code>@row.Recipe</code>)</MudText>
                             }
                             else if (row.Recipe is not null)
                             {
@@ -287,14 +286,14 @@ else
                             }
                             else
                             {
-                                <span class="text-muted small">— idle —</span>
+                                <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">— idle —</MudText>
                             }
                         </td>
-                        <td class="text-end">@row.Count.ToString("N0")</td>
+                        <td style="text-align: right;">@row.Count.ToString("N0")</td>
                     </tr>
                 }
             </tbody>
-        </table>
+        </MudSimpleTable>
     };
 
     private static string FormatPlayed(double seconds)


### PR DESCRIPTION
## Summary
- Replace `.alert`, `.row/.col-md-6`, `.table.table-sm`, `.form-control/.form-select`, `.btn`, `<details>` with MudBlazor equivalents.
- Status alert uses computed `Severity`; tables use `MudSimpleTable`; the gear-spin span stays inside `MudButton` so the busy spinner survives.
- Handler signatures (\`OnDetectedSaveSelected\`) adapted to the `MudSelect.ValueChanged` contract.

Smoke-tested via AppHost — screenshot in \`test/ui-tests/phase-3c-ingest.png\`.

## Test plan
- [x] Build clean
- [x] Status alert renders with computed severity (loaded state shown)
- [x] Grid sections layout correctly at md width
- [x] MudSimpleTable empty-state hint renders (\"No miners.\")
- [x] Save-dropdown + path field bound, Ingest button enables
- [ ] Round-trip ingest not re-tested this PR (no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)