### PR TITLE
feat(web): MudBlazor Phase 3d — FactoryMap legend

### DIFF
--- a/src/Web/Components/Pages/FactoryMap.razor
+++ b/src/Web/Components/Pages/FactoryMap.razor
@@ -10,159 +10,47 @@
 
 @if (errorMessage is not null)
 {
-    <div class="alert alert-danger">
-        <span class="led led-error" aria-hidden="true"></span>
-        <strong>Map unavailable.</strong>
-        <div class="small">@errorMessage</div>
-    </div>
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-2">
+        <MudText Typo="Typo.subtitle2"><strong>Map unavailable.</strong></MudText>
+        <MudText Typo="Typo.caption">@errorMessage</MudText>
+    </MudAlert>
 }
 else if (loadedSummary is null)
 {
-    <p><em>Loading factory state…</em></p>
+    <MudText><em>Loading factory state…</em></MudText>
 }
 
 <div class="factory-map-shell">
     <div class="map-legend">
-        <h5>Layers</h5>
+        <MudText Typo="Typo.overline" Class="legend-heading">Layers</MudText>
         @if (layers is { Length: > 0 })
         {
-            <ul class="layer-list">
+            <div class="layer-list">
                 @foreach (var layer in layers)
                 {
                     var layerCopy = layer;
-                    <li>
-                        <label class="layer-toggle">
-                            <input type="checkbox" checked="@layerCopy.Visible"
-                                @onchange="(e) => OnLayerToggled(layerCopy.Category, (bool)e.Value!)" />
-                            <span class="layer-swatch" style="background-color:@layerCopy.Color"></span>
-                            <span class="layer-name">@layerCopy.Label</span>
-                            <span class="layer-count">@layerCopy.Count</span>
-                        </label>
-                    </li>
+                    <div class="layer-toggle">
+                        <MudCheckBox T="bool"
+                                     Value="layerCopy.Visible"
+                                     ValueChanged="@(v => OnLayerToggled(layerCopy.Category, v))"
+                                     Color="Color.Primary"
+                                     Dense="true"
+                                     Size="Size.Small"
+                                     Class="layer-checkbox" />
+                        <span class="layer-swatch" style="background-color:@layerCopy.Color"></span>
+                        <span class="layer-name">@layerCopy.Label</span>
+                        <span class="layer-count">@layerCopy.Count</span>
+                    </div>
                 }
-            </ul>
+            </div>
         }
         else
         {
-            <p class="text-muted small mb-0">No data — ingest a save first.</p>
+            <MudText Typo="Typo.caption" Color="Color.Default">No data — ingest a save first.</MudText>
         }
     </div>
     <div id="factory-map-canvas" @ref="mapElement" class="map-canvas"></div>
 </div>
-
-<style>
-    .factory-map-shell {
-        display: grid;
-        grid-template-columns: 220px 1fr;
-        gap: 0.75rem;
-        margin-top: 1rem;
-    }
-    .map-canvas {
-        height: 78vh;
-        background-color: #0F0F14;
-        border: 1px solid var(--fx-border);
-        border-radius: 4px;
-        position: relative;
-        overflow: hidden;
-    }
-    .map-legend {
-        background-color: var(--fx-bg-panel);
-        border: 1px solid var(--fx-border);
-        border-radius: 4px;
-        padding: 0.75rem 0.85rem;
-        font-size: 0.85rem;
-    }
-    .map-legend h5 {
-        font-size: 0.78rem;
-        letter-spacing: 0.1em;
-        margin-bottom: 0.5rem;
-        color: var(--fx-text-muted);
-    }
-    .layer-list { list-style: none; padding: 0; margin: 0; }
-    .layer-list li { margin-bottom: 0.3rem; }
-    .layer-toggle {
-        display: grid;
-        grid-template-columns: 16px 14px 1fr auto;
-        align-items: center;
-        gap: 0.4rem;
-        cursor: pointer;
-        padding: 0.15rem 0.2rem;
-        border-radius: 3px;
-    }
-    .layer-toggle:hover { background-color: rgba(250, 149, 73, 0.06); }
-    .layer-swatch {
-        width: 12px;
-        height: 12px;
-        border-radius: 50%;
-        display: inline-block;
-        border: 1px solid rgba(255, 255, 255, 0.2);
-    }
-    .layer-name {
-        font-family: 'Bahnschrift', sans-serif;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        font-size: 0.78rem;
-    }
-    .layer-count {
-        font-family: 'Cascadia Mono', 'Consolas', monospace;
-        font-size: 0.78rem;
-        color: var(--fx-text-muted);
-    }
-    /* Leaflet popups + tooltips themed. */
-    :global(.leaflet-popup-content-wrapper),
-    :global(.leaflet-tooltip) {
-        background-color: var(--fx-bg-panel);
-        color: var(--fx-text);
-        border: 1px solid var(--fx-border);
-        border-radius: 4px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
-    }
-    :global(.leaflet-popup-tip),
-    :global(.leaflet-tooltip:before) {
-        background-color: var(--fx-bg-panel);
-        border: 1px solid var(--fx-border);
-    }
-    :global(.fx-map-tooltip) {
-        font-family: 'Bahnschrift', sans-serif;
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        padding: 0.2rem 0.45rem;
-    }
-    :global(.fx-popup-title) {
-        font-family: 'Bahnschrift', sans-serif;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        font-size: 0.72rem;
-        color: var(--fx-orange);
-        margin-bottom: 0.15rem;
-    }
-    :global(.fx-popup-kind) {
-        font-weight: 600;
-        margin-bottom: 0.4rem;
-    }
-    :global(.fx-popup-row) {
-        display: flex;
-        justify-content: space-between;
-        gap: 0.6rem;
-        font-size: 0.78rem;
-    }
-    :global(.fx-popup-row span:first-child) {
-        color: var(--fx-text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        font-size: 0.7rem;
-    }
-    :global(.leaflet-control-zoom a) {
-        background-color: var(--fx-bg-panel) !important;
-        color: var(--fx-text) !important;
-        border-color: var(--fx-border) !important;
-    }
-    :global(.leaflet-control-zoom a:hover) {
-        background-color: var(--fx-bg-elevated) !important;
-        color: var(--fx-orange) !important;
-    }
-</style>
 
 @code {
     private ElementReference mapElement;

--- a/src/Web/Components/Pages/FactoryMap.razor.css
+++ b/src/Web/Components/Pages/FactoryMap.razor.css
@@ -1,0 +1,142 @@
+.factory-map-shell {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.map-canvas {
+    height: 78vh;
+    background-color: #0F0F14;
+    border: 1px solid var(--fx-border);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+}
+
+.map-legend {
+    background-color: var(--fx-bg-panel);
+    border: 1px solid var(--fx-border);
+    border-radius: 4px;
+    padding: 0.75rem 0.85rem;
+    font-size: 0.85rem;
+}
+
+.legend-heading {
+    color: var(--fx-text-muted);
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.layer-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.layer-toggle {
+    display: grid;
+    grid-template-columns: auto 14px 1fr auto;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.15rem 0.2rem;
+    border-radius: 3px;
+}
+
+.layer-toggle:hover {
+    background-color: rgba(250, 149, 73, 0.06);
+}
+
+::deep .layer-checkbox {
+    margin: 0;
+    padding: 0;
+}
+
+::deep .layer-checkbox .mud-icon-button {
+    padding: 2px;
+}
+
+.layer-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.layer-name {
+    font-family: 'Bahnschrift', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.78rem;
+}
+
+.layer-count {
+    font-family: 'Cascadia Mono', 'Consolas', monospace;
+    font-size: 0.78rem;
+    color: var(--fx-text-muted);
+}
+
+/* Leaflet popups + tooltips themed. ::deep so the rules pierce the
+   scoped-CSS boundary into the JS-attached Leaflet DOM. */
+::deep .leaflet-popup-content-wrapper,
+::deep .leaflet-tooltip {
+    background-color: var(--fx-bg-panel);
+    color: var(--fx-text);
+    border: 1px solid var(--fx-border);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+::deep .leaflet-popup-tip,
+::deep .leaflet-tooltip:before {
+    background-color: var(--fx-bg-panel);
+    border: 1px solid var(--fx-border);
+}
+
+::deep .fx-map-tooltip {
+    font-family: 'Bahnschrift', sans-serif;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.2rem 0.45rem;
+}
+
+::deep .fx-popup-title {
+    font-family: 'Bahnschrift', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.72rem;
+    color: var(--fx-orange);
+    margin-bottom: 0.15rem;
+}
+
+::deep .fx-popup-kind {
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+::deep .fx-popup-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.6rem;
+    font-size: 0.78rem;
+}
+
+::deep .fx-popup-row span:first-child {
+    color: var(--fx-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.7rem;
+}
+
+::deep .leaflet-control-zoom a {
+    background-color: var(--fx-bg-panel) !important;
+    color: var(--fx-text) !important;
+    border-color: var(--fx-border) !important;
+}
+
+::deep .leaflet-control-zoom a:hover {
+    background-color: var(--fx-bg-elevated) !important;
+    color: var(--fx-orange) !important;
+}


### PR DESCRIPTION
## Summary
- Error alert + loading message → `MudAlert` / `MudText`
- Layer toggles use `MudCheckBox` (still in the bespoke swatch/name/count grid row)
- Inline `<style>` block moved to scoped `FactoryMap.razor.css`; Leaflet popup/tooltip/zoom overrides keep global reach via `::deep`

Smoke-tested via AppHost — screenshot in `test/ui-tests/phase-3d-map.png`. Markers render, layer toggles flip, popups stay themed.

## Test plan
- [x] Build clean
- [x] Map loads + 5 layers populate with counts
- [x] Leaflet zoom controls keep FICSIT theming
- [ ] Layer toggle on/off behavior not re-tested end-to-end (no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)