### PR TITLE
feat(map): calibrate wiki-backdrop bounds (#43)

### DIFF
--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -198,13 +198,21 @@ function buildCategoryLayers(featureCollection) {
 // - none: dark canvas only
 //
 // Selection persisted in localStorage under 'erp-map-backdrop'.
-// Default: 'terrain'. Per-image bounds calibration is tracked in #43.
+// Default: 'terrain'.
+//
+// Per-image `bounds` in Unreal cm align the imagery with marker positions
+// (issue #43). The three wiki images share the same projection — a 5000×5000
+// (or 2500×2500) square covering the playable world centered at world
+// origin (Grass Fields). When `bounds` is absent we fall back to the padded
+// resource-node extent, which is roughly correct but pixel-imprecise.
 // -------------------------------------------------------------------------
 
+const WIKI_MAP_BOUNDS = { minX: -324698, maxX: 425302, minY: -375000, maxY: 375000 };
+
 const MAP_BACKDROPS = {
-    'terrain': { kind: 'image', src: '/lib/maps/terrain.jpg', label: 'Terrain (wiki)' },
-    'biome':   { kind: 'image', src: '/lib/maps/biome.jpg',   label: 'Biome (wiki)' },
-    'water':   { kind: 'image', src: '/lib/maps/water.png',   label: 'Water (wiki)' },
+    'terrain': { kind: 'image', src: '/lib/maps/terrain.jpg', label: 'Terrain (wiki)', bounds: WIKI_MAP_BOUNDS },
+    'biome':   { kind: 'image', src: '/lib/maps/biome.jpg',   label: 'Biome (wiki)',   bounds: WIKI_MAP_BOUNDS },
+    'water':   { kind: 'image', src: '/lib/maps/water.png',   label: 'Water (wiki)',   bounds: WIKI_MAP_BOUNDS },
     'none':    { kind: 'none', label: 'None (dark canvas)' },
 };
 const DEFAULT_BACKDROP = 'terrain';
@@ -221,11 +229,13 @@ function addBackdrop(featureCollection) {
     const choice = readBackdropChoice();
     const backdrop = MAP_BACKDROPS[choice];
     if (!backdrop || backdrop.kind === 'none') return;
-    if (backdrop.kind === 'image') addImageBackdrop(featureCollection, backdrop.src);
+    if (backdrop.kind === 'image') {
+        const ext = backdrop.bounds ?? resourceNodeExtent(featureCollection, 0.15);
+        addImageBackdrop(backdrop.src, ext);
+    }
 }
 
-function addImageBackdrop(featureCollection, imageSrc) {
-    const ext = resourceNodeExtent(featureCollection, 0.15);
+function addImageBackdrop(imageSrc, ext) {
     const sw = unrealToLatLng(ext.minX, ext.maxY);
     const ne = unrealToLatLng(ext.maxX, ext.minY);
     backdropLayer = L.imageOverlay(imageSrc, [sw, ne], {

--- a/src/Web/wwwroot/lib/maps/README.md
+++ b/src/Web/wwwroot/lib/maps/README.md
@@ -19,13 +19,29 @@ for the licensing decision.
 
 ## Calibration
 
-The user-selectable backdrop is positioned by Leaflet `ImageOverlay`
-bounds, currently the same padded resource-node extent the procedural
-backdrop uses. If markers don't line up cleanly with a specific image,
-override per-image bounds in `factory-map.js`'s `MAP_BACKDROPS` table.
+All three wiki images share the same projection — they're rendered from
+the in-game world map data — so they use a single shared bounds entry
+`WIKI_MAP_BOUNDS` in `factory-map.js`'s `MAP_BACKDROPS` table:
+
+```
+X: -324698 to +425302   (Unreal cm, east-positive)
+Y: -375000 to +375000   (Unreal cm, south-positive)
+```
+
+These are the standard Satisfactory world bounds — 750,000 cm × 750,000
+cm, centered slightly east of world origin. Verified against marker
+alignment in issue [#43](https://github.com/ChrisonSimtian/ERP.Satisfactory/issues/43):
+miners and production buildings sit on land in the terrain and water
+backdrops; biome zones line up cleanly under markers.
+
+If a future backdrop uses a different framing, give it its own `bounds`
+entry. If `bounds` is omitted, `factory-map.js` falls back to the padded
+resource-node extent (roughly correct but pixel-imprecise).
 
 ## Adding a new backdrop
 
 1. Drop the image in this directory.
 2. Add an entry to `MAP_BACKDROPS` in `src/Web/wwwroot/js/factory-map.js`.
-3. Add a radio option in `src/Web/Components/Pages/Settings.razor`.
+   If the image uses the same projection as the existing wiki maps, point
+   its `bounds` at `WIKI_MAP_BOUNDS`; otherwise calibrate per-image.
+3. Add a `MudSelectItem` in `src/Web/Components/Pages/Settings.razor`.


### PR DESCRIPTION
Closes #43.

## Summary

Pin the three wiki backdrops (terrain / biome / water) to the standard Satisfactory world bounds in Unreal cm:

```
X: -324698 .. +425302   (east-positive)
Y: -375000 .. +375000   (south-positive)
```

All three share the same projection (they're rendered from the same in-game world map data), so they point at a single shared `WIKI_MAP_BOUNDS` constant rather than duplicating per-image bounds.

`addImageBackdrop` now uses `backdrop.bounds` when present and falls back to the padded resource-node extent when absent — same behaviour as before for any future backdrop that wants automatic framing.

## Verification

- Debug-marker probes at world origin and the standard NW/NE/SW/SE corners agreed with the bounds calculation to within a pixel
- Miners + production buildings stay on land under the terrain backdrop
- Biome zones line up cleanly under markers in the biome backdrop
- Water bodies sit between marker clusters in the water backdrop

Screenshots in `test/ui-tests/43-iter*.png`.

## Test plan
- [x] Build clean
- [x] Terrain, biome, water backdrops all show markers on land
- [x] Debug-probe agreement at ±1 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)