### PR TITLE
feat(map): belt-polyline plumbing (#44, partial)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -259,17 +259,34 @@ public sealed record FactoryStateView(
 // handles axis orientation + zoom bounds.
 // ---------------------------------------------------------------------------
 
-public sealed record GeoPoint(string Type, double[] Coordinates)
+// GeoJSON geometry — Point uses [x, y]; LineString uses [[x, y], …]. We
+// serialise both shapes through `object` so the JSON layout matches the
+// GeoJSON spec without needing two parallel `GeoFeature` records.
+public sealed record GeoGeometry(string Type, object Coordinates)
 {
-    public static GeoPoint From(Position p) => new("Point", [p.X, p.Y]);
+    public static GeoGeometry Point(Position p) => new("Point", new double[] { p.X, p.Y });
+
+    public static GeoGeometry LineString(IReadOnlyList<Position> polyline)
+    {
+        var coords = new double[polyline.Count][];
+        for (var i = 0; i < polyline.Count; i++)
+            coords[i] = [polyline[i].X, polyline[i].Y];
+        return new GeoGeometry("LineString", coords);
+    }
 }
 
 public sealed record GeoFeature(
     string Type,
-    GeoPoint Geometry,
+    GeoGeometry Geometry,
     Dictionary<string, object?> Properties)
 {
     public static GeoFeature Make(string category, string kind, Position position, Dictionary<string, object?>? extra = null)
+        => new("Feature", GeoGeometry.Point(position), BuildProps(category, kind, position, extra));
+
+    public static GeoFeature MakeLine(string category, string kind, IReadOnlyList<Position> polyline, Position fallback, Dictionary<string, object?>? extra = null)
+        => new("Feature", GeoGeometry.LineString(polyline), BuildProps(category, kind, fallback, extra));
+
+    private static Dictionary<string, object?> BuildProps(string category, string kind, Position position, Dictionary<string, object?>? extra)
     {
         var props = new Dictionary<string, object?>
         {
@@ -279,7 +296,7 @@ public sealed record GeoFeature(
         };
         if (extra is not null)
             foreach (var kv in extra) props[kv.Key] = kv.Value;
-        return new GeoFeature("Feature", GeoPoint.From(position), props);
+        return props;
     }
 }
 
@@ -322,10 +339,16 @@ public sealed record FactoryStateGeoJson(
             }));
 
         foreach (var belt in s.Belts)
-            features.Add(GeoFeature.Make("belt", belt.Reference, belt.Position, new()
+        {
+            var props = new Dictionary<string, object?>
             {
                 ["tier"] = belt.Tier.ToString(),
-            }));
+            };
+            if (belt.Polyline is { Count: >= 2 } poly)
+                features.Add(GeoFeature.MakeLine("belt", belt.Reference, poly, belt.Position, props));
+            else
+                features.Add(GeoFeature.Make("belt", belt.Reference, belt.Position, props));
+        }
 
         foreach (var g in s.Generators)
             features.Add(GeoFeature.Make("generator", g.Reference, g.Position, new()

--- a/src/ERP/Domain/ConveyorBelt.cs
+++ b/src/ERP/Domain/ConveyorBelt.cs
@@ -1,3 +1,14 @@
 namespace ERP.Domain;
 
-public sealed record ConveyorBelt(string Reference, BeltTier Tier, Position Position);
+/// <summary>
+/// A placed conveyor belt. <paramref name="Position"/> is the belt actor's
+/// origin (typically the input connector); <paramref name="Polyline"/> traces
+/// the belt's route when known. Polyline coordinates come from the parent
+/// FGConveyorChainActor's spline data — null when no chain actor references
+/// this belt (rare, but possible for orphaned or lift-pseudo-belt actors).
+/// </summary>
+public sealed record ConveyorBelt(
+    string Reference,
+    BeltTier Tier,
+    Position Position,
+    IReadOnlyList<Position>? Polyline = null);

--- a/src/Satisfactory/Save/SaveFileReader.cs
+++ b/src/Satisfactory/Save/SaveFileReader.cs
@@ -1,5 +1,6 @@
 using ERP.Domain;
 using SatisfactorySaveNet;
+using SatisfactorySaveNet.Abstracts.Extra;
 using SatisfactorySaveNet.Abstracts.Model;
 
 namespace Satisfactory.Save;
@@ -45,6 +46,12 @@ public sealed class SaveFileReader
         var generators = new List<PowerGenerator>();
         var warnings = new List<string>();
 
+        // Belt spline data lives on FGConveyorChainActor objects, not on the
+        // individual Build_ConveyorBeltMk* actors — Coffee Stain consolidated
+        // chain routing into a single per-chain actor. Build the lookup first
+        // (single pass over Levels), then populate Polyline on each belt below.
+        var beltSplines = BuildBeltSplineLookup(body);
+
         foreach (var obj in body.Levels.SelectMany(l => l.Objects))
         {
             if (obj is not ActorObject actor) continue;
@@ -77,7 +84,8 @@ public sealed class SaveFileReader
             }
             else if (BuildingIdentifiers.BeltTier(typePath) is { } beltTier)
             {
-                belts.Add(new ConveyorBelt(reference, beltTier, position));
+                var polyline = beltSplines.GetValueOrDefault(reference);
+                belts.Add(new ConveyorBelt(reference, beltTier, position, polyline));
             }
             else if (BuildingIdentifiers.GeneratorKind(typePath) is { } genKind)
             {
@@ -90,6 +98,58 @@ public sealed class SaveFileReader
         }
 
         return new LiveFactoryState(metadata, resourceNodes, miners, buildings, belts, generators, warnings);
+    }
+
+    /// <summary>
+    /// Walks every FGConveyorChainActor in the save body and indexes each
+    /// chain's per-belt spline points by the belt's PathName. The chain
+    /// actor's ConveyorActors collection holds one entry per belt segment
+    /// in the chain — each entry carries the belt's ObjectReference plus
+    /// its Splines (Location/ArriveTangent/LeaveTangent). We keep only
+    /// Location here; tangents are for smooth-curve interpolation that the
+    /// 2D map doesn't need.
+    /// </summary>
+    /// <summary>
+    /// Walks every FGConveyorChainActor in the save body and indexes each
+    /// chain's per-belt spline points by the belt's PathName. The chain
+    /// actor's ConveyorActors collection holds one entry per belt segment
+    /// in the chain — each entry carries the belt's ObjectReference plus
+    /// its Splines (Location/ArriveTangent/LeaveTangent). We keep only
+    /// Location here; tangents are for smooth-curve interpolation that the
+    /// 2D map doesn't need.
+    /// </summary>
+    /// <remarks>
+    /// At time of writing the vendored SatisfactorySaveNet fork does not
+    /// deserialize ExtraData for FGConveyorChainActor on v1.2+ saves
+    /// (ObjectSerializer.cs:130 shortlist excludes IsConveyorActor —
+    /// fork TODO.md §5). The lookup will be empty until the fork ports
+    /// the v1.2 wire format; downstream callers fall back to point
+    /// geometry when Polyline is null. Tracked in issue #44.
+    /// </remarks>
+    private static Dictionary<string, IReadOnlyList<Position>> BuildBeltSplineLookup(BodyV8 body)
+    {
+        var lookup = new Dictionary<string, IReadOnlyList<Position>>(StringComparer.Ordinal);
+        foreach (var obj in body.Levels.SelectMany(l => l.Objects))
+        {
+            if (obj is not ActorObject actor) continue;
+            if (actor.ExtraData is not ConveyorChainActor chain) continue;
+
+            foreach (var conv in chain.ConveyorActors)
+            {
+                var key = conv.ConveyorBase?.PathName;
+                if (string.IsNullOrEmpty(key)) continue;
+                if (conv.Splines.Count == 0) continue;
+
+                var polyline = new Position[conv.Splines.Count];
+                var i = 0;
+                foreach (var s in conv.Splines)
+                {
+                    polyline[i++] = new Position((float)s.Location.X, (float)s.Location.Y, (float)s.Location.Z);
+                }
+                lookup[key] = polyline;
+            }
+        }
+        return lookup;
     }
 
     private ResourceNode BuildResourceNode(string typePath, string reference, Position position)

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -136,12 +136,20 @@ function unrealToLatLng(x, y) {
 function computeBounds(features) {
     if (!features || features.length === 0) return null;
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const f of features) {
-        const [x, y] = f.geometry.coordinates;
+    const visit = (x, y) => {
         if (x < minX) minX = x;
         if (y < minY) minY = y;
         if (x > maxX) maxX = x;
         if (y > maxY) maxY = y;
+    };
+    for (const f of features) {
+        const g = f.geometry;
+        if (g.type === 'LineString') {
+            for (const [x, y] of g.coordinates) visit(x, y);
+        } else {
+            const [x, y] = g.coordinates;
+            visit(x, y);
+        }
     }
     return [unrealToLatLng(minX, minY), unrealToLatLng(maxX, maxY)];
 }
@@ -154,7 +162,6 @@ function buildCategoryLayers(featureCollection) {
     }
 
     for (const feature of featureCollection.features) {
-        const [x, y] = feature.geometry.coordinates;
         const cat = feature.properties.category;
         let style = STYLE[cat] ?? { color: '#FFFFFF', radius: 4, opacity: 1 };
 
@@ -166,28 +173,45 @@ function buildCategoryLayers(featureCollection) {
         }
 
         const target = layers[cat] ?? (layers[cat] = L.layerGroup());
+        const shape = buildShape(feature, style);
+        if (!shape) continue;
 
-        const marker = L.circleMarker(unrealToLatLng(x, y), {
-            radius: style.radius,
-            color: style.color,
-            fillColor: style.color,
-            fillOpacity: style.opacity,
-            weight: 1,
-            opacity: style.opacity,
-        });
-
-        marker.bindTooltip(tooltipText(feature), {
+        shape.bindTooltip(tooltipText(feature), {
             direction: 'top',
             offset: [0, -4],
             opacity: 0.95,
             className: 'fx-map-tooltip',
         });
-        marker.bindPopup(popupHtml(feature));
+        shape.bindPopup(popupHtml(feature));
 
-        target.addLayer(marker);
+        target.addLayer(shape);
         target._featureCount = (target._featureCount ?? 0) + 1;
     }
     return layers;
+}
+
+function buildShape(feature, style) {
+    const g = feature.geometry;
+    if (g.type === 'LineString') {
+        const latlngs = g.coordinates.map(([x, y]) => unrealToLatLng(x, y));
+        // Belts use the canvas renderer (preferCanvas: true on the map) so even
+        // dense Mk1 cluster routes stay performant. Stroke weight is small but
+        // visible; tier-coloured via the category STYLE.
+        return L.polyline(latlngs, {
+            color: style.color,
+            weight: 1.5,
+            opacity: Math.min(0.9, (style.opacity ?? 0.5) + 0.3),
+        });
+    }
+    const [x, y] = g.coordinates;
+    return L.circleMarker(unrealToLatLng(x, y), {
+        radius: style.radius,
+        color: style.color,
+        fillColor: style.color,
+        fillOpacity: style.opacity,
+        weight: 1,
+        opacity: style.opacity,
+    });
 }
 
 // -------------------------------------------------------------------------

--- a/test/Satisfactory/Save.Tests/SaveFileReaderParityTests.cs
+++ b/test/Satisfactory/Save.Tests/SaveFileReaderParityTests.cs
@@ -46,5 +46,18 @@ public class SaveFileReaderParityTests
             // serialize a value); assert default clock is plausible.
             Assert.All(state.Buildings, b => Assert.InRange(b.ClockSpeed, 0.01m, 2.5m));
         }
+
+        // #44 — belt polyline plumbing. When the fork starts emitting
+        // ConveyorChainActor ExtraData for v1.2 saves (currently excluded
+        // by ObjectSerializer.cs:130 — see fork TODO.md §5), every belt
+        // referenced by a chain actor will get a Polyline of ≥2 points.
+        // Until then this loop runs but yields no matches. Assertion is
+        // a shape check: any polyline we DO produce must be well-formed.
+        foreach (var belt in state.Belts.Where(b => b.Polyline is not null))
+        {
+            Assert.NotNull(belt.Polyline);
+            Assert.True(belt.Polyline!.Count >= 2,
+                $"Belt {belt.Reference} has Polyline with {belt.Polyline.Count} points; expected ≥2.");
+        }
     }
 }


### PR DESCRIPTION
Refs #44.

## TL;DR

End-to-end pipeline for rendering belts as polylines, **but currently emits Point geometry for every belt** because the vendored SatisfactorySaveNet fork doesn't deserialize \`FGConveyorChainActor\` ExtraData on v1.2+ saves. The plumbing is in place so the moment fork support lands, polylines just appear — no further code changes needed.

Full background in [the issue comment](https://github.com/ChrisonSimtian/ERP.Satisfactory/issues/44#issuecomment-4446500630).

## What's in this PR

| Layer | Change |
|---|---|
| Domain | \`ConveyorBelt.Polyline\` — \`IReadOnlyList<Position>?\` |
| Save parser | \`SaveFileReader.BuildBeltSplineLookup\` — pre-pass over \`body.Levels\` indexing each \`ConveyorChainActor\`'s spline points by \`ConveyorBase.PathName\` |
| API | \`GeoGeometry\` supports Point + LineString; \`GeoFeature.MakeLine\` for line features; belt projection emits LineString when polyline has ≥2 points |
| Map JS | \`buildShape\` branches on \`geometry.type\`; LineString → \`L.polyline\` with tier-coloured stroke |
| Tests | Parity test asserts polyline shape correctness when one appears (vacuous pass while fork support is missing) |

## Why it doesn't render lines yet

Empirically verified against \`Beta Game_autosave_2.sav\` (v1.2 experimental, 440 belts):

- 16 unique \`Conveyor\`/\`Chain\` typepaths present, including \`/Script/FactoryGame.FGConveyorChainActor\` and \`_RepSizeMedium\`
- ExtraData tally: \`CircuitData=1, PowerLineData=403, ConveyorData=482\` — **zero \`ConveyorChainActor\` entries**

Root cause: \`vendor/SatisfactorySaveNet/SatisfactorySaveNet/ObjectSerializer.cs:130\` excludes \`IsConveyorActor\` from the v1.2-ported branches. Fork's own \`TODO.md §5\` calls this out.

## Test plan
- [x] Build clean (whole solution)
- [x] Parity test passes on Pedestal fixture + the Beta save (the polyline assertion vacuously passes — no polylines exist yet)
- [x] Map still renders all 440 belts as Points (no regression)
- [ ] LineString rendering not visually verified end-to-end — gated on fork-side work

🤖 Generated with [Claude Code](https://claude.com/claude-code)