### PR TITLE
feat(map): manual resource-node overrides (#42 Option B)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -125,6 +125,55 @@ app.MapPost("/factory/ingest", async (
     }
 });
 
+// ----- Manual node overrides (#42 Option B) ---------------------------------
+// User-curated resource + purity for individual BP_ResourceNode_C actors.
+// Persisted to %LOCALAPPDATA%\ERP.Satisfactory\manual-node-overrides.json.
+// Body identifies the node by `reference` (the in-save PathName, surfaced in
+// GeoJSON as the resource-node feature's `kind`). The server resolves the
+// node's position from current state, persists at that position (so the
+// override survives across saves of the same world), and refreshes parsed
+// state so callers see the change immediately.
+
+app.MapPut("/factory/node-override", (
+    NodeOverrideRequest request,
+    Satisfactory.Save.ManualNodeOverrides overrides,
+    IFactoryStateProvider provider) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Reference))
+        return Results.BadRequest(new { error = "Reference is required." });
+    if (string.IsNullOrWhiteSpace(request.Resource))
+        return Results.BadRequest(new { error = "Resource is required (e.g. Desc_OreIron_C)." });
+    if (!Enum.TryParse<ERP.Domain.NodePurity>(request.Purity, ignoreCase: true, out var purity))
+        return Results.BadRequest(new { error = $"Unknown purity '{request.Purity}'. Use Impure, Normal, or Pure." });
+
+    var node = provider.Current.ResourceNodes
+        .FirstOrDefault(n => string.Equals(n.Reference, request.Reference, StringComparison.Ordinal));
+    if (node is null)
+        return Results.NotFound(new { error = $"No resource node with reference '{request.Reference}'." });
+
+    overrides.Upsert(node.Position, request.Resource, purity);
+    provider.Refresh();
+    return Results.NoContent();
+});
+
+app.MapDelete("/factory/node-override", (
+    string reference,
+    Satisfactory.Save.ManualNodeOverrides overrides,
+    IFactoryStateProvider provider) =>
+{
+    if (string.IsNullOrWhiteSpace(reference))
+        return Results.BadRequest(new { error = "reference query parameter is required." });
+
+    var node = provider.Current.ResourceNodes
+        .FirstOrDefault(n => string.Equals(n.Reference, reference, StringComparison.Ordinal));
+    if (node is null)
+        return Results.NotFound(new { error = $"No resource node with reference '{reference}'." });
+
+    var removed = overrides.Delete(node.Position);
+    if (removed) provider.Refresh();
+    return Results.NoContent();
+});
+
 app.MapPost("/plan", async (PlanRequest request, IMessageBus bus, ICatalogProvider catalog, ILoggerFactory loggerFactory) =>
 {
     if (!catalog.IsLoaded || catalog.Recipes.Count == 0)
@@ -170,6 +219,13 @@ public sealed record RecipeView(
 public sealed record ConfigureCatalogueRequest(string DocsPath);
 
 public sealed record IngestSaveRequest(string SavePath);
+
+/// <summary>
+/// PUT /factory/node-override body. Purity arrives as a string (Impure /
+/// Normal / Pure) — Minimal APIs JSON binding doesn't string-bind enums by
+/// default, and we don't want to enable that globally for everything else.
+/// </summary>
+public sealed record NodeOverrideRequest(string Reference, string Resource, string Purity);
 
 public sealed record DetectedSaveView(string Path, string Name, DateTime LastWriteTimeUtc, long SizeBytes);
 

--- a/src/ERP/Application/IFactoryStateProvider.cs
+++ b/src/ERP/Application/IFactoryStateProvider.cs
@@ -22,4 +22,11 @@ public interface IFactoryStateProvider
     /// warnings on partial parse) or throws on hard failure.
     /// </summary>
     FactoryStateStatus LoadFromPath(string savePath);
+
+    /// <summary>
+    /// Re-parses the currently-loaded save (if any) to pick up changes
+    /// from external sources like manual node overrides. No-op when
+    /// nothing is loaded. Returns the resulting status.
+    /// </summary>
+    FactoryStateStatus Refresh();
 }

--- a/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using ERP.Application;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Satisfactory.Save;
 
 namespace ERP.Infrastructure;
 
@@ -12,6 +13,11 @@ public static class InfrastructureServiceCollectionExtensions
         services.Configure<FactoryStateOptions>(configuration.GetSection("FactoryState:Satisfactory"));
         services.AddSingleton<UserCatalogueConfig>();
         services.AddSingleton<ICatalogProvider, DocsCatalogProvider>();
+        // Manual node overrides — user-local JSON loaded once at startup and
+        // mutated through the /factory/node-override API. Same singleton is
+        // shared with the SaveFileReader so re-parses pick up new entries.
+        services.AddSingleton<ManualNodeOverrides>(_ => ManualNodeOverrides.LoadOrCreate(
+            ManualNodeOverridesPath.Resolve(configuration["FactoryState:Satisfactory:OverridesPath"])));
         services.AddSingleton<IFactoryStateProvider, SatisfactorySaveNetFactoryStateProvider>();
         return services;
     }

--- a/src/ERP/Infrastructure/SatisfactorySaveNetFactoryStateProvider.cs
+++ b/src/ERP/Infrastructure/SatisfactorySaveNetFactoryStateProvider.cs
@@ -26,10 +26,11 @@ public sealed class SatisfactorySaveNetFactoryStateProvider : IFactoryStateProvi
 
     public SatisfactorySaveNetFactoryStateProvider(
         IOptions<FactoryStateOptions> options,
+        ManualNodeOverrides overrides,
         ILogger<SatisfactorySaveNetFactoryStateProvider> logger)
     {
         _options = options.Value;
-        _reader = new SaveFileReader();
+        _reader = new SaveFileReader(KnownResourceNodes.LoadEmbedded(), overrides);
         _logger = logger;
         (_state, _source) = LoadAtStartup();
     }
@@ -57,6 +58,13 @@ public sealed class SatisfactorySaveNetFactoryStateProvider : IFactoryStateProvi
             newState.Miners.Count, newState.Buildings.Count, newState.Belts.Count,
             newState.Generators.Count, newState.ResourceNodes.Count);
         return BuildStatus(newState, resolved);
+    }
+
+    public FactoryStateStatus Refresh()
+    {
+        if (_source is null) return GetStatus();
+        _state = _reader.Read(_source);
+        return BuildStatus(_state, _source);
     }
 
     private (LiveFactoryState State, string? Source) LoadAtStartup()

--- a/src/Satisfactory/Save/ManualNodeOverrides.cs
+++ b/src/Satisfactory/Save/ManualNodeOverrides.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using ERP.Domain;
+
+namespace Satisfactory.Save;
+
+/// <summary>
+/// User-curated overrides for <c>BP_ResourceNode_C</c> resource + purity,
+/// resolved by nearest-neighbour position match (same lookup shape as
+/// <see cref="KnownResourceNodes"/>).
+///
+/// Persisted to a JSON file outside the repo so the dataset is user-local:
+/// the path is resolved by <see cref="ManualNodeOverridesPath.Resolve"/>,
+/// defaulting to <c>%LOCALAPPDATA%\ERP.Satisfactory\manual-node-overrides.json</c>.
+///
+/// Consulted by <see cref="SaveFileReader"/> before the bundled dataset, so
+/// any user override wins. Issue #42 (Option B).
+/// </summary>
+public sealed class ManualNodeOverrides
+{
+    private readonly string _filePath;
+    private readonly List<KnownNode> _entries;
+    private readonly object _writeLock = new();
+
+    public ManualNodeOverrides(string filePath, IEnumerable<KnownNode> entries)
+    {
+        _filePath = filePath;
+        _entries = entries.ToList();
+    }
+
+    /// <summary>In-memory only, no persistence. Useful for tests.</summary>
+    public static ManualNodeOverrides Empty { get; } = new(string.Empty, []);
+
+    /// <summary>
+    /// Loads overrides from the JSON file at <paramref name="filePath"/>.
+    /// Returns an empty instance pointing at the same path when the file
+    /// is missing or malformed — Upsert will create it on first write.
+    /// </summary>
+    public static ManualNodeOverrides LoadOrCreate(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+            return new ManualNodeOverrides(filePath, []);
+
+        try
+        {
+            using var stream = File.OpenRead(filePath);
+            var entries = JsonSerializer.Deserialize<List<KnownNode>>(stream, JsonOptions);
+            return new ManualNodeOverrides(filePath, entries ?? []);
+        }
+        catch (JsonException)
+        {
+            return new ManualNodeOverrides(filePath, []);
+        }
+        catch (IOException)
+        {
+            return new ManualNodeOverrides(filePath, []);
+        }
+    }
+
+    /// <summary>Same shape as <see cref="KnownResourceNodes.Lookup"/>.</summary>
+    public KnownNode? Lookup(Position position, double tolerance = 500.0)
+    {
+        var maxDistSquared = tolerance * tolerance;
+        KnownNode? best = null;
+        var bestDistSquared = maxDistSquared;
+        foreach (var node in _entries)
+        {
+            var dx = node.X - position.X;
+            var dy = node.Y - position.Y;
+            var dz = node.Z - position.Z;
+            var distSquared = (dx * dx) + (dy * dy) + (dz * dz);
+            if (distSquared < bestDistSquared)
+            {
+                best = node;
+                bestDistSquared = distSquared;
+            }
+        }
+        return best;
+    }
+
+    /// <summary>
+    /// Adds or replaces the override at <paramref name="position"/>. If an
+    /// existing entry lies within <paramref name="tolerance"/> world units,
+    /// it's replaced; otherwise a new entry is added. Atomic write to disk.
+    /// </summary>
+    public void Upsert(Position position, string resource, NodePurity purity, double tolerance = 500.0)
+    {
+        if (string.IsNullOrEmpty(_filePath))
+            throw new InvalidOperationException("ManualNodeOverrides has no file path — can't persist.");
+
+        lock (_writeLock)
+        {
+            var existing = Lookup(position, tolerance);
+            if (existing is not null)
+            {
+                _entries.Remove(existing);
+            }
+            _entries.Add(new KnownNode(position.X, position.Y, position.Z, resource, purity));
+            PersistUnlocked();
+        }
+    }
+
+    /// <summary>
+    /// Removes the override at <paramref name="position"/> if one exists
+    /// within <paramref name="tolerance"/>. No-op otherwise. Atomic write.
+    /// </summary>
+    public bool Delete(Position position, double tolerance = 500.0)
+    {
+        if (string.IsNullOrEmpty(_filePath))
+            throw new InvalidOperationException("ManualNodeOverrides has no file path — can't persist.");
+
+        lock (_writeLock)
+        {
+            var existing = Lookup(position, tolerance);
+            if (existing is null) return false;
+            _entries.Remove(existing);
+            PersistUnlocked();
+            return true;
+        }
+    }
+
+    public int Count => _entries.Count;
+    public IReadOnlyList<KnownNode> Entries => _entries;
+    public string FilePath => _filePath;
+
+    private void PersistUnlocked()
+    {
+        var dir = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var tmp = _filePath + ".tmp";
+        using (var stream = File.Create(tmp))
+        {
+            JsonSerializer.Serialize(stream, _entries, JsonWriteOptions);
+        }
+        // Move is atomic on the same volume; replaces existing file on Windows.
+        File.Move(tmp, _filePath, overwrite: true);
+    }
+
+    // Both read and write paths need the string-enum converter so NodePurity
+    // round-trips as "Pure" / "Normal" / "Impure" rather than its underlying int.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions JsonWriteOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+}
+
+/// <summary>
+/// Resolves the on-disk path for <see cref="ManualNodeOverrides"/>. Mirrors
+/// the catalogue / save path pattern from ADR-0011: env var → config →
+/// default under <c>%LOCALAPPDATA%</c>.
+/// </summary>
+public static class ManualNodeOverridesPath
+{
+    public const string EnvVar = "ERP_SATISFACTORY_OVERRIDES_PATH";
+    public const string DefaultRelativePath = @"ERP.Satisfactory\manual-node-overrides.json";
+
+    public static string Resolve(string? configuredPath = null)
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(EnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv)) return fromEnv;
+        if (!string.IsNullOrWhiteSpace(configuredPath)) return configuredPath;
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(localAppData, DefaultRelativePath);
+    }
+}

--- a/src/Satisfactory/Save/SaveFileReader.cs
+++ b/src/Satisfactory/Save/SaveFileReader.cs
@@ -13,12 +13,14 @@ namespace Satisfactory.Save;
 public sealed class SaveFileReader
 {
     private readonly KnownResourceNodes _knownNodes;
+    private readonly ManualNodeOverrides _overrides;
 
-    public SaveFileReader() : this(KnownResourceNodes.LoadEmbedded()) { }
+    public SaveFileReader() : this(KnownResourceNodes.LoadEmbedded(), ManualNodeOverrides.Empty) { }
 
-    public SaveFileReader(KnownResourceNodes knownNodes)
+    public SaveFileReader(KnownResourceNodes knownNodes, ManualNodeOverrides overrides)
     {
         _knownNodes = knownNodes;
+        _overrides = overrides;
     }
 
     public LiveFactoryState Read(string savePath)
@@ -162,16 +164,17 @@ public sealed class SaveFileReader
             return new ResourceNode(reference, kind, Resource: null, NodePurity.Pure, position);
         }
 
-        // Mining nodes / fracking sites need a coordinate lookup against the
-        // bundled known-nodes dataset. Falls back to Unknown if no match.
+        // Mining nodes / fracking sites need a coordinate lookup. We consult
+        // user overrides first (per-machine file) then the bundled dataset.
+        // Either source can be empty; falls back to Unknown on full miss.
         if (kind is ERP.Domain.ResourceNodeKind.MiningNode
                  or ERP.Domain.ResourceNodeKind.FrackingCore
                  or ERP.Domain.ResourceNodeKind.FrackingSatellite)
         {
-            var known = _knownNodes.Lookup(position);
-            if (known is not null)
+            var hit = _overrides.Lookup(position) ?? _knownNodes.Lookup(position);
+            if (hit is not null)
             {
-                return new ResourceNode(reference, kind, new ItemId(known.Resource), known.Purity, position);
+                return new ResourceNode(reference, kind, new ItemId(hit.Resource), hit.Purity, position);
             }
         }
 

--- a/src/Web/Components/Pages/FactoryMap.razor
+++ b/src/Web/Components/Pages/FactoryMap.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @inject IJSRuntime JS
 @inject PlannerApiClient Api
+@inject IDialogService DialogService
 @implements IAsyncDisposable
 
 <PageTitle>Factory map</PageTitle>
@@ -48,6 +49,9 @@ else if (loadedSummary is null)
         {
             <MudText Typo="Typo.caption" Color="Color.Default">No data — ingest a save first.</MudText>
         }
+        <MudText Typo="Typo.caption" Color="Color.Default" Class="d-block mt-3">
+            Click a resource node to set its resource + purity.
+        </MudText>
     </div>
     <div id="factory-map-canvas" @ref="mapElement" class="map-canvas"></div>
 </div>
@@ -55,14 +59,20 @@ else if (loadedSummary is null)
 @code {
     private ElementReference mapElement;
     private IJSObjectReference? mapModule;
+    private DotNetObjectReference<FactoryMap>? selfRef;
     private LayerInfo[]? layers;
     private string? loadedSummary;
     private string? errorMessage;
+    private System.Text.Json.JsonElement? currentGeoJson;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
+        await LoadMap();
+    }
 
+    private async Task LoadMap()
+    {
         try
         {
             var geojson = await Api.GetFactoryStateGeoJsonAsync();
@@ -72,13 +82,17 @@ else if (loadedSummary is null)
                 StateHasChanged();
                 return;
             }
+            currentGeoJson = geojson;
 
-            mapModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/factory-map.js");
-            var rawLayers = await mapModule.InvokeAsync<LayerInfo[]>("initialize", mapElement, geojson);
+            mapModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/factory-map.js");
+            selfRef ??= DotNetObjectReference.Create(this);
+
+            var rawLayers = await mapModule.InvokeAsync<LayerInfo[]>("initialize", mapElement, geojson, selfRef);
 
             layers = rawLayers.Select(l => l with { Visible = true }).ToArray();
             var total = layers.Sum(l => l.Count);
             loadedSummary = $"{total:N0} features across {layers.Length} layers";
+            errorMessage = null;
             StateHasChanged();
         }
         catch (Exception ex)
@@ -100,6 +114,57 @@ else if (loadedSummary is null)
         }
     }
 
+    /// <summary>
+    /// Invoked from factory-map.js when a resource-node marker is clicked.
+    /// Opens the override dialog pre-filled with the node's current resource +
+    /// purity; if the user saves or clears, we reload the map so the change
+    /// is reflected.
+    /// </summary>
+    [JSInvokable]
+    public async Task OnResourceNodeClicked(string reference)
+    {
+        if (currentGeoJson is null) return;
+
+        var (currentResource, currentPurity) = FindNodeState(currentGeoJson.Value, reference);
+
+        var parameters = new DialogParameters
+        {
+            ["Reference"] = reference,
+            ["CurrentResource"] = currentResource,
+            ["CurrentPurity"] = currentPurity,
+        };
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+
+        var dialog = await DialogService.ShowAsync<NodeOverrideDialog>("Set resource node", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            await LoadMap();
+        }
+    }
+
+    private static (string? Resource, string? Purity) FindNodeState(System.Text.Json.JsonElement gj, string reference)
+    {
+        if (!gj.TryGetProperty("features", out var features) || features.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return (null, null);
+
+        // GeoFeature.Make() in Program.cs stores the node's in-save reference (PathName)
+        // as the feature's `kind` property — that's what we match against here.
+        foreach (var f in features.EnumerateArray())
+        {
+            if (!f.TryGetProperty("properties", out var props)) continue;
+            if (!props.TryGetProperty("category", out var cat) || cat.GetString() != "resource-node") continue;
+            if (!props.TryGetProperty("kind", out var kind) || kind.GetString() != reference) continue;
+
+            string? resource = props.TryGetProperty("resource", out var r) && r.ValueKind == System.Text.Json.JsonValueKind.String
+                ? r.GetString() : null;
+            string? purity = props.TryGetProperty("purity", out var p) && p.ValueKind == System.Text.Json.JsonValueKind.String
+                ? p.GetString() : null;
+            return (resource, purity);
+        }
+        return (null, null);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (mapModule is not null)
@@ -112,6 +177,7 @@ else if (loadedSummary is null)
             catch (JSDisconnectedException) { /* circuit closed */ }
             catch (Exception) { /* best-effort cleanup */ }
         }
+        selfRef?.Dispose();
     }
 
     private record LayerInfo(string Category, string Label, string Color, int Count, bool Visible = false);

--- a/src/Web/Components/Pages/NodeOverrideDialog.razor
+++ b/src/Web/Components/Pages/NodeOverrideDialog.razor
@@ -1,0 +1,136 @@
+@*
+    Manual node-override editor — opened from /factory/map when a resource-node
+    marker is clicked (#42 Option B). The caller passes the node's reference
+    (in-save PathName), and optionally the current resource + purity so the
+    dropdowns reflect existing state. Save calls PUT /factory/node-override
+    through PlannerApiClient; Clear deletes the override; Cancel just closes.
+*@
+
+@inject PlannerApiClient Api
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-2">
+            Reference: <code>@Reference</code>
+        </MudText>
+        <MudSelect T="string" @bind-Value="_resource"
+                   Label="Resource"
+                   Variant="Variant.Outlined"
+                   Dense="true"
+                   Margin="Margin.Dense"
+                   Class="mb-2">
+            @foreach (var (id, label) in KnownResources)
+            {
+                <MudSelectItem Value="@id">@label</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="string" @bind-Value="_purity"
+                   Label="Purity"
+                   Variant="Variant.Outlined"
+                   Dense="true"
+                   Margin="Margin.Dense">
+            <MudSelectItem Value="@("Impure")">Impure</MudSelectItem>
+            <MudSelectItem Value="@("Normal")">Normal</MudSelectItem>
+            <MudSelectItem Value="@("Pure")">Pure</MudSelectItem>
+        </MudSelect>
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudText Typo="Typo.caption" Color="Color.Error" Class="mt-2 d-block">@_error</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudSpacer />
+        <MudButton OnClick="Clear" Color="Color.Error" Variant="Variant.Outlined" Disabled="_busy">
+            Clear override
+        </MudButton>
+        <MudButton OnClick="Save" Color="Color.Primary" Variant="Variant.Filled" Disabled="_busy">
+            @(_busy ? "Saving…" : "Save")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter, EditorRequired] public string Reference { get; set; } = "";
+    [Parameter] public string? CurrentResource { get; set; }
+    [Parameter] public string? CurrentPurity { get; set; }
+
+    private string _resource = "Desc_OreIron_C";
+    private string _purity = "Normal";
+    private string? _error;
+    private bool _busy;
+
+    // Vanilla solid/liquid resources that BP_ResourceNode_C / BP_FrackingSatellite_C
+    // / BP_FrackingCore_C can carry. Geysers don't end up in this dialog
+    // (they're always Pure Geothermal — handled at parse time).
+    private static readonly (string Id, string Label)[] KnownResources = new[]
+    {
+        ("Desc_OreIron_C",    "Iron Ore"),
+        ("Desc_OreCopper_C",  "Copper Ore"),
+        ("Desc_Coal_C",       "Coal"),
+        ("Desc_Stone_C",      "Limestone"),
+        ("Desc_LiquidOil_C",  "Crude Oil"),
+        ("Desc_OreGold_C",    "Caterium Ore"),
+        ("Desc_Sulfur_C",     "Sulfur"),
+        ("Desc_RawQuartz_C",  "Raw Quartz"),
+        ("Desc_OreBauxite_C", "Bauxite"),
+        ("Desc_OreUranium_C", "Uranium"),
+        ("Desc_SAM_C",        "SAM"),
+        ("Desc_NitrogenGas_C", "Nitrogen Gas"),
+        ("Desc_Water_C",      "Water"),
+    };
+
+    protected override void OnParametersSet()
+    {
+        if (!string.IsNullOrEmpty(CurrentResource)) _resource = CurrentResource;
+        if (!string.IsNullOrEmpty(CurrentPurity) && CurrentPurity != "Unknown") _purity = CurrentPurity;
+    }
+
+    private async Task Save()
+    {
+        _busy = true;
+        _error = null;
+        try
+        {
+            var result = await Api.SetNodeOverrideAsync(Reference, _resource, _purity);
+            if (result.Success)
+            {
+                MudDialog.Close(DialogResult.Ok(true));
+            }
+            else
+            {
+                _error = result.Error ?? "Save failed.";
+            }
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private async Task Clear()
+    {
+        _busy = true;
+        _error = null;
+        try
+        {
+            var result = await Api.ClearNodeOverrideAsync(Reference);
+            if (result.Success)
+            {
+                MudDialog.Close(DialogResult.Ok(true));
+            }
+            else
+            {
+                _error = result.Error ?? "Clear failed.";
+            }
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -61,6 +61,33 @@ public class PlannerApiClient(HttpClient httpClient)
         var error = await response.Content.ReadAsStringAsync(ct);
         return new FactoryIngestResult(false, null, error);
     }
+
+    /// <summary>
+    /// Upserts a manual resource + purity override for the given node
+    /// reference. The API resolves the node's position from current state
+    /// and persists at that position; subsequent re-parses of the same world
+    /// will pick up the override automatically.
+    /// </summary>
+    public async Task<NodeOverrideResult> SetNodeOverrideAsync(string reference, string resource, string purity, CancellationToken ct = default)
+    {
+        var response = await httpClient.PutAsJsonAsync(
+            "/factory/node-override",
+            new { reference, resource, purity },
+            ct);
+        if (response.IsSuccessStatusCode) return new NodeOverrideResult(true, null);
+        var error = await response.Content.ReadAsStringAsync(ct);
+        return new NodeOverrideResult(false, error);
+    }
+
+    public async Task<NodeOverrideResult> ClearNodeOverrideAsync(string reference, CancellationToken ct = default)
+    {
+        var response = await httpClient.DeleteAsync(
+            $"/factory/node-override?reference={Uri.EscapeDataString(reference)}",
+            ct);
+        if (response.IsSuccessStatusCode) return new NodeOverrideResult(true, null);
+        var error = await response.Content.ReadAsStringAsync(ct);
+        return new NodeOverrideResult(false, error);
+    }
 }
 
 public sealed record CatalogItem(string Id, string Name);
@@ -138,3 +165,5 @@ public sealed record FactoryStateViewModel(
 public sealed record FactoryIngestResult(bool Success, FactoryStateViewModel? State, string? Error);
 
 public sealed record DetectedSaveViewModel(string Path, string Name, DateTime LastWriteTimeUtc, long SizeBytes);
+
+public sealed record NodeOverrideResult(bool Success, string? Error);

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -12,6 +12,7 @@ let map = null;
 let categoryLayers = {};
 let geojson = null;
 let backdropLayer = null;
+let dotNetCallback = null; // Optional Blazor handle for resource-node clicks (#42).
 
 const STYLE = {
     'resource-node': { color: '#FFC53D', radius: 3.5, opacity: 0.85, label: 'Resource nodes' },
@@ -32,7 +33,7 @@ const NODE_KIND_STYLE = {
     'FrackingSatellite':  { color: '#7E5DC5', radius: 4,   opacity: 0.9  },
 };
 
-export async function initialize(element, featureCollection) {
+export async function initialize(element, featureCollection, callback) {
     await ensureLeafletLoaded();
     if (map) {
         map.remove();
@@ -40,6 +41,7 @@ export async function initialize(element, featureCollection) {
     }
 
     geojson = featureCollection;
+    dotNetCallback = callback ?? null;
 
     map = L.map(element, {
         crs: L.CRS.Simple,
@@ -88,6 +90,7 @@ export function dispose() {
     categoryLayers = {};
     geojson = null;
     backdropLayer = null;
+    dotNetCallback = null;
 }
 
 // -------------------------------------------------------------------------
@@ -183,6 +186,18 @@ function buildCategoryLayers(featureCollection) {
             className: 'fx-map-tooltip',
         });
         shape.bindPopup(popupHtml(feature));
+
+        // Resource-node markers are click-editable when a Blazor callback is
+        // wired up (#42 manual overrides). Other categories don't need this.
+        if (cat === 'resource-node' && dotNetCallback) {
+            const reference = feature.properties.kind;
+            shape.on('click', () => {
+                // invokeMethodAsync is the standard Blazor JS-interop entry; the
+                // C# side has a [JSInvokable] method matching this signature.
+                dotNetCallback.invokeMethodAsync('OnResourceNodeClicked', reference)
+                    .catch(err => console.error('Resource-node click callback failed:', err));
+            });
+        }
 
         target.addLayer(shape);
         target._featureCount = (target._featureCount ?? 0) + 1;

--- a/test/Satisfactory/Save.Tests/ManualNodeOverridesTests.cs
+++ b/test/Satisfactory/Save.Tests/ManualNodeOverridesTests.cs
@@ -1,0 +1,163 @@
+using ERP.Domain;
+
+namespace Satisfactory.Save.Tests;
+
+public class ManualNodeOverridesTests
+{
+    [Fact]
+    public void LoadOrCreate_Returns_Empty_Instance_When_File_Missing()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "nope.json");
+
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+
+        Assert.Equal(0, overrides.Count);
+        Assert.Equal(path, overrides.FilePath);
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void LoadOrCreate_Returns_Empty_Instance_When_File_Is_Malformed()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "broken.json");
+        File.WriteAllText(path, "{ this is not valid json");
+
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+
+        Assert.Equal(0, overrides.Count);
+    }
+
+    [Fact]
+    public void Upsert_Persists_New_Entry_And_Roundtrips_From_Disk()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "overrides.json");
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+
+        overrides.Upsert(new Position(1000, 2000, 50), "Desc_OreIron_C", NodePurity.Pure);
+
+        Assert.True(File.Exists(path));
+        var reloaded = ManualNodeOverrides.LoadOrCreate(path);
+        Assert.Equal(1, reloaded.Count);
+        var hit = reloaded.Lookup(new Position(1000, 2000, 50));
+        Assert.NotNull(hit);
+        Assert.Equal("Desc_OreIron_C", hit!.Resource);
+        Assert.Equal(NodePurity.Pure, hit.Purity);
+    }
+
+    [Fact]
+    public void Upsert_Replaces_Existing_Entry_Within_Tolerance()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "overrides.json");
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+
+        overrides.Upsert(new Position(0, 0, 0), "Desc_OreIron_C", NodePurity.Normal);
+        // A small movement (well under default 500 unit tolerance) — same node, updated.
+        overrides.Upsert(new Position(100, 100, 0), "Desc_OreCopper_C", NodePurity.Pure);
+
+        Assert.Equal(1, overrides.Count);
+        var hit = overrides.Lookup(new Position(50, 50, 0));
+        Assert.Equal("Desc_OreCopper_C", hit!.Resource);
+        Assert.Equal(NodePurity.Pure, hit.Purity);
+    }
+
+    [Fact]
+    public void Upsert_Adds_New_Entry_When_Outside_Tolerance()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "overrides.json");
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+
+        overrides.Upsert(new Position(0, 0, 0), "Desc_OreIron_C", NodePurity.Normal);
+        overrides.Upsert(new Position(10000, 0, 0), "Desc_OreCopper_C", NodePurity.Pure);
+
+        Assert.Equal(2, overrides.Count);
+    }
+
+    [Fact]
+    public void Delete_Removes_Entry_And_Persists()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "overrides.json");
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+        overrides.Upsert(new Position(1000, 1000, 0), "Desc_Coal_C", NodePurity.Pure);
+
+        var removed = overrides.Delete(new Position(1100, 1100, 0));
+
+        Assert.True(removed);
+        Assert.Equal(0, overrides.Count);
+        var reloaded = ManualNodeOverrides.LoadOrCreate(path);
+        Assert.Equal(0, reloaded.Count);
+    }
+
+    [Fact]
+    public void Delete_Is_Noop_When_No_Match_In_Tolerance()
+    {
+        using var temp = new TempDir();
+        var path = Path.Combine(temp.Path, "overrides.json");
+        var overrides = ManualNodeOverrides.LoadOrCreate(path);
+        overrides.Upsert(new Position(0, 0, 0), "Desc_Coal_C", NodePurity.Pure);
+
+        var removed = overrides.Delete(new Position(50000, 50000, 0));
+
+        Assert.False(removed);
+        Assert.Equal(1, overrides.Count);
+    }
+
+    [Fact]
+    public void Empty_Instance_Throws_On_Upsert()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            ManualNodeOverrides.Empty.Upsert(new Position(0, 0, 0), "Desc_OreIron_C", NodePurity.Normal));
+    }
+
+    [Fact]
+    public void Path_Resolver_Prefers_Env_Var_Over_Config_And_Default()
+    {
+        var prior = Environment.GetEnvironmentVariable(ManualNodeOverridesPath.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(ManualNodeOverridesPath.EnvVar, @"C:\from\env.json");
+
+            Assert.Equal(@"C:\from\env.json",
+                ManualNodeOverridesPath.Resolve(configuredPath: @"C:\from\config.json"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ManualNodeOverridesPath.EnvVar, prior);
+        }
+    }
+
+    [Fact]
+    public void Path_Resolver_Falls_Through_To_Configured_Then_LocalAppData()
+    {
+        var prior = Environment.GetEnvironmentVariable(ManualNodeOverridesPath.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(ManualNodeOverridesPath.EnvVar, null);
+
+            Assert.Equal(@"C:\from\config.json",
+                ManualNodeOverridesPath.Resolve(configuredPath: @"C:\from\config.json"));
+
+            var defaultPath = ManualNodeOverridesPath.Resolve(configuredPath: null);
+            Assert.EndsWith(ManualNodeOverridesPath.DefaultRelativePath, defaultPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ManualNodeOverridesPath.EnvVar, prior);
+        }
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = Directory.CreateTempSubdirectory("erp-overrides-test-").FullName;
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds click-to-edit on resource-node markers in `/factory/map`. Dialog (MudBlazor) lets the user pick resource + purity for any `BP_ResourceNode_C` actor.
- Overrides persist to `%LOCALAPPDATA%\ERP.Satisfactory\manual-node-overrides.json` (path overridable via `ERP_SATISFACTORY_OVERRIDES_PATH` or config) and are consulted **before** the bundled `KnownResourceNodes` dataset on every save parse.
- New `PUT/DELETE /factory/node-override` API endpoints; `IFactoryStateProvider.Refresh()` so the API can re-apply overrides without re-resolving the save path.

## Why Option B
Issue #42 originally proposed bundling a ≥459-entry JSON dataset sourced from the wiki / extracted from the .pak. Option B sidesteps the licensing + sourcing toil by letting the user curate their own world's data interactively. The bundled dataset path (`KnownResourceNodes`) is left in place for future contribution; either source can fill it.

## Test plan
- [x] `ManualNodeOverridesTests` (10 tests) — LoadOrCreate missing/malformed, Upsert persist + roundtrip, replace-within-tolerance, add-outside-tolerance, Delete + persist, Delete noop, Empty throws, path resolver precedence.
- [x] Full `dotnet test` green (Catalog 18, Save 17, Web UI 2).
- [ ] Manual: ingest a save, click a node on `/factory/map`, set Iron / Pure, confirm marker re-colours and survives a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)