### PR TITLE
feat(planner): report total power per recipe group (#7)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -435,12 +435,14 @@ public sealed record StepDto(
     string BuildingId,
     string BuildingName,
     decimal BuildingCount,
+    decimal PowerMw,
     IReadOnlyList<AmountDto> Inputs,
     IReadOnlyList<AmountDto> Outputs);
 
 public sealed record PlanDto(
     bool IsFeasible,
     IReadOnlyList<StepDto> Steps,
+    decimal TotalPowerMw,
     IReadOnlyList<AmountDto> RawInputsConsumed,
     IReadOnlyList<AmountDto> MissingInputs)
 {
@@ -449,16 +451,20 @@ public sealed record PlanDto(
         AmountDto ToAmount(ItemAmount a) =>
             new(a.Item.Value, catalog.FindItem(a.Item)?.Name ?? a.Item.Value, Math.Round(a.Quantity, 4));
 
+        var steps = plan.Steps.Select(s => new StepDto(
+            s.Recipe.Id.Value,
+            s.Recipe.Name,
+            s.Recipe.Building.Value,
+            catalog.FindBuilding(s.Recipe.Building)?.Name ?? s.Recipe.Building.Value,
+            Math.Round(s.BuildingCount, 4),
+            Math.Round(s.PowerMw, 4),
+            s.InputsPerMinute.Select(ToAmount).ToList(),
+            s.OutputsPerMinute.Select(ToAmount).ToList())).ToList();
+
         return new(
             IsFeasible: plan.IsFeasible,
-            Steps: plan.Steps.Select(s => new StepDto(
-                s.Recipe.Id.Value,
-                s.Recipe.Name,
-                s.Recipe.Building.Value,
-                catalog.FindBuilding(s.Recipe.Building)?.Name ?? s.Recipe.Building.Value,
-                Math.Round(s.BuildingCount, 4),
-                s.InputsPerMinute.Select(ToAmount).ToList(),
-                s.OutputsPerMinute.Select(ToAmount).ToList())).ToList(),
+            Steps: steps,
+            TotalPowerMw: Math.Round(steps.Sum(s => s.PowerMw), 4),
             RawInputsConsumed: plan.RawInputsConsumed.Select(ToAmount).ToList(),
             MissingInputs: plan.MissingInputs.Select(ToAmount).ToList());
     }

--- a/src/ERP/Application/Queries/PlanProduction/PlanProductionQuery.cs
+++ b/src/ERP/Application/Queries/PlanProduction/PlanProductionQuery.cs
@@ -31,7 +31,7 @@ public static class PlanProductionHandler
         }
 
         var steps = stepsByRecipe.Values
-            .Select(a => BuildStep(a.Recipe, a.OutputRatePerMinute))
+            .Select(a => BuildStep(a.Recipe, a.OutputRatePerMinute, catalog))
             .ToList();
 
         return new ProductionPlan(
@@ -125,7 +125,7 @@ public static class PlanProductionHandler
         }
     }
 
-    private static ProductionStep BuildStep(Recipe recipe, decimal scale)
+    private static ProductionStep BuildStep(Recipe recipe, decimal scale, ICatalogProvider catalog)
     {
         var inputs = recipe.Inputs
             .Select(i => new ItemAmount(i.Item, RatePerMinute(i.Quantity, recipe.Duration) * scale))
@@ -133,7 +133,16 @@ public static class PlanProductionHandler
         var outputs = recipe.Outputs
             .Select(o => new ItemAmount(o.Item, RatePerMinute(o.Quantity, recipe.Duration) * scale))
             .ToList();
-        return new ProductionStep(recipe, scale, inputs, outputs);
+
+        // Power: documented base draw × building count. The catalogue only
+        // exposes BasePowerMw today; variable-power buildings (miners, etc.)
+        // would need a separate AveragePowerMw field, which doesn't exist yet
+        // — so this is intentionally the base figure. When the building is
+        // unknown or has no documented power, the contribution is zero.
+        var basePower = catalog.FindBuilding(recipe.Building)?.BasePowerMw ?? 0;
+        var powerMw = (decimal)basePower * scale;
+
+        return new ProductionStep(recipe, scale, powerMw, inputs, outputs);
     }
 
     private static decimal RatePerMinute(decimal quantityPerRun, TimeSpan duration) =>

--- a/src/ERP/Domain/ProductionStep.cs
+++ b/src/ERP/Domain/ProductionStep.cs
@@ -1,7 +1,21 @@
 namespace ERP.Domain;
 
+/// <summary>
+/// One row in a production plan: a recipe and how many buildings of its
+/// configured type are required to satisfy demand.
+/// <para>
+/// <see cref="PowerMw"/> is the aggregate <em>base</em> power draw of all
+/// buildings in the step (= <c>Building.BasePowerMw × BuildingCount</c>).
+/// Some buildings (most notably miners and certain power-generation tied
+/// extractors) have variable power that scales with purity / overclock —
+/// the catalogue currently exposes only <c>BasePowerMw</c>, so this figure
+/// is the documented base draw, not an in-game average. When base power is
+/// unknown the value is <c>0</c>.
+/// </para>
+/// </summary>
 public sealed record ProductionStep(
     Recipe Recipe,
     decimal BuildingCount,
+    decimal PowerMw,
     IReadOnlyList<ItemAmount> InputsPerMinute,
     IReadOnlyList<ItemAmount> OutputsPerMinute);

--- a/src/Web/Components/Pages/Planner.razor
+++ b/src/Web/Components/Pages/Planner.razor
@@ -139,7 +139,7 @@ else
 @if (plan is not null)
 {
     <MudDivider Class="my-4" />
-    <div class="d-flex align-items-center gap-2 mb-3">
+    <div class="d-flex align-items-center gap-2 mb-3 flex-wrap">
         <MudText Typo="Typo.h4" Class="mb-0">Plan</MudText>
         @if (plan.IsFeasible)
         {
@@ -148,6 +148,13 @@ else
         else
         {
             <MudChip T="string" Color="Color.Warning" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Warning">Missing inputs</MudChip>
+        }
+        @if (plan.Steps.Count > 0)
+        {
+            <MudChip T="string" Color="Color.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Bolt"
+                     title="Sum of base power draw (Building.BasePowerMw × buildings). Variable-power buildings (e.g. miners) report base only.">
+                @FormatPower(plan.TotalPowerMw) MW total
+            </MudChip>
         }
     </div>
 
@@ -168,6 +175,7 @@ else
                 <PropertyColumn Property="s => s.RecipeName" Title="Recipe" />
                 <PropertyColumn Property="s => s.BuildingName" Title="Building" />
                 <PropertyColumn Property="s => s.BuildingCount" Title="Buildings" Format="0.##" CellStyle="text-align: right;" HeaderStyle="text-align: right;" />
+                <PropertyColumn Property="s => s.PowerMw" Title="Power (MW)" Format="0.##" CellStyle="text-align: right;" HeaderStyle="text-align: right;" />
                 <TemplateColumn Title="Inputs / min" Sortable="false" Filterable="false">
                     <CellTemplate>
                         <div class="fx-amount-list">
@@ -287,6 +295,9 @@ else
 
     private static string FormatRate(decimal rate) =>
         rate == Math.Floor(rate) ? rate.ToString("0") : rate.ToString("0.##");
+
+    private static string FormatPower(decimal mw) =>
+        mw == Math.Floor(mw) ? mw.ToString("0") : mw.ToString("0.##");
 
     private Task<IEnumerable<CatalogItem>> SearchItems(string? value, CancellationToken ct)
     {

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -114,12 +114,14 @@ public sealed record StepView(
     string BuildingId,
     string BuildingName,
     decimal BuildingCount,
+    decimal PowerMw,
     IReadOnlyList<AmountView> Inputs,
     IReadOnlyList<AmountView> Outputs);
 
 public sealed record PlanResponse(
     bool IsFeasible,
     IReadOnlyList<StepView> Steps,
+    decimal TotalPowerMw,
     IReadOnlyList<AmountView> RawInputsConsumed,
     IReadOnlyList<AmountView> MissingInputs);
 

--- a/test/ERP/Application.Tests/PlanProductionHandlerTests.cs
+++ b/test/ERP/Application.Tests/PlanProductionHandlerTests.cs
@@ -1,0 +1,139 @@
+using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+
+namespace ERP.Application.Tests;
+
+public class PlanProductionHandlerTests
+{
+    private static readonly BuildingId SmelterId = new("Build_SmelterMk1_C");
+    private static readonly BuildingId ConstructorId = new("Build_ConstructorMk1_C");
+
+    private static readonly ItemId IronOre = new("Desc_OreIron_C");
+    private static readonly ItemId IronIngot = new("Desc_IronIngot_C");
+    private static readonly ItemId IronPlate = new("Desc_IronPlate_C");
+
+    // Update 10-ish values: smelter 4 MW, constructor 4 MW. Iron ingot recipe
+    // produces 1 ingot per 2 s = 30/min; iron plate produces 2 plates per 6 s = 20/min.
+    private static readonly Recipe IronIngotRecipe = new(
+        new RecipeId("Recipe_IngotIron_C"),
+        "Iron Ingot",
+        SmelterId,
+        Inputs: [new ItemAmount(IronOre, 1)],
+        Outputs: [new ItemAmount(IronIngot, 1)],
+        Duration: TimeSpan.FromSeconds(2));
+
+    private static readonly Recipe IronPlateRecipe = new(
+        new RecipeId("Recipe_IronPlate_C"),
+        "Iron Plate",
+        ConstructorId,
+        Inputs: [new ItemAmount(IronIngot, 3)],
+        Outputs: [new ItemAmount(IronPlate, 2)],
+        Duration: TimeSpan.FromSeconds(6));
+
+    [Fact]
+    public void Computes_Power_For_Single_Step_Plan()
+    {
+        // 30 ingots/min → exactly one smelter (1.0 building × 4 MW = 4 MW).
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+            ],
+            recipes: [IronIngotRecipe]);
+
+        var plan = PlanProductionHandler.Handle(
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronIngot, 30)],
+                Available: [new ResourceAvailability(IronOre, 30)]),
+            catalog);
+
+        var step = Assert.Single(plan.Steps);
+        Assert.Equal(1m, step.BuildingCount);
+        Assert.Equal(4m, step.PowerMw);
+    }
+
+    [Fact]
+    public void Computes_Power_Across_Multiple_Steps_With_Scaling()
+    {
+        // 60 plates/min → 3 constructors (60/20 = 3.0) at 4 MW each = 12 MW.
+        // Needs 90 ingots/min → 3 smelters at 4 MW each = 12 MW.
+        // Total = 24 MW.
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+                new Building(ConstructorId, "Constructor", BasePowerMw: 4),
+            ],
+            recipes: [IronIngotRecipe, IronPlateRecipe]);
+
+        var plan = PlanProductionHandler.Handle(
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronPlate, 60)],
+                Available: [new ResourceAvailability(IronOre, 999)]),
+            catalog);
+
+        Assert.Equal(2, plan.Steps.Count);
+        var plateStep = plan.Steps.Single(s => s.Recipe.Id == IronPlateRecipe.Id);
+        var ingotStep = plan.Steps.Single(s => s.Recipe.Id == IronIngotRecipe.Id);
+        Assert.Equal(3m, plateStep.BuildingCount);
+        Assert.Equal(12m, plateStep.PowerMw);
+        Assert.Equal(3m, ingotStep.BuildingCount);
+        Assert.Equal(12m, ingotStep.PowerMw);
+        Assert.Equal(24m, plan.Steps.Sum(s => s.PowerMw));
+    }
+
+    [Fact]
+    public void Power_Is_Zero_When_Building_Missing_From_Catalogue()
+    {
+        // Missing building entry → defensive zero rather than throwing.
+        var catalog = new FakeCatalog(
+            buildings: [], // smelter intentionally absent
+            recipes: [IronIngotRecipe]);
+
+        var plan = PlanProductionHandler.Handle(
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronIngot, 30)],
+                Available: [new ResourceAvailability(IronOre, 30)]),
+            catalog);
+
+        var step = Assert.Single(plan.Steps);
+        Assert.Equal(0m, step.PowerMw);
+    }
+
+    /// <summary>
+    /// Minimal in-memory catalogue stand-in. The handler only calls
+    /// <see cref="FindDefaultProducerOf"/> and <see cref="FindBuilding"/>, so
+    /// everything else throws to surface unexpected usage in tests.
+    /// </summary>
+    private sealed class FakeCatalog : ICatalogProvider
+    {
+        private readonly Dictionary<BuildingId, Building> _buildings;
+        private readonly List<Recipe> _recipes;
+
+        public FakeCatalog(IEnumerable<Building> buildings, IEnumerable<Recipe> recipes)
+        {
+            _buildings = buildings.ToDictionary(b => b.Id);
+            _recipes = recipes.ToList();
+        }
+
+        public bool IsLoaded => true;
+        public string? Source => "fake";
+        public IReadOnlyList<Item> Items => [];
+        public IReadOnlyList<Building> Buildings => _buildings.Values.ToList();
+        public IReadOnlyList<Recipe> Recipes => _recipes;
+
+        public Item? FindItem(ItemId id) => null;
+        public Building? FindBuilding(BuildingId id) =>
+            _buildings.TryGetValue(id, out var b) ? b : null;
+        public Recipe? FindRecipe(RecipeId id) =>
+            _recipes.FirstOrDefault(r => r.Id == id);
+
+        public Recipe? FindDefaultProducerOf(ItemId item) =>
+            _recipes.FirstOrDefault(r => r.Outputs.Any(o => o.Item == item));
+
+        public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) =>
+            _recipes.Where(r => r.Outputs.Any(o => o.Item == item)).ToList();
+
+        public CatalogueStatus GetStatus() => throw new NotSupportedException();
+        public CatalogueStatus LoadFromPath(string docsJsonPath) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Closes #7.

## Summary
- `ProductionStep` gains `PowerMw` (computed at step materialisation as `BasePowerMw × buildingScale`).
- `PlanDto` gains `TotalPowerMw` (rounded sum across steps).
- Planner page shows a `Power (MW)` column plus a total-power chip alongside the feasibility chip.
- 3 new xUnit tests in `ERP.Application.Tests` (single-step, multi-step scaling, defensive zero when building missing from catalogue).

## Note
Today's "LP solver" is a recursive recipe-expansion handler (`PlanProductionHandler`), not a true LP. Power is plugged in at step materialisation so it survives a future swap to a real LP solver.

## Test plan
- [x] `dotnet build ERP.Satisfactory.slnx` — green
- [x] `dotnet test` — 38 passed, 0 failed
- [ ] Manual planner UI check (needs a configured Docs.json catalogue + live AppHost — not run by the agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)