### PR TITLE
docs(claude): note submodule init requirement for worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ ERP-style production planner for the game *Satisfactory*. Primary objective:
 ## Build & run
 
 ```powershell
-dotnet build ERP.Satisfactory.sln
+git submodule update --init --recursive   # required after clone or `git worktree add`
+dotnet build ERP.Satisfactory.slnx
 dotnet run --project src/AppHost
 ```
+
+The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`).
+Worktrees do **not** auto-init submodules — run the command above whenever a fresh
+worktree or clone is created, or the solution will fail to build.


### PR DESCRIPTION
Quick docs fix surfaced by this session.

## Why
Three agents in a parallel-PR session this week burned time on `vendor/SatisfactorySaveNet` not being initialised in their worktrees. `git worktree add` does not auto-init submodules, and CLAUDE.md's Build & run section didn't mention them.

## Changes
- Add `git submodule update --init --recursive` as the first step in Build & run, with a short note that worktrees don't auto-init.
- Fix the build command to reference `ERP.Satisfactory.slnx` (the actual file) instead of the legacy `ERP.Satisfactory.sln`.

## Test plan
- [x] Doc-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)