### PR TITLE
ci(persistence): migration drift guard + Postgres runtime smoke (#81)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,6 +6,11 @@
       "version": "3.7.115",
       "commands": ["nbgv"],
       "rollForward": false
+    },
+    "dotnet-ef": {
+      "version": "10.0.8",
+      "commands": ["dotnet-ef"],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,97 @@ jobs:
           if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
+  # Migration drift guard (ADR-0018 follow-up, issue #81).
+  # Asserts both EF Core migration sets (SQLite + Postgres) are in sync with
+  # the current PlanDbContext model — `has-pending-model-changes` exits non-zero
+  # if a snapshot drifts. Runs in parallel with Build & Test for fast feedback.
+  # ---------------------------------------------------------------------------
+  migration-drift:
+    name: Migration drift (SQLite + Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize vendored SatisfactorySaveNet submodule
+        run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ubuntu-latest-nuget-${{ hashFiles('**/*.csproj', '**/global.json') }}
+          restore-keys: ubuntu-latest-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+          global-json-file: global.json
+
+      - name: Check migrations (both providers)
+        run: ./build.sh CheckMigrations
+
+  # ---------------------------------------------------------------------------
+  # Postgres runtime smoke (ADR-0018 follow-up, issue #81).
+  # Spins up postgres:16 via the GitHub Actions services block and runs
+  # `dotnet ef database update` against it — proves the Postgres migration
+  # actually applies. Non-zero exit fails the job.
+  # ---------------------------------------------------------------------------
+  postgres-smoke:
+    name: Postgres migration smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: plans
+        ports:
+          - 5432:5432
+        # Wait for Postgres to accept connections before the job's steps run.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize vendored SatisfactorySaveNet submodule
+        run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ubuntu-latest-nuget-${{ hashFiles('**/*.csproj', '**/global.json') }}
+          restore-keys: ubuntu-latest-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+          global-json-file: global.json
+
+      - name: Apply Postgres migrations
+        env:
+          ERP_PERSISTENCE_CONNECTION: Host=localhost;Port=5432;Database=plans;Username=postgres;Password=postgres
+        run: ./build.sh MigrationsPostgresSmoke
+
+      - name: List applied tables (log only)
+        if: always()
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -d plans -c "\dt" || true
+
+  # ---------------------------------------------------------------------------
   # Publish — surface TRX results to commit check + PR comment.
   # ---------------------------------------------------------------------------
   publish-test-results:
@@ -127,7 +218,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Release
-    needs: [lint, build-and-test]
+    needs: [lint, build-and-test, migration-drift, postgres-smoke]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 15

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -24,11 +24,13 @@
     "ExecutableTarget": {
       "type": "string",
       "enum": [
+        "CheckMigrations",
         "Clean",
         "Compile",
         "ComputeVersion",
         "Format",
         "InstallPlaywrightBrowsers",
+        "MigrationsPostgresSmoke",
         "Release",
         "Restore",
         "Test",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -154,10 +154,14 @@ class Build : NukeBuild
             void Check(string contextName, params (string Key, string Value)[] extraEnv)
             {
                 Log.Information("Checking pending model changes for {Context}", contextName);
+                // --configuration matches what Compile produced so --no-build can find
+                // the right bin/<Configuration>/net10.0/ApiService.deps.json. Without
+                // this, ef defaults to Debug while CI builds Release and the lookup fails.
                 var args = $"ef migrations has-pending-model-changes " +
                            $"--project \"{persistenceProject}\" " +
                            $"--startup-project \"{startupProject}\" " +
                            $"--context {contextName} " +
+                           $"--configuration {Configuration} " +
                            $"--no-build";
 
                 var env = new Dictionary<string, string>(EnvironmentInfo.Variables);
@@ -219,6 +223,7 @@ class Build : NukeBuild
                        $"--project \"{persistenceProject}\" " +
                        $"--startup-project \"{startupProject}\" " +
                        $"--context PostgresPlanDbContext " +
+                       $"--configuration {Configuration} " +
                        $"--no-build";
 
             var process = ProcessTasks.StartProcess(

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -128,6 +128,109 @@ class Build : NukeBuild
             Log.Information("TRX results written to {Dir} (Web.UiTests excluded — run `./build.sh Test` locally to include them)", TestResultsDirectory);
         });
 
+    // -------------------------------------------------------------------------
+    // Migration-drift guard (ADR-0018 follow-up, issue #81).
+    //
+    // Dual-provider EF Core means two migration sets that must each match the
+    // current `PlanDbContext` model. `dotnet ef migrations has-pending-model-changes`
+    // exits non-zero when the snapshot is out of date — perfect for CI.
+    //
+    // Runs for both SqlitePlanDbContext and PostgresPlanDbContext. The Postgres
+    // design-time factory requires a connection-string env var (the connection
+    // isn't actually opened for `has-pending-model-changes`, but the factory
+    // refuses to construct without it).
+    // -------------------------------------------------------------------------
+    Target CheckMigrations => _ => _
+        .Description("Verifies both EF Core migration sets (SQLite + Postgres) are in sync with the current model.")
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            // Tool restore is idempotent — pulls dotnet-ef from .config/dotnet-tools.json.
+            DotNet("tool restore", workingDirectory: RootDirectory, logOutput: false);
+
+            var persistenceProject = RootDirectory / "src" / "ERP" / "Infrastructure" / "Persistence";
+            var startupProject = RootDirectory / "src" / "ApiService";
+
+            void Check(string contextName, params (string Key, string Value)[] extraEnv)
+            {
+                Log.Information("Checking pending model changes for {Context}", contextName);
+                var args = $"ef migrations has-pending-model-changes " +
+                           $"--project \"{persistenceProject}\" " +
+                           $"--startup-project \"{startupProject}\" " +
+                           $"--context {contextName} " +
+                           $"--no-build";
+
+                var env = new Dictionary<string, string>(EnvironmentInfo.Variables);
+                foreach (var (k, v) in extraEnv) env[k] = v;
+
+                var process = ProcessTasks.StartProcess(
+                    "dotnet",
+                    args,
+                    workingDirectory: RootDirectory,
+                    environmentVariables: env);
+                process.AssertZeroExitCode();
+                Log.Information("{Context}: migration snapshot is in sync.", contextName);
+            }
+
+            Check("SqlitePlanDbContext");
+
+            // Placeholder connection string — design-time factory only validates
+            // that it's set, it never opens the connection for this command.
+            Check("PostgresPlanDbContext",
+                ("ERP_PERSISTENCE_CONNECTION", "Host=localhost;Database=plans;Username=postgres;Password=placeholder"));
+        });
+
+    // -------------------------------------------------------------------------
+    // Postgres runtime smoke (ADR-0018 follow-up, issue #81).
+    //
+    // Applies the Postgres migration set against a real Postgres instance and
+    // asserts the schema creates successfully. In CI this runs inside a job
+    // with a `postgres:16` services container; locally you point it at any
+    // reachable Postgres via the standard env vars.
+    //
+    // Requires:
+    //   ERP_PERSISTENCE_CONNECTION = Npgsql connection string to a live DB.
+    // -------------------------------------------------------------------------
+    Target MigrationsPostgresSmoke => _ => _
+        .Description("Applies the Postgres migration set against a live database. Requires ERP_PERSISTENCE_CONNECTION.")
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            var conn = Environment.GetEnvironmentVariable("ERP_PERSISTENCE_CONNECTION");
+            if (string.IsNullOrWhiteSpace(conn))
+            {
+                throw new InvalidOperationException(
+                    "MigrationsPostgresSmoke requires ERP_PERSISTENCE_CONNECTION pointing at a live Postgres. " +
+                    "Locally: `docker run --rm -d -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:16` then " +
+                    "set ERP_PERSISTENCE_CONNECTION=Host=localhost;Database=plans;Username=postgres;Password=postgres.");
+            }
+
+            DotNet("tool restore", workingDirectory: RootDirectory, logOutput: false);
+
+            var persistenceProject = RootDirectory / "src" / "ERP" / "Infrastructure" / "Persistence";
+            var startupProject = RootDirectory / "src" / "ApiService";
+
+            var env = new Dictionary<string, string>(EnvironmentInfo.Variables)
+            {
+                ["ERP_PERSISTENCE_CONNECTION"] = conn,
+            };
+
+            var args = $"ef database update " +
+                       $"--project \"{persistenceProject}\" " +
+                       $"--startup-project \"{startupProject}\" " +
+                       $"--context PostgresPlanDbContext " +
+                       $"--no-build";
+
+            var process = ProcessTasks.StartProcess(
+                "dotnet",
+                args,
+                workingDirectory: RootDirectory,
+                environmentVariables: env);
+            process.AssertZeroExitCode();
+            Log.Information("Postgres migration applied successfully against {Conn}",
+                System.Text.RegularExpressions.Regex.Replace(conn, "Password=[^;]*", "Password=***"));
+        });
+
     Target ComputeVersion => _ => _
         .Description("Reads the Nerdbank.GitVersioning version (SemVer2) and prints it.")
         .Executes(() =>

--- a/docs/adr/0018-persistence-stack.md
+++ b/docs/adr/0018-persistence-stack.md
@@ -92,5 +92,71 @@ base `PlanDbContext` service type so repositories (`PlanRepository`,
 
 - The existing in-memory plan storage is NOT migrated to this layer yet —
   that's a separate task (likely the next phase of issue #12).
-- Add a CI check that `dotnet ef migrations has-pending-model-changes` is
-  clean for both contexts.
+- ~~Add a CI check that `dotnet ef migrations has-pending-model-changes` is
+  clean for both contexts.~~ Done in issue #81 — see _CI guards_ below.
+
+## CI guards (issue #81)
+
+Two CI jobs protect the dual-provider migration setup:
+
+1. **Migration drift** — `.github/workflows/ci.yml :: migration-drift` runs the
+   Nuke `CheckMigrations` target, which calls
+   `dotnet ef migrations has-pending-model-changes` for both
+   `SqlitePlanDbContext` and `PostgresPlanDbContext`. If the model changes
+   without the matching `migrations add` running for either provider, the job
+   fails. The Postgres design-time factory requires a connection-string env
+   var even though `has-pending-model-changes` never opens the connection — a
+   placeholder is good enough.
+2. **Postgres runtime smoke** — `.github/workflows/ci.yml :: postgres-smoke`
+   spins up `postgres:16` via the GitHub Actions `services` block and runs
+   `dotnet ef database update` against it. Proves the migration generated for
+   Postgres actually applies.
+
+`dotnet-ef` is pinned in `.config/dotnet-tools.json` so CI gets a reproducible
+version regardless of what's globally installed on the runner.
+
+### Running the guards locally
+
+PowerShell (Windows), bash equivalents are obvious:
+
+```powershell
+# 1) Drift guard — both providers. No external services needed; the Postgres
+#    factory only wants a connection string, it never opens the connection.
+$env:ERP_PERSISTENCE_CONNECTION = 'Host=localhost;Database=plans;Username=postgres;Password=placeholder'
+./build.ps1 CheckMigrations
+
+# 2) Postgres runtime smoke — needs a live Postgres. Easiest: Docker.
+docker run --rm -d --name pg-smoke `
+    -e POSTGRES_PASSWORD=postgres `
+    -e POSTGRES_DB=plans `
+    -p 5432:5432 postgres:16
+
+$env:ERP_PERSISTENCE_CONNECTION = 'Host=localhost;Database=plans;Username=postgres;Password=postgres'
+./build.ps1 MigrationsPostgresSmoke
+
+docker stop pg-smoke
+```
+
+The underlying raw `dotnet ef` invocations (if you want to run them directly):
+
+```powershell
+# Drift, SQLite
+dotnet ef migrations has-pending-model-changes `
+    --project src/ERP/Infrastructure/Persistence `
+    --startup-project src/ApiService `
+    --context SqlitePlanDbContext
+
+# Drift, Postgres
+$env:ERP_PERSISTENCE_CONNECTION = 'Host=localhost;Database=plans;Username=postgres;Password=placeholder'
+dotnet ef migrations has-pending-model-changes `
+    --project src/ERP/Infrastructure/Persistence `
+    --startup-project src/ApiService `
+    --context PostgresPlanDbContext
+
+# Apply Postgres schema to a live DB
+$env:ERP_PERSISTENCE_CONNECTION = 'Host=localhost;Database=plans;Username=postgres;Password=postgres'
+dotnet ef database update `
+    --project src/ERP/Infrastructure/Persistence `
+    --startup-project src/ApiService `
+    --context PostgresPlanDbContext
+```


### PR DESCRIPTION
## Summary
- Add Nuke `CheckMigrations` target running `dotnet ef migrations has-pending-model-changes` for both `SqlitePlanDbContext` and `PostgresPlanDbContext`; non-zero exit fails CI when a snapshot drifts.
- Add Nuke `MigrationsPostgresSmoke` target running `dotnet ef database update` against a live Postgres — proves the generated migration applies.
- Wire two new GitHub Actions jobs (`migration-drift`, `postgres-smoke`) into `.github/workflows/ci.yml`; `postgres-smoke` uses the `services` block with `postgres:16`.
- Pin `dotnet-ef` in `.config/dotnet-tools.json` for reproducible CI.
- Document local-dev instructions in `docs/adr/0018-persistence-stack.md`.

Closes the two follow-ups flagged in ADR-0018 from #71.

## Test plan
- [x] `./build.sh CheckMigrations` passes on a clean tree
- [x] `./build.sh CheckMigrations` fails when a model change is introduced without `migrations add` (verified locally by temporarily changing `HasMaxLength(200)` -> 250 on `SavedPlan.Name`)
- [x] `./build.sh Format` still passes with new Build.cs code
- [ ] `migration-drift` CI job passes on this PR
- [ ] `postgres-smoke` CI job passes on this PR (applies migrations against `postgres:16` services container)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)