### PR TITLE
First-load setup wizard + filesystem picker

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -118,6 +118,172 @@ app.MapGet("/factory/saves", () =>
         .Select(f => new DetectedSaveView(f.FullName, f.Name, f.LastWriteTimeUtc, f.Length))
         .ToList());
 
+// Backing endpoint for the in-app filesystem picker (issue #84). Lists the
+// directory at `path` so the Blazor `PathPickerDialog` can render breadcrumbs +
+// folder/file rows. Read-only enumeration of an inherently-local dev tool —
+// no auth gate, but every IO call is wrapped so a denied / missing path
+// becomes a structured error instead of a 500.
+//
+// `purpose` is an optional hint ("catalogue" | "saves") used to compute a
+// smart starting directory when the caller hasn't given an explicit `path` —
+// the picker can land the user inside Satisfactory's Docs/SaveGames folder
+// instead of making them click through ~/Library/... by hand.
+app.MapGet("/fs/browse", (string? path, string? filter, string? purpose) =>
+{
+    var startPath = ResolveStartPath(path, purpose);
+
+    DirectoryInfo dir;
+    try
+    {
+        dir = new DirectoryInfo(startPath);
+        if (!dir.Exists)
+        {
+            // Silently fall back so a stale user-stored path doesn't dead-end the picker.
+            dir = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+        }
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem(title: "Invalid path", detail: ex.Message, statusCode: 400);
+    }
+
+    var allowed = ParseFilter(filter);
+    var dirs = new List<FsEntryView>();
+    var files = new List<FsEntryView>();
+
+    IEnumerable<DirectoryInfo> subDirs;
+    IEnumerable<FileInfo> entries;
+    try
+    {
+        subDirs = dir.EnumerateDirectories();
+        entries = dir.EnumerateFiles();
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+        return Results.Problem(title: "Access denied", detail: ex.Message, statusCode: 403);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem(title: "Failed to enumerate", detail: ex.Message, statusCode: 422);
+    }
+
+    foreach (var sub in subDirs.OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase))
+    {
+        // Skip hidden entries on Unix-likes — Library, .git, etc. clutter the picker.
+        if (sub.Name.StartsWith('.')) continue;
+        try
+        {
+            dirs.Add(new FsEntryView(sub.Name, sub.FullName, true, sub.LastWriteTimeUtc, null));
+        }
+        catch
+        {
+            // Symlink target missing, permission etc. — skip silently.
+        }
+    }
+
+    foreach (var f in entries.OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase))
+    {
+        if (f.Name.StartsWith('.')) continue;
+        if (allowed.Count > 0 && !allowed.Contains(f.Extension.ToLowerInvariant())) continue;
+        files.Add(new FsEntryView(f.Name, f.FullName, false, f.LastWriteTimeUtc, f.Length));
+    }
+
+    return Results.Ok(new FsBrowseView(dir.FullName, dir.Parent?.FullName, dirs, files));
+
+    static string ResolveStartPath(string? path, string? purpose)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            var expanded = ExpandHome(path);
+            // If the caller hands us a file (e.g. a previously-picked Docs.json
+            // or .sav), land in its directory so the picker shows siblings.
+            if (File.Exists(expanded))
+                return Path.GetDirectoryName(expanded) ?? home;
+            return expanded;
+        }
+
+        foreach (var candidate in CandidatesFor(purpose, home))
+        {
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return home;
+    }
+
+    // Probe order matters: Satisfactory Docs/SaveGames first so the user lands
+    // exactly where they need to pick, with the user's profile dir as the
+    // universal last-resort. The macOS bottle name varies (users can name
+    // bottles anything), so we enumerate `~/Library/Application Support/
+    // CrossOver/Bottles/*` rather than hard-coding "Steam".
+    static IEnumerable<string> CandidatesFor(string? purpose, string home)
+    {
+        if (string.IsNullOrWhiteSpace(purpose)) yield break;
+
+        // For each base install root we emit tiered candidates: the exact target
+        // first (Docs/), then a less-specific fallback (the install root) so a
+        // SF 1.0+ user — whose catalogue lives inside .pak, not in CommunityResources —
+        // still lands at the install instead of `~/`.
+        if (OperatingSystem.IsMacOS())
+        {
+            var bottlesRoot = Path.Combine(home, "Library/Application Support/CrossOver/Bottles");
+            if (Directory.Exists(bottlesRoot))
+            {
+                foreach (var bottle in Directory.EnumerateDirectories(bottlesRoot))
+                {
+                    var install = Path.Combine(bottle, "drive_c/Program Files (x86)/Steam/steamapps/common/Satisfactory");
+                    if (purpose == "catalogue")
+                    {
+                        yield return Path.Combine(install, "CommunityResources/Docs");
+                        yield return Path.Combine(install, "CommunityResources");
+                        yield return install;
+                    }
+                    else if (purpose == "saves")
+                    {
+                        yield return Path.Combine(bottle, "drive_c/users/crossover/AppData/Local/FactoryGame/Saved/SaveGames");
+                    }
+                }
+            }
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            if (purpose == "catalogue")
+            {
+                yield return @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
+                yield return @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources";
+                yield return @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory";
+                yield return @"C:\Program Files\Epic Games\SatisfactoryEarlyAccess\CommunityResources\Docs";
+                yield return @"C:\Program Files\Epic Games\SatisfactoryEarlyAccess";
+            }
+            else if (purpose == "saves")
+            {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                if (!string.IsNullOrEmpty(localAppData))
+                    yield return Path.Combine(localAppData, "FactoryGame", "Saved", "SaveGames");
+            }
+        }
+    }
+
+    static string ExpandHome(string p)
+    {
+        if (p.StartsWith("~/", StringComparison.Ordinal) || p == "~")
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return p == "~" ? home : Path.Combine(home, p[2..]);
+        }
+        return p;
+    }
+
+    static HashSet<string> ParseFilter(string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter)) return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return filter.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(e => e.StartsWith('.') ? e : "." + e)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+});
+
 app.MapPost("/factory/ingest", async (
     IngestSaveRequest request, IMessageBus bus, IFactoryStateProvider provider,
     ICatalogProvider catalog, ILoggerFactory loggerFactory) =>
@@ -247,6 +413,16 @@ public sealed record IngestSaveRequest(string SavePath);
 public sealed record NodeOverrideRequest(string Reference, string Resource, string Purity);
 
 public sealed record DetectedSaveView(string Path, string Name, DateTime LastWriteTimeUtc, long SizeBytes);
+
+/// <summary>One row in the in-app filesystem picker (issue #84).</summary>
+public sealed record FsEntryView(string Name, string FullPath, bool IsDirectory, DateTime LastWriteTimeUtc, long? SizeBytes);
+
+/// <summary>Response from GET /fs/browse — what the picker dialog renders for a directory.</summary>
+public sealed record FsBrowseView(
+    string CurrentPath,
+    string? ParentPath,
+    IReadOnlyList<FsEntryView> Directories,
+    IReadOnlyList<FsEntryView> Files);
 
 public sealed record SaveMetadataView(
     string SessionName,

--- a/src/Web/Components/Layout/MainLayout.razor
+++ b/src/Web/Components/Layout/MainLayout.razor
@@ -1,5 +1,8 @@
 @inherits LayoutComponentBase
 @inject IJSRuntime JS
+@inject NavigationManager Nav
+@inject PlannerApiClient Api
+@inject SetupState SetupState
 
 <MudThemeProvider Theme="FicsitTheme.Instance" IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
@@ -65,6 +68,32 @@
             _isDarkMode = darkInitial;
             StateHasChanged();
         }
+
+        await MaybeRedirectToSetupAsync();
+    }
+
+    // Gate first-load on the setup wizard. Runs from every page that uses
+    // MainLayout (i.e. everywhere except /setup itself, which opts into
+    // SetupLayout). Once the user dismisses the wizard or loads a catalogue,
+    // they stop hitting this redirect.
+    private async Task MaybeRedirectToSetupAsync()
+    {
+        if (await SetupState.IsDismissedAsync()) return;
+
+        CatalogueStatusView? status;
+        try
+        {
+            status = await Api.GetCatalogueStatusAsync();
+        }
+        catch
+        {
+            // ApiService unreachable on first paint — don't redirect, the user
+            // can refresh once the API is up. The wizard is a guide, not a hard gate.
+            return;
+        }
+        if (status is { IsLoaded: true }) return;
+
+        Nav.NavigateTo("/setup");
     }
 
     private async Task ToggleTheme()

--- a/src/Web/Components/Layout/SetupLayout.razor
+++ b/src/Web/Components/Layout/SetupLayout.razor
@@ -1,0 +1,59 @@
+@inherits LayoutComponentBase
+@inject IJSRuntime JS
+
+@* Minimal layout for the first-load wizard — no nav drawer so the user isn't
+   tempted to bail mid-setup. Mirrors MainLayout's theme/appbar wiring so the
+   FICSIT styling stays consistent. *@
+
+<MudThemeProvider Theme="FicsitTheme.Instance" IsDarkMode="_isDarkMode" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout Class="fx-layout">
+    <MudAppBar Elevation="0" Dense="true" Color="Color.Transparent" Class="fx-appbar">
+        <span class="status-strip" aria-hidden="true">FICSIT · INITIAL CONFIG</span>
+        <MudSpacer />
+        <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+                       OnClick="ToggleTheme"
+                       Color="Color.Inherit"
+                       title="Toggle light / dark mode"
+                       Class="fx-theme-toggle" />
+    </MudAppBar>
+
+    <MudMainContent Class="fx-main">
+        <div class="hazard-tape thin" aria-hidden="true"></div>
+        <article class="content px-4">
+            @Body
+        </article>
+    </MudMainContent>
+</MudLayout>
+
+<div id="blazor-error-ui">
+    An unhandled error has occurred.
+    <a href="" class="reload">Reload</a>
+    <a class="dismiss">🗙</a>
+</div>
+
+@code {
+    private bool _isDarkMode = true;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        var initial = await JS.InvokeAsync<string>("erpReadInitialTheme");
+        var darkInitial = !string.Equals(initial, "light", StringComparison.Ordinal);
+        if (darkInitial != _isDarkMode)
+        {
+            _isDarkMode = darkInitial;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ToggleTheme()
+    {
+        _isDarkMode = !_isDarkMode;
+        await JS.InvokeVoidAsync("erpSetTheme", _isDarkMode ? "dark" : "light");
+    }
+}

--- a/src/Web/Components/Pages/FactoryIngest.razor
+++ b/src/Web/Components/Pages/FactoryIngest.razor
@@ -1,6 +1,8 @@
 @page "/factory/ingest"
 @rendermode InteractiveServer
 @inject PlannerApiClient Api
+@inject IDialogService DialogService
+@using Web.Components.Shared
 
 <PageTitle>Factory state</PageTitle>
 
@@ -119,6 +121,11 @@ else
                   Placeholder="C:\Users\<you>\AppData\Local\FactoryGame\Saved\SaveGames\<steamId>\Beta Game_autosave_0.sav"
                   Variant="Variant.Outlined"
                   Margin="Margin.Dense"
+                  ReadOnly="true"
+                  Adornment="Adornment.End"
+                  AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+                  AdornmentAriaLabel="Browse for save file"
+                  OnAdornmentClick="BrowseSavePath"
                   Class="mb-1" />
     <MudText Typo="Typo.caption" Class="d-block mb-2">
         Either point at a specific <code>.sav</code> file or a directory (we'll pick the most-recently-written
@@ -188,6 +195,24 @@ else
         if (!string.IsNullOrWhiteSpace(value))
         {
             pathInput = value;
+        }
+    }
+
+    private async Task BrowseSavePath()
+    {
+        var parameters = new DialogParameters<PathPickerDialog>
+        {
+            { x => x.InitialPath, pathInput },
+            { x => x.Mode, PathPickerDialog.PathPickerMode.Either },
+            { x => x.FileFilter, "sav" },
+            { x => x.Purpose, "saves" },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<PathPickerDialog>("Choose .sav file or SaveGames folder", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: string picked })
+        {
+            pathInput = picked;
         }
     }
 

--- a/src/Web/Components/Pages/Settings.razor
+++ b/src/Web/Components/Pages/Settings.razor
@@ -2,6 +2,10 @@
 @rendermode InteractiveServer
 @inject PlannerApiClient Api
 @inject IJSRuntime JS
+@inject NavigationManager Nav
+@inject SetupState SetupState
+@inject IDialogService DialogService
+@using Web.Components.Shared
 
 <PageTitle>Settings</PageTitle>
 
@@ -53,6 +57,11 @@ else
                   Variant="Variant.Outlined"
                   Margin="Margin.Dense"
                   HelperTextOnFocus="false"
+                  ReadOnly="true"
+                  Adornment="Adornment.End"
+                  AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+                  AdornmentAriaLabel="Browse for Docs folder"
+                  OnAdornmentClick="BrowseCataloguePath"
                   Class="mb-1" />
     <MudText Typo="Typo.caption" Class="d-block mb-2">
         Either point at the <code>Docs</code> folder (we'll pick <code>en-US.json</code> automatically) or pass a specific
@@ -68,6 +77,17 @@ else
     {
         <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
     }
+</div>
+
+<h2 class="mt-5">Setup wizard</h2>
+<div class="mt-3">
+    <MudText Typo="Typo.body2" Class="mb-2">
+        Re-run the first-load wizard. Useful after wiping config or pointing at a new
+        Satisfactory install.
+    </MudText>
+    <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="RerunSetup">
+        Re-run setup
+    </MudButton>
 </div>
 
 <h2 class="mt-5">Factory map</h2>
@@ -147,6 +167,30 @@ else
         {
             // localStorage unavailable — keep default.
         }
+    }
+
+    private async Task BrowseCataloguePath()
+    {
+        var parameters = new DialogParameters<PathPickerDialog>
+        {
+            { x => x.InitialPath, pathInput },
+            { x => x.Mode, PathPickerDialog.PathPickerMode.Either },
+            { x => x.FileFilter, "json" },
+            { x => x.Purpose, "catalogue" },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<PathPickerDialog>("Choose Docs folder or locale file", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: string picked })
+        {
+            pathInput = picked;
+        }
+    }
+
+    private async Task RerunSetup()
+    {
+        await SetupState.SetDismissedAsync(false);
+        Nav.NavigateTo("/setup");
     }
 
     private async Task OnMapBackdropChanged(string value)

--- a/src/Web/Components/Pages/Setup.razor
+++ b/src/Web/Components/Pages/Setup.razor
@@ -1,0 +1,179 @@
+@page "/setup"
+@layout Layout.SetupLayout
+@rendermode InteractiveServer
+@inject NavigationManager Nav
+@inject SetupState SetupState
+@using Web.Components.Setup
+
+<PageTitle>Setup</PageTitle>
+
+@*
+    First-load wizard. The host renders a simple list of named steps so adding /
+    removing one is just an edit to the `steps` array — the body of this file
+    doesn't need to change. Each step component is self-contained so the same
+    component can render later from Settings (re-run setup) without rework.
+*@
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="setup-wizard">
+    <h1>Setup</h1>
+    <MudText Typo="Typo.body1" Class="mb-2">
+        A short first-run walk-through. Only the catalogue step is required —
+        skip the rest if you just want to get going.
+    </MudText>
+
+    <ol class="setup-steps">
+        @for (var i = 0; i < steps.Count; i++)
+        {
+            var idx = i;
+            var step = steps[idx];
+            var state = StateFor(idx);
+            <li class="setup-step @StateClass(state)">
+                <button type="button"
+                        class="setup-step-head"
+                        @onclick="@(() => GoTo(idx))"
+                        aria-current="@(idx == current ? "step" : null)">
+                    <span class="setup-step-marker">@(idx + 1)</span>
+                    <span class="setup-step-title">@step.Title</span>
+                    <span class="setup-step-badge">@BadgeFor(step, state)</span>
+                </button>
+                @if (idx == current)
+                {
+                    <div class="setup-step-body">
+                        @step.Body
+                        <div class="setup-step-nav">
+                            <MudButton OnClick="Back" Disabled="@(idx == 0)" Variant="Variant.Text">Back</MudButton>
+                            @if (!IsLastStep)
+                            {
+                                <MudButton OnClick="Next" Variant="Variant.Filled" Color="Color.Primary"
+                                           Disabled="@(!CanLeaveCurrent)">
+                                    @(step.IsRequired ? "Next" : "Next / skip")
+                                </MudButton>
+                            }
+                            else
+                            {
+                                <MudButton OnClick="FinishAsync" Variant="Variant.Filled" Color="Color.Primary"
+                                           Disabled="@(!CanFinish)">
+                                    Finish
+                                </MudButton>
+                            }
+                        </div>
+                    </div>
+                }
+            </li>
+        }
+    </ol>
+
+    <div class="setup-skip">
+        <MudButton OnClick="SkipAsync" Variant="Variant.Text">
+            Skip setup — I'll configure things later
+        </MudButton>
+    </div>
+</MudContainer>
+
+@code {
+    private sealed record WizardStep(string Title, bool IsRequired, RenderFragment Body);
+
+    private enum StepState { Upcoming, Current, Complete }
+
+    private List<WizardStep> steps = new();
+    private int current;
+    private bool catalogueComplete;
+
+    protected override void OnInitialized()
+    {
+        steps = new List<WizardStep>
+        {
+            new("Catalogue (required)", IsRequired: true,
+                Body: @<CataloguePathStep CompletedChanged="OnCatalogueCompletedChanged" />),
+            new("Map backdrop", IsRequired: false,
+                Body: @<MapBackdropStep />),
+            new("First save", IsRequired: false,
+                Body: @<SaveIngestStep />),
+            new("Plan storage", IsRequired: false,
+                Body: @<PersistenceProviderStep />),
+        };
+    }
+
+    private bool IsLastStep => current == steps.Count - 1;
+    private bool CanLeaveCurrent => !steps[current].IsRequired || catalogueComplete;
+    private bool CanFinish => catalogueComplete;
+
+    private StepState StateFor(int idx) =>
+        idx < current ? StepState.Complete
+        : idx == current ? StepState.Current
+        : StepState.Upcoming;
+
+    private static string StateClass(StepState s) => s switch
+    {
+        StepState.Complete => "is-complete",
+        StepState.Current => "is-current",
+        _ => "is-upcoming",
+    };
+
+    private static string BadgeFor(WizardStep step, StepState state) => state switch
+    {
+        StepState.Complete => "✓",
+        StepState.Current => step.IsRequired ? "required" : "optional",
+        _ => step.IsRequired ? "required" : "optional",
+    };
+
+    private void GoTo(int idx)
+    {
+        // Backwards-only jumps are always free; forward jumps respect the
+        // required-step gate so a user can't skip past the catalogue.
+        if (idx < current || CanLeaveCurrent)
+        {
+            current = idx;
+        }
+    }
+
+    private void Next()
+    {
+        if (!CanLeaveCurrent) return;
+        if (current < steps.Count - 1)
+        {
+            current++;
+        }
+    }
+
+    private void Back()
+    {
+        if (current > 0) current--;
+    }
+
+    private void OnCatalogueCompletedChanged(bool completed)
+    {
+        catalogueComplete = completed;
+        StateHasChanged();
+    }
+
+    private async Task FinishAsync()
+    {
+        if (!CanFinish) return;
+        await SetupState.SetDismissedAsync(true);
+        Nav.NavigateTo("/");
+    }
+
+    private async Task SkipAsync()
+    {
+        await SetupState.SetDismissedAsync(true);
+        Nav.NavigateTo("/");
+    }
+}
+
+<style>
+    .setup-wizard { padding-top: 1rem; padding-bottom: 2rem; }
+    .setup-steps { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .setup-step { border-left: 2px solid var(--mud-palette-divider); padding: 0 0 1.25rem 1rem; margin: 0; position: relative; }
+    .setup-step.is-current { border-left-color: var(--mud-palette-primary); }
+    .setup-step.is-complete { border-left-color: var(--mud-palette-success); }
+    .setup-step-head { display: flex; align-items: center; gap: 0.75rem; background: none; border: 0; padding: 0.25rem 0; color: inherit; cursor: pointer; font: inherit; width: 100%; text-align: left; }
+    .setup-step-marker { display: inline-flex; align-items: center; justify-content: center; width: 1.75rem; height: 1.75rem; border-radius: 50%; background: var(--mud-palette-action-default-hover); font-weight: 600; font-size: 0.9rem; flex-shrink: 0; }
+    .setup-step.is-current .setup-step-marker { background: var(--mud-palette-primary); color: var(--mud-palette-primary-text); }
+    .setup-step.is-complete .setup-step-marker { background: var(--mud-palette-success); color: var(--mud-palette-success-text); }
+    .setup-step-title { font-weight: 600; flex-grow: 1; }
+    .setup-step-badge { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.7; }
+    .setup-step-body { margin-top: 1rem; margin-left: 2.5rem; }
+    .setup-step-nav { margin-top: 1.25rem; display: flex; gap: 0.5rem; justify-content: flex-end; }
+    .setup-skip { margin-top: 2rem; display: flex; justify-content: flex-end; }
+</style>

--- a/src/Web/Components/Setup/CataloguePathStep.razor
+++ b/src/Web/Components/Setup/CataloguePathStep.razor
@@ -1,0 +1,152 @@
+@inject PlannerApiClient Api
+@inject IDialogService DialogService
+@using Web.Components.Shared
+
+@* Required step: points the planner at a Docs.json so the recipe graph can load.
+   Mirrors the catalogue section of Settings.razor so users see the same UX
+   whether they're onboarding or reconfiguring later. *@
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    The planner walks the recipe graph from Satisfactory's <code>Docs.json</code>.
+    Point us at the file or its containing <code>Docs</code> directory.
+</MudText>
+
+@if (status is null)
+{
+    <MudText><em>Loading status...</em></MudText>
+}
+else
+{
+    <MudAlert Severity="@StatusSeverity" Variant="Variant.Outlined" Class="mb-3">
+        <MudText Typo="Typo.subtitle2"><strong>@StatusHeadline</strong></MudText>
+        @if (!string.IsNullOrEmpty(status.Source))
+        {
+            <MudText Typo="Typo.caption">Source: <code>@status.Source</code></MudText>
+        }
+        @if (status.IsLoaded)
+        {
+            <MudText Typo="Typo.caption">
+                @status.ItemCount items · @status.BuildingCount buildings · @status.RecipeCount recipes
+            </MudText>
+        }
+    </MudAlert>
+}
+
+<MudTextField @bind-Value="pathInput"
+              Label="Path to the Satisfactory Docs directory or a specific locale file"
+              Placeholder="@DocsPathPlaceholder"
+              Variant="Variant.Outlined"
+              Margin="Margin.Dense"
+              ReadOnly="true"
+              Adornment="Adornment.End"
+              AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+              AdornmentAriaLabel="Browse for Docs folder"
+              OnAdornmentClick="Browse"
+              Class="mb-2" />
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
+           Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isApplying)">
+    @(isApplying ? "Loading..." : "Load catalogue")
+</MudButton>
+@if (!string.IsNullOrEmpty(message))
+{
+    <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
+}
+
+@code {
+    [Parameter] public EventCallback<bool> CompletedChanged { get; set; }
+
+    private CatalogueStatusView? status;
+    private string? pathInput;
+    private string? message;
+    private bool messageIsError;
+    private bool isApplying;
+    private bool lastEmittedCompleted;
+
+    private Severity StatusSeverity => status is null
+        ? Severity.Info
+        : status.IsLoaded ? Severity.Success : Severity.Warning;
+
+    private string StatusHeadline => status is null
+        ? ""
+        : status.IsLoaded ? "Catalogue loaded."
+        : "No catalogue loaded yet.";
+
+    // Same OS-aware placeholder as Settings.razor — keeps onboarding friendly on
+    // mac (CrossOver bottle path) without forcing Windows defaults on everyone.
+    private static string DocsPathPlaceholder =>
+        OperatingSystem.IsMacOS()
+            ? "~/Library/Application Support/CrossOver/Bottles/Steam/drive_c/Program Files (x86)/Steam/steamapps/common/Satisfactory/CommunityResources/Docs"
+            : @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
+
+    protected override async Task OnInitializedAsync()
+    {
+        status = await Api.GetCatalogueStatusAsync();
+        if (status is { IsLoaded: true, Source: { } source } && source != "(empty)")
+        {
+            pathInput = source;
+        }
+        await EmitCompletedAsync(status?.IsLoaded ?? false);
+    }
+
+    private async Task Browse()
+    {
+        var parameters = new DialogParameters<PathPickerDialog>
+        {
+            { x => x.InitialPath, pathInput },
+            { x => x.Mode, PathPickerDialog.PathPickerMode.Either },
+            { x => x.FileFilter, "json" },
+            { x => x.Purpose, "catalogue" },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<PathPickerDialog>("Choose Docs folder or locale file", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: string picked })
+        {
+            pathInput = picked;
+        }
+    }
+
+    private async Task Apply()
+    {
+        if (string.IsNullOrWhiteSpace(pathInput)) return;
+
+        isApplying = true;
+        message = null;
+        try
+        {
+            var result = await Api.ConfigureCatalogueAsync(pathInput!);
+            if (result.Success && result.Status is not null)
+            {
+                status = result.Status;
+                message = $"Loaded {result.Status.ItemCount} items / {result.Status.RecipeCount} recipes.";
+                messageIsError = false;
+            }
+            else
+            {
+                message = result.Error ?? "Failed to load Docs.json.";
+                messageIsError = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            message = ex.Message;
+            messageIsError = true;
+        }
+        finally
+        {
+            isApplying = false;
+            await EmitCompletedAsync(status?.IsLoaded ?? false);
+        }
+    }
+
+    private async Task EmitCompletedAsync(bool completed)
+    {
+        if (completed == lastEmittedCompleted) return;
+        lastEmittedCompleted = completed;
+        if (CompletedChanged.HasDelegate)
+        {
+            await CompletedChanged.InvokeAsync(completed);
+        }
+    }
+}

--- a/src/Web/Components/Setup/MapBackdropStep.razor
+++ b/src/Web/Components/Setup/MapBackdropStep.razor
@@ -1,0 +1,68 @@
+@inject IJSRuntime JS
+
+@* Optional step: chooses the Factory map's background. Cosmetic, but a nice
+   thing to set during onboarding so the map page isn't a black canvas. *@
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    Optional. The Factory map can render on top of a Satisfactory-themed backdrop.
+    Pick one now or change later under Settings.
+</MudText>
+
+<MudSelect T="string" Value="backdrop" ValueChanged="OnBackdropChanged"
+           Label="Backdrop"
+           Variant="Variant.Outlined"
+           Margin="Margin.Dense"
+           Dense="true"
+           Class="mb-1"
+           Style="max-width: 360px;">
+    <MudSelectItem Value="@("terrain")">Terrain (wiki)</MudSelectItem>
+    <MudSelectItem Value="@("biome")">Biome (wiki)</MudSelectItem>
+    <MudSelectItem Value="@("water")">Water (wiki)</MudSelectItem>
+    <MudSelectItem Value="@("none")">None (dark canvas)</MudSelectItem>
+</MudSelect>
+<MudText Typo="Typo.caption" Class="d-block">
+    Backdrops are sourced from the
+    <a href="https://satisfactory.wiki.gg/" target="_blank" rel="noreferrer">Satisfactory Fandom wiki</a>
+    under fair-use terms for non-commercial fan tools (ADR-0015).
+    @if (!string.IsNullOrEmpty(message))
+    {
+        <MudText HtmlTag="span" Color="Color.Success" Class="ms-2">@message</MudText>
+    }
+</MudText>
+
+@code {
+    private string backdrop = "terrain";
+    private string? message;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        try
+        {
+            var stored = await JS.InvokeAsync<string?>("localStorage.getItem", "erp-map-backdrop");
+            if (!string.IsNullOrEmpty(stored))
+            {
+                backdrop = stored;
+                StateHasChanged();
+            }
+        }
+        catch
+        {
+            // localStorage unavailable — keep default.
+        }
+    }
+
+    private async Task OnBackdropChanged(string value)
+    {
+        backdrop = value;
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "erp-map-backdrop", backdrop);
+            message = "Saved.";
+        }
+        catch (Exception ex)
+        {
+            message = "Couldn't save: " + ex.Message;
+        }
+    }
+}

--- a/src/Web/Components/Setup/PersistenceProviderStep.razor
+++ b/src/Web/Components/Setup/PersistenceProviderStep.razor
@@ -1,0 +1,28 @@
+@* Stub step: surfaces the SQLite ↔ Postgres switch in the onboarding flow even
+   though the runtime toggle doesn't exist yet (issue #77, milestone #8).
+   Disabled until the persistence reconfiguration story is real. *@
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    The planner saves your plans to a local SQLite file by default — no setup
+    needed. A Postgres option exists in the codebase for multi-user / shared
+    deployments but it's not wired into the UI yet.
+</MudText>
+
+<MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-3">
+    <MudText Typo="Typo.subtitle2"><strong>Coming soon</strong></MudText>
+    <MudText Typo="Typo.caption">
+        Switching providers from the UI tracks against
+        <a href="https://github.com/ChrisonSimtian/ERP.Satisfactory/issues/77"
+           target="_blank" rel="noreferrer">issue #77</a>.
+        For now plans go to a local SQLite file (<code>plans.db</code>) next to the API service.
+    </MudText>
+</MudAlert>
+
+<MudRadioGroup T="string" Value="@selected" ValueChanged="@(v => selected = v)" Disabled="true">
+    <MudRadio T="string" Value="@("sqlite")">SQLite (local file — default)</MudRadio>
+    <MudRadio T="string" Value="@("postgres")">Postgres (shared, not yet wired up)</MudRadio>
+</MudRadioGroup>
+
+@code {
+    private string selected = "sqlite";
+}

--- a/src/Web/Components/Setup/SaveIngestStep.razor
+++ b/src/Web/Components/Setup/SaveIngestStep.razor
@@ -1,0 +1,149 @@
+@inject PlannerApiClient Api
+@inject IDialogService DialogService
+@using Web.Components.Shared
+
+@* Optional step: parse a .sav file so the user lands on a populated Factory
+   map / state page after onboarding. Mirrors FactoryIngest.razor's UX. *@
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    Optional. If you point us at one of your Satisfactory save files we'll
+    parse it now so the Factory map and state pages are populated when you land.
+</MudText>
+
+@if (detectedSaves is { Length: > 0 })
+{
+    <MudSelect T="string" Value="selectedSavePath" ValueChanged="OnDetectedSaveSelected"
+               Label="Detected save files"
+               Variant="Variant.Outlined"
+               Margin="Margin.Dense"
+               Dense="true"
+               Class="mb-1">
+        <MudSelectItem Value="@("")">— pick a save —</MudSelectItem>
+        @foreach (var s in detectedSaves)
+        {
+            <MudSelectItem Value="@s.Path">
+                @s.Name · @s.LastWriteTimeUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm") · @FormatSize(s.SizeBytes)
+            </MudSelectItem>
+        }
+    </MudSelect>
+    <MudText Typo="Typo.caption" Class="d-block mb-3">
+        Found @detectedSaves.Length save(s) under the default SaveGames folder.
+        Selecting one fills the path field below.
+    </MudText>
+}
+
+<MudTextField @bind-Value="pathInput"
+              Label="Path to a .sav file or a SaveGames directory"
+              Placeholder="@SavePathPlaceholder"
+              Variant="Variant.Outlined"
+              Margin="Margin.Dense"
+              ReadOnly="true"
+              Adornment="Adornment.End"
+              AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+              AdornmentAriaLabel="Browse for save file"
+              OnAdornmentClick="Browse"
+              Class="mb-2" />
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Ingest"
+           Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isIngesting)">
+    @(isIngesting ? "Ingesting..." : "Ingest save")
+</MudButton>
+@if (!string.IsNullOrEmpty(message))
+{
+    <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
+}
+
+@code {
+    private DetectedSaveViewModel[]? detectedSaves;
+    private string? pathInput;
+    private string? selectedSavePath;
+    private string? message;
+    private bool messageIsError;
+    private bool isIngesting;
+
+    private static string SavePathPlaceholder =>
+        OperatingSystem.IsMacOS()
+            ? "~/Library/Application Support/CrossOver/Bottles/Steam/drive_c/users/crossover/AppData/Local/FactoryGame/Saved/SaveGames/<steamId>/<session>.sav"
+            : @"C:\Users\<you>\AppData\Local\FactoryGame\Saved\SaveGames\<steamId>\<session>.sav";
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            detectedSaves = await Api.GetDetectedSavesAsync();
+        }
+        catch
+        {
+            // Catalogue may not be loaded yet on a fresh wizard run — the API
+            // can return errors here. Treat as "no saves detected" and let the
+            // user paste a path manually.
+            detectedSaves = [];
+        }
+    }
+
+    private void OnDetectedSaveSelected(string value)
+    {
+        selectedSavePath = value;
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            pathInput = value;
+        }
+    }
+
+    private async Task Browse()
+    {
+        var parameters = new DialogParameters<PathPickerDialog>
+        {
+            { x => x.InitialPath, pathInput },
+            { x => x.Mode, PathPickerDialog.PathPickerMode.Either },
+            { x => x.FileFilter, "sav" },
+            { x => x.Purpose, "saves" },
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<PathPickerDialog>("Choose .sav file or SaveGames folder", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: string picked })
+        {
+            pathInput = picked;
+        }
+    }
+
+    private async Task Ingest()
+    {
+        if (string.IsNullOrWhiteSpace(pathInput)) return;
+
+        isIngesting = true;
+        message = null;
+        try
+        {
+            var result = await Api.IngestSaveAsync(pathInput!);
+            if (result.Success && result.State is not null)
+            {
+                var totalBuildings = result.State.Buildings.Sum(b => b.Count);
+                var totalMiners = result.State.Miners.Sum(m => m.Count);
+                message = $"Loaded {totalMiners} miners, {totalBuildings} buildings.";
+                messageIsError = false;
+            }
+            else
+            {
+                message = result.Error ?? "Failed to parse save file.";
+                messageIsError = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            message = ex.Message;
+            messageIsError = true;
+        }
+        finally
+        {
+            isIngesting = false;
+        }
+    }
+
+    private static string FormatSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / 1024.0 / 1024.0:F1} MB";
+    }
+}

--- a/src/Web/Components/Shared/PathPickerDialog.razor
+++ b/src/Web/Components/Shared/PathPickerDialog.razor
@@ -1,0 +1,232 @@
+@inject PlannerApiClient Api
+
+@* Reusable filesystem picker (issue #84). Opened via MudDialogService from any
+   page that needs an absolute path on the host machine. The dialog returns
+   the picked path as a string (or null on cancel). *@
+
+<MudDialog>
+    <DialogContent>
+        <div class="path-picker">
+            <MudText Typo="Typo.caption" Class="d-block mb-1">@PromptForMode</MudText>
+
+            <div class="path-picker-bar">
+                <MudIconButton Icon="@Icons.Material.Filled.ArrowUpward"
+                               OnClick="GoUp"
+                               Disabled="@(view?.ParentPath is null || isLoading)"
+                               Size="Size.Small"
+                               title="Up one level" />
+                <MudIconButton Icon="@Icons.Material.Filled.Home"
+                               OnClick="GoHome"
+                               Disabled="@isLoading"
+                               Size="Size.Small"
+                               title="Home directory" />
+                <code class="path-picker-current">@(view?.CurrentPath ?? "...")</code>
+            </div>
+
+            @if (errorMessage is not null)
+            {
+                <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Dense="true" Class="my-2">
+                    @errorMessage
+                </MudAlert>
+            }
+
+            <div class="path-picker-list" tabindex="0">
+                @if (view is null && errorMessage is null)
+                {
+                    <MudText Typo="Typo.caption" Class="pa-2"><em>Loading...</em></MudText>
+                }
+                else if (view is not null)
+                {
+                    @if (view.Directories.Count == 0 && view.Files.Count == 0)
+                    {
+                        <MudText Typo="Typo.caption" Class="pa-2"><em>Empty directory.</em></MudText>
+                    }
+                    @foreach (var d in view.Directories)
+                    {
+                        <button type="button"
+                                class="path-picker-row @(IsSelected(d) ? "is-selected" : null)"
+                                @onclick="() => OnEntryClick(d)"
+                                @ondblclick="() => Enter(d)">
+                            <MudIcon Icon="@Icons.Material.Filled.Folder" Size="Size.Small" Class="me-2" />
+                            <span class="path-picker-name">@d.Name</span>
+                            <span class="path-picker-meta">@d.LastWriteTimeUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</span>
+                        </button>
+                    }
+                    @foreach (var f in view.Files)
+                    {
+                        <button type="button"
+                                class="path-picker-row @(IsSelected(f) ? "is-selected" : null) @(Mode == PathPickerMode.FolderOnly ? "is-disabled" : null)"
+                                disabled="@(Mode == PathPickerMode.FolderOnly)"
+                                @onclick="() => OnEntryClick(f)"
+                                @ondblclick="() => PickFromDouble(f)">
+                            <MudIcon Icon="@Icons.Material.Filled.InsertDriveFile" Size="Size.Small" Class="me-2" />
+                            <span class="path-picker-name">@f.Name</span>
+                            <span class="path-picker-meta">
+                                @(f.SizeBytes.HasValue ? FormatSize(f.SizeBytes.Value) : "")
+                                · @f.LastWriteTimeUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm")
+                            </span>
+                        </button>
+                    }
+                }
+            </div>
+
+            @if (selected is not null)
+            {
+                <MudText Typo="Typo.caption" Class="d-block mt-2">
+                    Selected: <code>@selected.FullPath</code>
+                </MudText>
+            }
+            else if (Mode != PathPickerMode.FileOnly && view is not null)
+            {
+                <MudText Typo="Typo.caption" Class="d-block mt-2">
+                    No selection — Pick selects the current folder: <code>@view.CurrentPath</code>
+                </MudText>
+            }
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   OnClick="Pick" Disabled="@(!CanPick)">
+            Pick
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public enum PathPickerMode { FolderOnly, FileOnly, Either }
+
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter] public string? InitialPath { get; set; }
+    [Parameter] public PathPickerMode Mode { get; set; } = PathPickerMode.Either;
+    /// <summary>Comma-separated extensions like "json,sav" — empty means all files.</summary>
+    [Parameter] public string? FileFilter { get; set; }
+    /// <summary>Optional context hint ("catalogue" / "saves") that lets the server
+    /// pick a smart starting directory when <see cref="InitialPath"/> is null.</summary>
+    [Parameter] public string? Purpose { get; set; }
+
+    private FsBrowseView? view;
+    private FsEntryView? selected;
+    private string? errorMessage;
+    private bool isLoading;
+
+    private string PromptForMode => Mode switch
+    {
+        PathPickerMode.FolderOnly => "Pick a folder.",
+        PathPickerMode.FileOnly => "Pick a file.",
+        _ => "Pick a folder or a file.",
+    };
+
+    private bool CanPick => Mode switch
+    {
+        PathPickerMode.FolderOnly => view is not null,         // current folder selectable as default
+        PathPickerMode.FileOnly => selected is { IsDirectory: false },
+        _ => view is not null,
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync(InitialPath);
+    }
+
+    private bool IsSelected(FsEntryView e) =>
+        selected is not null && string.Equals(selected.FullPath, e.FullPath, StringComparison.Ordinal);
+
+    private void OnEntryClick(FsEntryView e)
+    {
+        selected = e;
+    }
+
+    private async Task Enter(FsEntryView d)
+    {
+        // Double-click on a folder navigates into it. Clear any prior selection
+        // so the user must explicitly pick again inside the new directory.
+        selected = null;
+        await LoadAsync(d.FullPath);
+    }
+
+    private async Task PickFromDouble(FsEntryView f)
+    {
+        if (Mode == PathPickerMode.FolderOnly) return;
+        selected = f;
+        Pick();
+        await Task.CompletedTask;
+    }
+
+    private async Task GoUp()
+    {
+        if (view?.ParentPath is null) return;
+        selected = null;
+        await LoadAsync(view.ParentPath);
+    }
+
+    private async Task GoHome()
+    {
+        selected = null;
+        await LoadAsync(null);
+    }
+
+    private async Task LoadAsync(string? path)
+    {
+        isLoading = true;
+        errorMessage = null;
+        try
+        {
+            // Only forward the purpose hint when no explicit path is in play —
+            // once the user starts navigating, they want to stay where they are.
+            var purpose = string.IsNullOrWhiteSpace(path) ? Purpose : null;
+            var result = await Api.BrowseFilesystemAsync(path, FileFilter, purpose);
+            if (result.Success && result.View is not null)
+            {
+                view = result.View;
+            }
+            else
+            {
+                errorMessage = result.Error ?? "Failed to list directory.";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void Pick()
+    {
+        // If the user clicked an entry, pick that. Otherwise (folder mode) pick
+        // the current directory itself — a common "I'm in the right folder,
+        // accept it" shortcut.
+        var path = selected?.FullPath
+                   ?? (Mode != PathPickerMode.FileOnly ? view?.CurrentPath : null);
+        if (path is null) return;
+        Dialog.Close(DialogResult.Ok(path));
+    }
+
+    private void Cancel() => Dialog.Cancel();
+
+    private static string FormatSize(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / 1024.0 / 1024.0:F1} MB";
+    }
+}
+
+<style>
+    .path-picker { min-width: 480px; max-width: 720px; }
+    .path-picker-bar { display: flex; align-items: center; gap: 0.25rem; margin-bottom: 0.5rem; }
+    .path-picker-current { flex-grow: 1; overflow-x: auto; white-space: nowrap; padding: 0.25rem 0.5rem; background: var(--mud-palette-action-default-hover); border-radius: 0.25rem; font-size: 0.85rem; }
+    .path-picker-list { border: 1px solid var(--mud-palette-divider); border-radius: 0.25rem; max-height: 360px; min-height: 200px; overflow-y: auto; background: var(--mud-palette-background); }
+    .path-picker-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0.75rem; width: 100%; background: none; border: 0; color: inherit; cursor: pointer; font: inherit; text-align: left; }
+    .path-picker-row:hover:not(.is-disabled) { background: var(--mud-palette-action-default-hover); }
+    .path-picker-row.is-selected { background: var(--mud-palette-primary); color: var(--mud-palette-primary-text); }
+    .path-picker-row.is-disabled { opacity: 0.5; cursor: not-allowed; }
+    .path-picker-name { flex-grow: 1; }
+    .path-picker-meta { font-size: 0.75rem; opacity: 0.7; white-space: nowrap; }
+    .path-picker-row.is-selected .path-picker-meta { opacity: 0.85; }
+</style>

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -88,6 +88,30 @@ public class PlannerApiClient(HttpClient httpClient)
         var error = await response.Content.ReadAsStringAsync(ct);
         return new NodeOverrideResult(false, error);
     }
+
+    /// <summary>
+    /// Backing call for the filesystem picker (issue #84). `path` is an
+    /// absolute filesystem path on the host machine; pass null to start at the
+    /// user's home directory. `filter` is a comma-separated extension list
+    /// (e.g. "json" or ".sav,.json") — empty means all files.
+    /// </summary>
+    public async Task<FsBrowseResult> BrowseFilesystemAsync(string? path, string? filter, string? purpose = null, CancellationToken ct = default)
+    {
+        var query = new List<string>();
+        if (!string.IsNullOrWhiteSpace(path)) query.Add($"path={Uri.EscapeDataString(path)}");
+        if (!string.IsNullOrWhiteSpace(filter)) query.Add($"filter={Uri.EscapeDataString(filter)}");
+        if (!string.IsNullOrWhiteSpace(purpose)) query.Add($"purpose={Uri.EscapeDataString(purpose)}");
+        var url = "/fs/browse" + (query.Count > 0 ? "?" + string.Join("&", query) : "");
+
+        var response = await httpClient.GetAsync(url, ct);
+        if (response.IsSuccessStatusCode)
+        {
+            var view = await response.Content.ReadFromJsonAsync<FsBrowseView>(ct);
+            return new FsBrowseResult(true, view, null);
+        }
+        var error = await response.Content.ReadAsStringAsync(ct);
+        return new FsBrowseResult(false, null, error);
+    }
 }
 
 public sealed record CatalogItem(string Id, string Name);
@@ -169,3 +193,13 @@ public sealed record FactoryIngestResult(bool Success, FactoryStateViewModel? St
 public sealed record DetectedSaveViewModel(string Path, string Name, DateTime LastWriteTimeUtc, long SizeBytes);
 
 public sealed record NodeOverrideResult(bool Success, string? Error);
+
+public sealed record FsEntryView(string Name, string FullPath, bool IsDirectory, DateTime LastWriteTimeUtc, long? SizeBytes);
+
+public sealed record FsBrowseView(
+    string CurrentPath,
+    string? ParentPath,
+    IReadOnlyList<FsEntryView> Directories,
+    IReadOnlyList<FsEntryView> Files);
+
+public sealed record FsBrowseResult(bool Success, FsBrowseView? View, string? Error);

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -24,6 +24,8 @@ builder.Services.AddHttpClient<Web.PlannerApiClient>(client =>
         client.BaseAddress = new("https+http://apiservice");
     });
 
+builder.Services.AddScoped<Web.SetupState>();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())

--- a/src/Web/SetupState.cs
+++ b/src/Web/SetupState.cs
@@ -1,0 +1,48 @@
+using Microsoft.JSInterop;
+
+namespace Web;
+
+/// <summary>
+/// Tracks whether the user has completed or dismissed the first-load setup
+/// wizard. Backed by <c>localStorage</c> so it survives a page reload but is
+/// per-browser (no server-side persistence yet — see issue #83 "out of scope").
+/// </summary>
+public sealed class SetupState(IJSRuntime js)
+{
+    private const string DismissedKey = "erp-setup-dismissed";
+
+    public async ValueTask<bool> IsDismissedAsync()
+    {
+        try
+        {
+            var raw = await js.InvokeAsync<string?>("localStorage.getItem", DismissedKey);
+            return string.Equals(raw, "true", StringComparison.Ordinal);
+        }
+        catch
+        {
+            // Server-side pre-render or no JS — assume not dismissed so a fresh
+            // user still gets the wizard on the first interactive render.
+            return false;
+        }
+    }
+
+    public async ValueTask SetDismissedAsync(bool value)
+    {
+        try
+        {
+            if (value)
+            {
+                await js.InvokeVoidAsync("localStorage.setItem", DismissedKey, "true");
+            }
+            else
+            {
+                await js.InvokeVoidAsync("localStorage.removeItem", DismissedKey);
+            }
+        }
+        catch
+        {
+            // No JS — silently no-op. The dismissed flag is best-effort UX, not a
+            // correctness constraint.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- First-load setup wizard at `/setup` with a reusable four-step flow (Catalogue / Map backdrop / First save / Plan storage). MainLayout redirects to it on a fresh install; Settings has a "Re-run setup" button to clear the dismissed flag.
- Filesystem picker dialog replacing the plain-text path inputs on the catalogue and save fields. Backed by a new `/fs/browse` API endpoint that lands the user *inside* their Satisfactory install / SaveGames folder when found, instead of in `~/`.

Closes #83. Closes #84.

## Test plan
- [ ] Fresh checkout (or clear `localStorage["erp-setup-dismissed"]`) lands on `/setup`.
- [ ] Catalogue step Browse adornment opens the picker, defaults to Satisfactory's install dir on macOS (CrossOver) when present.
- [ ] Picking a Docs/Docs.json path loads the catalogue and the Catalogue step shows "Catalogue loaded".
- [ ] Skip / Finish dismisses the wizard; subsequent navigation no longer redirects.
- [ ] Re-run setup on Settings clears the flag and bounces back to `/setup`.
- [ ] Save Browse adornment lands at the `SaveGames/<steamId>/` folder when present.
- [ ] Picker correctly handles passing the previously-picked path as InitialPath (lands in its directory if a file was picked last time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)