### PR TITLE
Bump SatisfactorySaveNet submodule to NUKE build setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,9 @@ dotnet run --project src/AppHost
 The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`).
 Worktrees do **not** auto-init submodules — run the command above whenever a fresh
 worktree or clone is created, or the solution will fail to build.
+
+The `SatisfactorySaveNet` submodule has its own NUKE build (`./build.sh` in
+that directory) that produces NuGet packages and publishes them to GitHub
+Packages on tag pushes — see its `.github/workflows/ci.yml`. ERP consumes the
+library via `ProjectReference` today; switching to `PackageReference` happens
+once the first tagged release lands.


### PR DESCRIPTION
## Summary
- Bumps `vendor/SatisfactorySaveNet` to `c6d9cff` — ChrisonSimtian/SatisfactorySaveNet#2, which adds a NUKE build + CI workflow that publishes NuGet packages to GitHub Packages on tag pushes.
- Notes the new build flow in `CLAUDE.md` so future onboarders know about `./build.sh` in the submodule.

No source changes here. ERP keeps consuming via `ProjectReference` until the first tagged release lands on the fork — at which point a follow-up PR will switch to `PackageReference` against the fork's GitHub Packages feed.

## Test plan
- [x] Local: `dotnet build ERP.Satisfactory.slnx` green after the submodule pointer bump.
- [ ] CI green on this PR.
- [ ] (Follow-up, not in this PR) Push a `v*` tag on the fork → confirm package appears under https://github.com/ChrisonSimtian/SatisfactorySaveNet/packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)