### PR TITLE
Wire Nerdbank.GitVersioning into ERP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs full history for version-height calc
 
       - name: Initialize vendored SatisfactorySaveNet submodule
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs full history for version-height calc
 
       - name: Initialize vendored SatisfactorySaveNet submodule
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
@@ -106,6 +110,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs full history for version-height calc
 
       - name: Initialize vendored SatisfactorySaveNet submodule
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
@@ -155,6 +161,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs full history for version-height calc
 
       - name: Initialize vendored SatisfactorySaveNet submodule
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    Wire Nerdbank.GitVersioning into every project under the repo so version.json
+    actually drives $(Version), $(AssemblyVersion), $(FileVersion), and
+    $(InformationalVersion). version.json existed before this file but had no
+    backing package, so it was inert. Excludes test projects — they're never
+    published and don't need version stamping.
+
+    PrivateAssets="all" keeps NB.GV from flowing as a transitive dependency to
+    any package consumers (we'd only be a consumer ourselves today, but the
+    plumbing applies if any project ever does ship a nupkg).
+  -->
+  <ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests')) and !$(MSBuildProjectName.EndsWith('UiTests'))">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- `version.json` has lived at the repo root for a while but with no backing `PackageReference` it never actually stamped anything.
- Adds a root `Directory.Build.props` that pulls `Nerdbank.GitVersioning` 3.7.115 (`PrivateAssets="all"`) into every project **except** tests / UI tests — they don't ship.
- `$(Version)` / `$(AssemblyVersion)` / `$(FileVersion)` / `$(InformationalVersion)` now flow from `version.json` + git height.

Matches the parallel change on the fork (ChrisonSimtian/SatisfactorySaveNet#4).

## Test plan
- [x] Local `dotnet build ERP.Satisfactory.slnx` clean.
- [x] `Web.dll` reports `AssemblyInformationalVersion = "0.1.50+<sha>"` (baseline `0.1` + git height 50).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)