### PR TITLE
Consume SatisfactorySaveNet via PackageReference from GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
   checks: write       # publish-unit-test-result-action needs this
   pull-requests: write
+  packages: read      # consume SatisfactorySaveNet from GitHub Packages (nuget.config)
+
+# Surface GITHUB_TOKEN to dotnet restore so nuget.config's %GITHUB_TOKEN%
+# placeholder resolves to the workflow's installation token. GitHub Packages
+# NuGet always requires auth — even for public packages — so this is needed
+# by every job that runs `dotnet restore` / `dotnet build`.
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ ERP-style production planner for the game *Satisfactory*. Primary objective:
 
 ```powershell
 git submodule update --init --recursive   # required after clone or `git worktree add`
+export GITHUB_TOKEN=$(gh auth token)      # nuget.config reads it for GitHub Packages
 dotnet build ERP.Satisfactory.slnx
 dotnet run --project src/AppHost
 ```
@@ -23,8 +24,13 @@ The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`)
 Worktrees do **not** auto-init submodules — run the command above whenever a fresh
 worktree or clone is created, or the solution will fail to build.
 
-The `SatisfactorySaveNet` submodule has its own NUKE build (`./build.sh` in
-that directory) that produces NuGet packages and publishes them to GitHub
-Packages on tag pushes — see its `.github/workflows/ci.yml`. ERP consumes the
-library via `ProjectReference` today; switching to `PackageReference` happens
-once the first tagged release lands.
+ERP consumes `SatisfactorySaveNet` via `PackageReference` from the fork's
+GitHub Packages feed — see `nuget.config`. GitHub Packages NuGet *always*
+requires auth (even for public packages), so set `GITHUB_TOKEN` before
+restoring. Your `gh` CLI token needs the `read:packages` scope: one-time
+`gh auth refresh -h github.com -s read:packages`.
+
+CI does the same thing via `secrets.GITHUB_TOKEN` (the workflow grants
+`packages: read`). The `SatisfactorySaveNet` submodule is still vendored
+for local iteration on the fork; its own NUKE build is at `./build.sh` in
+that directory and publishes on tag pushes.

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,21 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!--
+      SatisfactorySaveNet fork (ChrisonSimtian/SatisfactorySaveNet) publishes
+      to GitHub Packages on tag pushes. GitHub Packages NuGet always requires
+      authentication, even for public packages — `read:packages` scope is
+      enough.
+        CI:   ${{ secrets.GITHUB_TOKEN }} → exposed as GITHUB_TOKEN env (workflow grants packages: read)
+        Local: export GITHUB_TOKEN=$(gh auth token)    (one-time per shell, gh PAT must have read:packages)
+    -->
+    <add key="github-chrisonsimtian" value="https://nuget.pkg.github.com/ChrisonSimtian/index.json" protocolVersion="3" />
   </packageSources>
+
+  <packageSourceCredentials>
+    <github-chrisonsimtian>
+      <add key="Username" value="ChrisonSimtian" />
+      <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+    </github-chrisonsimtian>
+  </packageSourceCredentials>
 </configuration>

--- a/src/Satisfactory/Save/Satisfactory.Save.csproj
+++ b/src/Satisfactory/Save/Satisfactory.Save.csproj
@@ -2,8 +2,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\ERP\Domain\ERP.Domain.csproj" />
-    <ProjectReference Include="..\..\..\vendor\SatisfactorySaveNet\SatisfactorySaveNet\SatisfactorySaveNet.csproj" />
-    <ProjectReference Include="..\..\..\vendor\SatisfactorySaveNet\SatisfactorySaveNet.Abstracts\SatisfactorySaveNet.Abstracts.csproj" />
+    <!--
+      Consumed from the fork's GitHub Packages feed (see nuget.config). Bump
+      the version when the fork ships a new tagged release; the submodule under
+      vendor/SatisfactorySaveNet stays for local fork iteration but is no
+      longer on the build path.
+    -->
+    <PackageReference Include="SatisfactorySaveNet" Version="4.0.2" />
+    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.0.2" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Flips `src/Satisfactory/Save/Satisfactory.Save.csproj` from two `ProjectReference`s against the vendored fork to two `PackageReference`s pinned at **`4.0.2`** (the latest on the fork's GitHub Packages feed and the one with the v1.2 chain-actor gate fix).
- The vendored submodule stays — it's still useful for local iteration on the fork — it's just no longer on ERP's build graph.

## Auth
GitHub Packages NuGet requires auth even for public packages.
- `nuget.config` adds the fork's feed and templates `ClearTextPassword` from `%GITHUB_TOKEN%`.
- The workflow grants `packages: read` and surfaces `GITHUB_TOKEN` at the env level.
- `CLAUDE.md` documents the one-time `gh auth refresh -s read:packages` step for local devs.

## Outstanding (#103)
The fork's tag-driven publish doesn't currently produce new versions post-NB.GV — that's why this pins `4.0.2`, not `4.0.3`. The versioning-model fix is tracked separately at #103.

## Test plan
- [x] Local `GITHUB_TOKEN=$(gh auth token) dotnet build ERP.Satisfactory.slnx` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)