### PR TITLE
Bump SatisfactorySaveNet to 4.1.1 (closes #103)

### DIFF
--- a/src/Satisfactory/Save/Satisfactory.Save.csproj
+++ b/src/Satisfactory/Save/Satisfactory.Save.csproj
@@ -8,8 +8,8 @@
       vendor/SatisfactorySaveNet stays for local fork iteration but is no
       longer on the build path.
     -->
-    <PackageReference Include="SatisfactorySaveNet" Version="4.0.2" />
-    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.0.2" />
+    <PackageReference Include="SatisfactorySaveNet" Version="4.1.1" />
+    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.1.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
First version bump consuming the fork's new continuous-publish flow:
- ChrisonSimtian/SatisfactorySaveNet#5 → publish fires on every main push (not just tags).
- ChrisonSimtian/SatisfactorySaveNet#6 → `version.json` baseline → `4.1`, so NB.GV versions stop colliding with the pre-NB.GV tag publishes (`4.0.1`, `4.0.2`).

The first post-fix publish landed `SatisfactorySaveNet.4.1.1.nupkg` + `SatisfactorySaveNet.Abstracts.4.1.1.nupkg`. This PR points ERP at them.

Closes #103.

## Test plan
- [x] Local `GITHUB_TOKEN=$(gh auth token) dotnet restore ...` finds 4.1.1 on the GH Packages feed.
- [x] Full `dotnet build ERP.Satisfactory.slnx` green.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)