### PR TITLE
Skip + ignore vendor submodules now that they're off the build graph

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,18 @@
 [submodule "vendor/SatisfactorySaveNet"]
 	path = vendor/SatisfactorySaveNet
 	url = https://github.com/ChrisonSimtian/SatisfactorySaveNet.git
-	# ignore = all
-	# update = none
+	# ERP consumes the fork via NuGet (see nuget.config), not as a project
+	# reference. The submodule is kept on disk for local iteration on the
+	# fork but is off the build graph — so we tell git to skip its pointer
+	# entirely. `update = none` makes `submodule update` a no-op for this
+	# entry; `ignore = all` hides any commit-pointer drift from `git status`
+	# / `git diff` so a fresh fork checkout doesn't show as a parent change.
+	ignore = all
+	update = none
 [submodule "vendor/CUE4Parse"]
 	path = vendor/CUE4Parse
 	url = https://github.com/FabianFG/CUE4Parse
+	# CUE4Parse isn't on the build graph either — vendored only for
+	# inspection. Same skip/ignore treatment.
+	ignore = all
+	update = none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,23 +14,26 @@ ERP-style production planner for the game *Satisfactory*. Primary objective:
 ## Build & run
 
 ```powershell
-git submodule update --init --recursive   # required after clone or `git worktree add`
-export GITHUB_TOKEN=$(gh auth token)      # nuget.config reads it for GitHub Packages
+export GITHUB_TOKEN=$(gh auth token)   # nuget.config reads it for GitHub Packages
 dotnet build ERP.Satisfactory.slnx
 dotnet run --project src/AppHost
 ```
-
-The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`).
-Worktrees do **not** auto-init submodules — run the command above whenever a fresh
-worktree or clone is created, or the solution will fail to build.
 
 ERP consumes `SatisfactorySaveNet` via `PackageReference` from the fork's
 GitHub Packages feed — see `nuget.config`. GitHub Packages NuGet *always*
 requires auth (even for public packages), so set `GITHUB_TOKEN` before
 restoring. Your `gh` CLI token needs the `read:packages` scope: one-time
-`gh auth refresh -h github.com -s read:packages`.
+`gh auth refresh -h github.com -s read:packages`. CI does the same thing
+via `secrets.GITHUB_TOKEN` (the workflow grants `packages: read`).
 
-CI does the same thing via `secrets.GITHUB_TOKEN` (the workflow grants
-`packages: read`). The `SatisfactorySaveNet` submodule is still vendored
-for local iteration on the fork; its own NUKE build is at `./build.sh` in
-that directory and publishes on tag pushes.
+The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`),
+both marked `update = none` + `ignore = all` in `.gitmodules`. They are *not*
+required for the build — they're kept as optional drop-ins for iterating on
+the fork locally. To populate one explicitly:
+
+```bash
+git submodule update --init --checkout vendor/SatisfactorySaveNet
+```
+
+The fork's own NUKE build (`./build.sh` inside the submodule) publishes to
+GitHub Packages on every push to its `main`.

--- a/src/Satisfactory/Save/Satisfactory.Save.csproj
+++ b/src/Satisfactory/Save/Satisfactory.Save.csproj
@@ -8,8 +8,8 @@
       vendor/SatisfactorySaveNet stays for local fork iteration but is no
       longer on the build path.
     -->
-    <PackageReference Include="SatisfactorySaveNet" Version="4.0.2" />
-    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.0.2" />
+    <PackageReference Include="SatisfactorySaveNet" Version="4.1.1" />
+    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.1.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
Now that ERP consumes `SatisfactorySaveNet` via NuGet (PR #105) and `CUE4Parse` was never referenced, neither submodule is required for `dotnet build`. Add `update = none` + `ignore = all` to both `.gitmodules` entries so:
- Fresh clones / worktrees no longer auto-checkout them — `dotnet build` works out of the box.
- Pointer drift after fork merges no longer shows up in `git status` / `git diff`.

`CLAUDE.md` is updated to drop the now-unnecessary `git submodule update --init --recursive` step from the build flow, and to document the explicit `--checkout` invocation for devs who want to iterate on the fork locally.

## Test plan
- [x] `dotnet build ERP.Satisfactory.slnx` clean locally (submodule still populated from prior session, but build doesn't reach into it).
- [ ] CI green.
- [ ] (Manual) On a fresh worktree without the submodule populated, the build still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)