### PR TITLE
ci: restate packages:read on Release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write    # create tags + releases
+      packages: read     # per-job permissions replace workflow-level, so restate
 
     steps:
       - name: Checkout (full history for NB.GV)


### PR DESCRIPTION
Per-job permissions blocks replace workflow-level inheritance (don't merge), so Release lost packages:read when it set contents:write. Without it GITHUB_TOKEN can't auth to nuget.pkg.github.com — restore of SatisfactorySaveNet.Abstracts fails with 403 Forbidden in the Release job (other jobs pass via inherited workflow-level perms).

Adding packages:read to the Release job's own block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)