### PR TITLE
release: bump to 0.2 — plan persistence & sharing

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1",
+  "version": "0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
Bumps \`version.json\` from \`0.1\` → \`0.2\`. Nerdbank.GitVersioning will resolve this to **v0.2.0** on the next push to main, replacing the auto-tick path of \`v0.1.10+\`.

The minor bump signals the first significant feature past initial scaffolding: the entire **Plan Persistence & Sharing** milestone (#8) shipped today.

## What's in v0.2.0

**Persistence layer** ([ADR-0018](docs/adr/0018-persistence-stack.md))
- EF Core 10 foundation, provider-agnostic core (#71)
- Dual provider: SQLite default, Postgres opt-in via \`Persistence:Provider\`
- Two \`DbContext\` subclasses with separate migration sets to keep snapshots cleanly separated
- Plan CRUD migrated from in-memory to EF, plans now survive process restarts (#77 / PR #87)

**Sharing & portability**
- Browser auto-save: debounced LocalStorage drafts with snackbar restore + discard (#78 / PR #86)
- JSON export/import: round-trip plans through versioned \`.json\` files (#79 / PR #95)
- Share-link tokens: read-only public URL per saved plan, revocable (#80 / PR #96)

**CI hardening**
- Migration-drift guard runs \`dotnet ef migrations has-pending-model-changes\` for both providers (#81 / PR #82)
- Live Postgres migration smoke runs \`dotnet ef database update\` against a \`postgres:16\` services container (also #81)
- Release-job auth fix so SatisfactorySaveNet (now PackageReference from GHCR) restores cleanly (PR #108)

**Side-quests landed along the way**
- v1.0 + v1.2 \`.sav\` fixtures bundled for offline dev (PR #94)
- Long-tail roadmap doc (\`docs/roadmap.md\`) with v2 platform direction (PRs #93, #99)
- 5 future-feature issues filed (#88 LP solver, #89 flow graph, #90 fluids, #91 power, #92 node allocation)

## Test plan
- [x] Doc-only change to \`version.json\`
- [ ] CI green, Release job creates a \`v0.2.0\` GitHub release on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)