### PR TITLE
Skip actions/cache on self-hosted runners (use persistent disk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
 
       - name: Cache NuGet packages
+        # GH-hosted only — persistent self-hosted runners keep
+        # ~/.nuget/packages warm between runs, so the remote cache
+        # store roundtrip is pure overhead there.
+        if: runner.environment != 'self-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
@@ -88,6 +92,10 @@ jobs:
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
 
       - name: Cache NuGet packages
+        # GH-hosted only — persistent self-hosted runners keep
+        # ~/.nuget/packages warm between runs, so the remote cache
+        # store roundtrip is pure overhead there.
+        if: runner.environment != 'self-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
@@ -141,6 +149,10 @@ jobs:
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
 
       - name: Cache NuGet packages
+        # GH-hosted only — persistent self-hosted runners keep
+        # ~/.nuget/packages warm between runs, so the remote cache
+        # store roundtrip is pure overhead there.
+        if: runner.environment != 'self-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
@@ -198,6 +210,10 @@ jobs:
         run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
 
       - name: Cache NuGet packages
+        # GH-hosted only — persistent self-hosted runners keep
+        # ~/.nuget/packages warm between runs, so the remote cache
+        # store roundtrip is pure overhead there.
+        if: runner.environment != 'self-hosted'
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages


### PR DESCRIPTION
## Summary
Persistent self-hosted runners keep `~/.nuget/packages` warm between runs on local disk, so `actions/cache@v4`'s remote roundtrip is pure overhead. Gate each cache step with `if: runner.environment != 'self-hosted'`:

- GH-hosted (postgres-smoke): cache still runs as before.
- Self-hosted (lint, build-and-test, migration-drift): step skips, NuGet restore reads straight from the local cache.

Conditional rather than removal so the cache reactivates automatically if a job ever moves back to GH-hosted.

## Test plan
- [ ] CI on this PR: the three self-hosted jobs show `Cache NuGet packages` skipped (grey, not green).
- [ ] Restore times in those jobs come down by another 5–30s vs the previous baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)