### PR TITLE
refactor(planner): introduce IRecipePlanner port (#88, phase A)

### DIFF
--- a/src/ERP/Application/IRecipePlanner.cs
+++ b/src/ERP/Application/IRecipePlanner.cs
@@ -1,0 +1,16 @@
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+
+namespace ERP.Application;
+
+/// <summary>
+/// Port for planning production: take a set of <see cref="ProductionTarget"/>s
+/// plus <see cref="ResourceAvailability"/> caps and return a
+/// <see cref="ProductionPlan"/> that hits the targets. Multiple implementations
+/// exist (recursive expansion today; LP-backed optimisation per #88) and are
+/// selected via configuration.
+/// </summary>
+public interface IRecipePlanner
+{
+    ProductionPlan Plan(PlanProductionQuery query);
+}

--- a/src/ERP/Application/Queries/PlanProduction/PlanProductionQuery.cs
+++ b/src/ERP/Application/Queries/PlanProduction/PlanProductionQuery.cs
@@ -1,3 +1,4 @@
+using ERP.Application;
 using ERP.Domain;
 
 namespace ERP.Application.Queries.PlanProduction;
@@ -6,152 +7,14 @@ public sealed record PlanProductionQuery(
     IReadOnlyList<ProductionTarget> Targets,
     IReadOnlyList<ResourceAvailability> Available);
 
+/// <summary>
+/// Wolverine handler entry point. The planning logic itself lives behind
+/// <see cref="IRecipePlanner"/> — this shim just delegates so the engine can
+/// be swapped (recursive today; LP-backed per #88) via DI registration in
+/// <c>AddErpInfrastructure</c>.
+/// </summary>
 public static class PlanProductionHandler
 {
-    // Defensive guard against pathological recipe graphs (cycles via byproducts,
-    // unexpectedly deep chains). Real Satisfactory chains are <= 15 levels;
-    // 100 leaves plenty of headroom while still cutting off runaway recursion.
-    private const int MaxRecursionDepth = 100;
-
-    public static ProductionPlan Handle(PlanProductionQuery query, ICatalogProvider catalog)
-    {
-        var remainingAvailable = query.Available.ToDictionary(
-            a => a.Item,
-            a => a.ItemsPerMinute);
-
-        var stepsByRecipe = new Dictionary<RecipeId, RecipeAggregate>();
-        var rawConsumed = new Dictionary<ItemId, decimal>();
-        var missing = new Dictionary<ItemId, decimal>();
-        var visiting = new HashSet<ItemId>();
-
-        foreach (var target in query.Targets)
-        {
-            Expand(target.Item, target.ItemsPerMinute, catalog,
-                remainingAvailable, stepsByRecipe, rawConsumed, missing, visiting, depth: 0);
-        }
-
-        var steps = stepsByRecipe.Values
-            .Select(a => BuildStep(a.Recipe, a.OutputRatePerMinute, catalog))
-            .ToList();
-
-        return new ProductionPlan(
-            Targets: query.Targets,
-            Available: query.Available,
-            Steps: steps,
-            RawInputsConsumed: rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList(),
-            MissingInputs: missing.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList());
-    }
-
-    private static void Expand(
-        ItemId item,
-        decimal demandPerMinute,
-        ICatalogProvider catalog,
-        Dictionary<ItemId, decimal> available,
-        Dictionary<RecipeId, RecipeAggregate> steps,
-        Dictionary<ItemId, decimal> rawConsumed,
-        Dictionary<ItemId, decimal> missing,
-        HashSet<ItemId> visiting,
-        int depth)
-    {
-        if (demandPerMinute <= 0) return;
-
-        // Cycle detection: if this item is already being expanded higher up the
-        // call stack, treat the inner occurrence as missing — cycles must be
-        // broken by an external source, not by recursive production.
-        if (visiting.Contains(item))
-        {
-            Add(missing, item, demandPerMinute);
-            return;
-        }
-
-        if (depth > MaxRecursionDepth)
-        {
-            Add(missing, item, demandPerMinute);
-            return;
-        }
-
-        // 1) Cover from on-hand availability first.
-        if (available.TryGetValue(item, out var onHand) && onHand > 0)
-        {
-            var taken = Math.Min(onHand, demandPerMinute);
-            available[item] = onHand - taken;
-            Add(rawConsumed, item, taken);
-            demandPerMinute -= taken;
-            if (demandPerMinute <= 0) return;
-        }
-
-        // 2) Find a recipe that produces it.
-        var recipe = catalog.FindDefaultProducerOf(item);
-        if (recipe is null)
-        {
-            Add(missing, item, demandPerMinute);
-            return;
-        }
-
-        // 3) Scale the recipe and recurse into its inputs.
-        var producedPerRun = recipe.Outputs.First(o => o.Item == item).Quantity;
-        var producedPerMinute = producedPerRun * (decimal)(60 / recipe.Duration.TotalSeconds);
-        var scale = demandPerMinute / producedPerMinute;
-        AggregateStep(steps, recipe, scale);
-
-        visiting.Add(item);
-        try
-        {
-            foreach (var input in recipe.Inputs)
-            {
-                var inputPerMinute = input.Quantity * (decimal)(60 / recipe.Duration.TotalSeconds);
-                Expand(input.Item, inputPerMinute * scale, catalog,
-                    available, steps, rawConsumed, missing, visiting, depth + 1);
-            }
-        }
-        finally
-        {
-            visiting.Remove(item);
-        }
-    }
-
-    private static void AggregateStep(
-        Dictionary<RecipeId, RecipeAggregate> steps,
-        Recipe recipe,
-        decimal scale)
-    {
-        if (steps.TryGetValue(recipe.Id, out var existing))
-        {
-            steps[recipe.Id] = existing with { OutputRatePerMinute = existing.OutputRatePerMinute + scale };
-        }
-        else
-        {
-            steps[recipe.Id] = new RecipeAggregate(recipe, scale);
-        }
-    }
-
-    private static ProductionStep BuildStep(Recipe recipe, decimal scale, ICatalogProvider catalog)
-    {
-        var inputs = recipe.Inputs
-            .Select(i => new ItemAmount(i.Item, RatePerMinute(i.Quantity, recipe.Duration) * scale))
-            .ToList();
-        var outputs = recipe.Outputs
-            .Select(o => new ItemAmount(o.Item, RatePerMinute(o.Quantity, recipe.Duration) * scale))
-            .ToList();
-
-        // Power: documented base draw × building count. The catalogue only
-        // exposes BasePowerMw today; variable-power buildings (miners, etc.)
-        // would need a separate AveragePowerMw field, which doesn't exist yet
-        // — so this is intentionally the base figure. When the building is
-        // unknown or has no documented power, the contribution is zero.
-        var basePower = catalog.FindBuilding(recipe.Building)?.BasePowerMw ?? 0;
-        var powerMw = (decimal)basePower * scale;
-
-        return new ProductionStep(recipe, scale, powerMw, inputs, outputs);
-    }
-
-    private static decimal RatePerMinute(decimal quantityPerRun, TimeSpan duration) =>
-        quantityPerRun * (decimal)(60 / duration.TotalSeconds);
-
-    private static void Add(Dictionary<ItemId, decimal> map, ItemId key, decimal value)
-    {
-        map[key] = map.TryGetValue(key, out var current) ? current + value : value;
-    }
-
-    private sealed record RecipeAggregate(Recipe Recipe, decimal OutputRatePerMinute);
+    public static ProductionPlan Handle(PlanProductionQuery query, IRecipePlanner planner) =>
+        planner.Plan(query);
 }

--- a/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
+++ b/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
@@ -1,0 +1,163 @@
+using ERP.Domain;
+
+namespace ERP.Application.Queries.PlanProduction;
+
+/// <summary>
+/// Default <see cref="IRecipePlanner"/>: recursive recipe expansion. For each
+/// target, calls <see cref="ICatalogProvider.FindDefaultProducerOf"/> and
+/// recurses into the chosen recipe's inputs. Picks the catalogue's "default"
+/// recipe arbitrarily when alternates exist — alt-recipe optimisation is the
+/// LP planner's job (#88 / <c>OrToolsRecipePlanner</c>).
+/// </summary>
+public sealed class RecursiveRecipePlanner : IRecipePlanner
+{
+    // Defensive guard against pathological recipe graphs (cycles via byproducts,
+    // unexpectedly deep chains). Real Satisfactory chains are <= 15 levels;
+    // 100 leaves plenty of headroom while still cutting off runaway recursion.
+    private const int MaxRecursionDepth = 100;
+
+    private readonly ICatalogProvider _catalog;
+
+    public RecursiveRecipePlanner(ICatalogProvider catalog) => _catalog = catalog;
+
+    public ProductionPlan Plan(PlanProductionQuery query)
+    {
+        var remainingAvailable = query.Available.ToDictionary(
+            a => a.Item,
+            a => a.ItemsPerMinute);
+
+        var stepsByRecipe = new Dictionary<RecipeId, RecipeAggregate>();
+        var rawConsumed = new Dictionary<ItemId, decimal>();
+        var missing = new Dictionary<ItemId, decimal>();
+        var visiting = new HashSet<ItemId>();
+
+        foreach (var target in query.Targets)
+        {
+            Expand(target.Item, target.ItemsPerMinute,
+                remainingAvailable, stepsByRecipe, rawConsumed, missing, visiting, depth: 0);
+        }
+
+        var steps = stepsByRecipe.Values
+            .Select(a => BuildStep(a.Recipe, a.OutputRatePerMinute))
+            .ToList();
+
+        return new ProductionPlan(
+            Targets: query.Targets,
+            Available: query.Available,
+            Steps: steps,
+            RawInputsConsumed: rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList(),
+            MissingInputs: missing.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList());
+    }
+
+    private void Expand(
+        ItemId item,
+        decimal demandPerMinute,
+        Dictionary<ItemId, decimal> available,
+        Dictionary<RecipeId, RecipeAggregate> steps,
+        Dictionary<ItemId, decimal> rawConsumed,
+        Dictionary<ItemId, decimal> missing,
+        HashSet<ItemId> visiting,
+        int depth)
+    {
+        if (demandPerMinute <= 0) return;
+
+        // Cycle detection: if this item is already being expanded higher up the
+        // call stack, treat the inner occurrence as missing — cycles must be
+        // broken by an external source, not by recursive production.
+        if (visiting.Contains(item))
+        {
+            Add(missing, item, demandPerMinute);
+            return;
+        }
+
+        if (depth > MaxRecursionDepth)
+        {
+            Add(missing, item, demandPerMinute);
+            return;
+        }
+
+        // 1) Cover from on-hand availability first.
+        if (available.TryGetValue(item, out var onHand) && onHand > 0)
+        {
+            var taken = Math.Min(onHand, demandPerMinute);
+            available[item] = onHand - taken;
+            Add(rawConsumed, item, taken);
+            demandPerMinute -= taken;
+            if (demandPerMinute <= 0) return;
+        }
+
+        // 2) Find a recipe that produces it.
+        var recipe = _catalog.FindDefaultProducerOf(item);
+        if (recipe is null)
+        {
+            Add(missing, item, demandPerMinute);
+            return;
+        }
+
+        // 3) Scale the recipe and recurse into its inputs.
+        var producedPerRun = recipe.Outputs.First(o => o.Item == item).Quantity;
+        var producedPerMinute = producedPerRun * (decimal)(60 / recipe.Duration.TotalSeconds);
+        var scale = demandPerMinute / producedPerMinute;
+        AggregateStep(steps, recipe, scale);
+
+        visiting.Add(item);
+        try
+        {
+            foreach (var input in recipe.Inputs)
+            {
+                var inputPerMinute = input.Quantity * (decimal)(60 / recipe.Duration.TotalSeconds);
+                Expand(input.Item, inputPerMinute * scale,
+                    available, steps, rawConsumed, missing, visiting, depth + 1);
+            }
+        }
+        finally
+        {
+            visiting.Remove(item);
+        }
+    }
+
+    private static void AggregateStep(
+        Dictionary<RecipeId, RecipeAggregate> steps,
+        Recipe recipe,
+        decimal scale)
+    {
+        if (steps.TryGetValue(recipe.Id, out var existing))
+        {
+            steps[recipe.Id] = existing with { OutputRatePerMinute = existing.OutputRatePerMinute + scale };
+        }
+        else
+        {
+            steps[recipe.Id] = new RecipeAggregate(recipe, scale);
+        }
+    }
+
+    private ProductionStep BuildStep(Recipe recipe, decimal scale)
+    {
+        var inputs = recipe.Inputs
+            .Select(i => new ItemAmount(i.Item, RatePerMinute(i.Quantity, recipe.Duration) * scale))
+            .ToList();
+        var outputs = recipe.Outputs
+            .Select(o => new ItemAmount(o.Item, RatePerMinute(o.Quantity, recipe.Duration) * scale))
+            .ToList();
+
+        // Power: documented base draw × building count. The catalogue only
+        // exposes BasePowerMw today; variable-power buildings (miners, etc.)
+        // would need a separate AveragePowerMw field, which doesn't exist yet
+        // — so this is intentionally the base figure. When the building is
+        // unknown or has no documented power, the contribution is zero.
+        var basePower = _catalog.FindBuilding(recipe.Building)?.BasePowerMw ?? 0;
+        var powerMw = (decimal)basePower * scale;
+
+        return new ProductionStep(recipe, scale, powerMw, inputs, outputs);
+    }
+
+    private static decimal RatePerMinute(decimal quantityPerRun, TimeSpan duration) =>
+        quantityPerRun * (decimal)(60 / duration.TotalSeconds);
+
+    private static void Add(Dictionary<ItemId, decimal> map, ItemId key, decimal value)
+    {
+        map[key] = map.TryGetValue(key, out var current) ? current + value : value;
+    }
+
+    private sealed record RecipeAggregate(Recipe Recipe, decimal OutputRatePerMinute);
+}

--- a/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Satisfactory.Save;
@@ -23,6 +24,9 @@ public static class InfrastructureServiceCollectionExtensions
         // world-fixed and we surface them straight from the bundled JSON.
         services.AddSingleton(_ => KnownFlora.LoadEmbedded());
         services.AddSingleton<IFactoryStateProvider, SatisfactorySaveNetFactoryStateProvider>();
+        // Recipe planner port (#88). Recursive impl today; LP-backed adapter
+        // will land alongside this one behind a `Planner:Engine` switch.
+        services.AddSingleton<IRecipePlanner, RecursiveRecipePlanner>();
         return services;
     }
 }

--- a/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
+++ b/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
@@ -4,7 +4,7 @@ using ERP.Domain;
 
 namespace ERP.Application.Tests;
 
-public class PlanProductionHandlerTests
+public class RecursiveRecipePlannerTests
 {
     private static readonly BuildingId SmelterId = new("Build_SmelterMk1_C");
     private static readonly BuildingId ConstructorId = new("Build_ConstructorMk1_C");
@@ -41,11 +41,10 @@ public class PlanProductionHandlerTests
             ],
             recipes: [IronIngotRecipe]);
 
-        var plan = PlanProductionHandler.Handle(
-            new PlanProductionQuery(
-                Targets: [new ProductionTarget(IronIngot, 30)],
-                Available: [new ResourceAvailability(IronOre, 30)]),
-            catalog);
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
 
         var step = Assert.Single(plan.Steps);
         Assert.Equal(1m, step.BuildingCount);
@@ -65,11 +64,10 @@ public class PlanProductionHandlerTests
             ],
             recipes: [IronIngotRecipe, IronPlateRecipe]);
 
-        var plan = PlanProductionHandler.Handle(
-            new PlanProductionQuery(
-                Targets: [new ProductionTarget(IronPlate, 60)],
-                Available: [new ResourceAvailability(IronOre, 999)]),
-            catalog);
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronPlate, 60)],
+            Available: [new ResourceAvailability(IronOre, 999)]));
 
         Assert.Equal(2, plan.Steps.Count);
         var plateStep = plan.Steps.Single(s => s.Recipe.Id == IronPlateRecipe.Id);
@@ -89,18 +87,17 @@ public class PlanProductionHandlerTests
             buildings: [], // smelter intentionally absent
             recipes: [IronIngotRecipe]);
 
-        var plan = PlanProductionHandler.Handle(
-            new PlanProductionQuery(
-                Targets: [new ProductionTarget(IronIngot, 30)],
-                Available: [new ResourceAvailability(IronOre, 30)]),
-            catalog);
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
 
         var step = Assert.Single(plan.Steps);
         Assert.Equal(0m, step.PowerMw);
     }
 
     /// <summary>
-    /// Minimal in-memory catalogue stand-in. The handler only calls
+    /// Minimal in-memory catalogue stand-in. The planner only calls
     /// <see cref="FindDefaultProducerOf"/> and <see cref="FindBuilding"/>, so
     /// everything else throws to surface unexpected usage in tests.
     /// </summary>


### PR DESCRIPTION
## Summary

Phase A of #88. **Pure structural refactor — no behavior change.** Every existing test passes byte-for-byte.

- New port `IRecipePlanner` in `ERP.Application` (top-level placement mirrors `IFactoryStateProvider`).
- Existing recursive logic moves from the static `PlanProductionHandler` into a new `RecursiveRecipePlanner : IRecipePlanner` (instance class, `ICatalogProvider` injected via ctor).
- `PlanProductionHandler` shrinks to a Wolverine entry-point shim that delegates to the injected planner — the engine is now swappable via DI.
- `IRecipePlanner → RecursiveRecipePlanner` registered in `AddErpInfrastructure` (singleton).
- Test file renamed (git tracks at 85% similarity) and updated to instantiate the planner directly.

## Why this shape

Onion architecture: the OR-Tools-backed planner (Phase B) brings a native dep that doesn't belong in the Application layer. Introducing the port now keeps Phase B's adapter cleanly in `ERP.Infrastructure`, and the engine choice becomes a config switch rather than a code change.

## OR-Tools PoC outcome

Verified on a throwaway `poc/or-tools` branch — `Google.OrTools 9.15.6755` loads its native runtime and solves a trivial GLOP LP cleanly on:
- macOS dev machine (~22s test duration, cold)
- Self-hosted Linux CI runner (full lane green)

Library choice for Phase B is **locked to OR-Tools**.

## What's NOT in this PR

- The LP adapter itself. That's Phase B — `OrToolsRecipePlanner` in `ERP.Infrastructure`, `Planner:Engine = recursive | lp` config switch, parity tests, alt-recipe + capped-input + byproduct tests.
- Any default change. `RecursiveRecipePlanner` remains the only registered engine until Phase B lands.

## Test plan

- [x] `./build.sh TestNoUi` passes locally (Restore + Compile + TestNoUi, ~4s).
- [x] All 3 existing planner tests pass (renamed file).
- [x] CI passes the full lane (touches `src/**` + `test/**`, so the new path filter from #113 will run everything).
- [x] Smoke test the `/plan` endpoint in dev to confirm Wolverine still wires the handler.

Closes nothing yet — #88 stays open until Phase B lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)