### PR TITLE
feat(planner): OR-Tools LP adapter behind Planner:Engine switch (#88, phase B)

### DIFF
--- a/ERP.Satisfactory.slnx
+++ b/ERP.Satisfactory.slnx
@@ -41,6 +41,9 @@
   <Folder Name="/test/ERP/Domain.Tests/">
     <Project Path="test/ERP/Domain.Tests/ERP.Domain.Tests.csproj" />
   </Folder>
+  <Folder Name="/test/ERP/Infrastructure.Tests/">
+    <Project Path="test/ERP/Infrastructure.Tests/ERP.Infrastructure.Tests.csproj" />
+  </Folder>
   <Folder Name="/test/ERP/Persistence.Tests/">
     <Project Path="test/ERP/Persistence.Tests/ERP.Infrastructure.Persistence.Tests.csproj" />
   </Folder>

--- a/src/ERP/Infrastructure/ERP.Infrastructure.csproj
+++ b/src/ERP/Infrastructure/ERP.Infrastructure.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.OrTools" Version="9.15.6755" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />

--- a/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using ERP.Application;
 using ERP.Application.Queries.PlanProduction;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Satisfactory.Save;
 
 namespace ERP.Infrastructure;
@@ -12,6 +14,7 @@ public static class InfrastructureServiceCollectionExtensions
     {
         services.Configure<CatalogueOptions>(configuration.GetSection("Catalogue:Satisfactory"));
         services.Configure<FactoryStateOptions>(configuration.GetSection("FactoryState:Satisfactory"));
+        services.Configure<PlannerOptions>(configuration.GetSection("Planner"));
         services.AddSingleton<UserCatalogueConfig>();
         services.AddSingleton<ICatalogProvider, DocsCatalogProvider>();
         // Manual node overrides — user-local JSON loaded once at startup and
@@ -24,9 +27,22 @@ public static class InfrastructureServiceCollectionExtensions
         // world-fixed and we surface them straight from the bundled JSON.
         services.AddSingleton(_ => KnownFlora.LoadEmbedded());
         services.AddSingleton<IFactoryStateProvider, SatisfactorySaveNetFactoryStateProvider>();
-        // Recipe planner port (#88). Recursive impl today; LP-backed adapter
-        // will land alongside this one behind a `Planner:Engine` switch.
-        services.AddSingleton<IRecipePlanner, RecursiveRecipePlanner>();
+        // Recipe planner port (#88). Engine is selected by Planner:Engine
+        // config — defaults to Recursive. The LP engine uses OR-Tools GLOP
+        // (Google.OrTools native deps verified for macOS dev + self-hosted
+        // Linux CI). Both impls share the IRecipePlanner contract.
+        services.AddSingleton<IRecipePlanner>(sp =>
+        {
+            var engine = sp.GetRequiredService<IOptions<PlannerOptions>>().Value.Engine;
+            var catalog = sp.GetRequiredService<ICatalogProvider>();
+            return engine switch
+            {
+                PlannerEngine.Lp => new OrToolsRecipePlanner(
+                    catalog,
+                    sp.GetService<ILogger<OrToolsRecipePlanner>>()),
+                _ => new RecursiveRecipePlanner(catalog),
+            };
+        });
         return services;
     }
 }

--- a/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
+++ b/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
@@ -1,0 +1,201 @@
+using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+using Google.OrTools.LinearSolver;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Infrastructure;
+
+/// <summary>
+/// LP-backed <see cref="IRecipePlanner"/> using Google OR-Tools' GLOP solver
+/// (#88). Each recipe is a continuous activation-rate variable (building-
+/// equivalents); the objective minimises total base power subject to a supply-
+/// ≥-demand constraint per item, with raw availability capped per
+/// <see cref="ResourceAvailability"/>. Alternate recipes are selected
+/// automatically: the cheapest power solution that fits the caps wins.
+/// Shortfalls (target unsatisfiable) surface as <c>MissingInputs</c> via a
+/// large-penalty slack variable, so the LP always returns a solution.
+/// </summary>
+public sealed class OrToolsRecipePlanner : IRecipePlanner
+{
+    // Anything below this in solver-returned values is treated as zero.
+    // GLOP returns ~1e-13 noise on zero-bound variables under default settings;
+    // 1e-6 is comfortably above that while still small enough that a "real"
+    // building count would never fall under it.
+    private const double Epsilon = 1e-6;
+
+    // Penalty applied to shortfall vars in the objective. Two tiers so the
+    // LP attributes infeasibility to the upstream cause (a raw input that
+    // ran out) rather than pushing it onto the downstream target. Without
+    // this tiering, the LP can find equal-shortfall solutions where the
+    // *recipe runs partially* — the gap then appears on the target item
+    // instead of on the raw, which is the wrong story for the user. Both
+    // penalties dominate any realistic power coefficient × activation rate
+    // (max ~10⁶ in any sane factory).
+    private const double ShortfallPenaltyForRaw = 1e6;    // items with no producer recipe
+    private const double ShortfallPenaltyForProduced = 1e9; // items reachable via some recipe
+
+    // Tie-breaker on raw-availability draw. Without it the LP is indifferent
+    // between drawing `needed` vs `available` from a raw input (the supply
+    // constraint is ≥, not =), and GLOP can return any value in that range
+    // — typically the upper bound. A small positive coefficient makes the
+    // LP prefer the minimum draw, so RawInputsConsumed matches what the plan
+    // actually uses. Has to be above GLOP's default optimality tolerance
+    // (~10⁻⁶) to actually break the tie, but still well below typical power
+    // coefficients (~10⁰–10²) so it doesn't influence recipe selection.
+    private const double RawDrawTieBreaker = 1e-3;
+
+    private readonly ICatalogProvider _catalog;
+    private readonly ILogger<OrToolsRecipePlanner>? _logger;
+
+    public OrToolsRecipePlanner(ICatalogProvider catalog, ILogger<OrToolsRecipePlanner>? logger = null)
+    {
+        _catalog = catalog;
+        _logger = logger;
+    }
+
+    public ProductionPlan Plan(PlanProductionQuery query)
+    {
+        var solver = Solver.CreateSolver("GLOP")
+            ?? throw new InvalidOperationException(
+                "GLOP solver unavailable — check that Google.OrTools native deps loaded.");
+
+        var available = query.Available.ToDictionary(a => a.Item, a => (double)a.ItemsPerMinute);
+        var targets = query.Targets.ToDictionary(t => t.Item, t => (double)t.ItemsPerMinute);
+        var recipes = _catalog.Recipes.ToList();
+
+        // Item universe = every item that appears as a target, in availability,
+        // or in any recipe's inputs/outputs. Each item gets one supply
+        // constraint + a raw-supply var (capped) + a shortfall var (penalised).
+        var items = new HashSet<ItemId>(query.Targets.Select(t => t.Item));
+        foreach (var a in query.Available) items.Add(a.Item);
+        foreach (var r in recipes)
+        {
+            foreach (var i in r.Inputs) items.Add(i.Item);
+            foreach (var o in r.Outputs) items.Add(o.Item);
+        }
+
+        // Decision variables.
+        var xVars = recipes.ToDictionary(
+            r => r.Id,
+            r => solver.MakeNumVar(0.0, double.PositiveInfinity, $"x_{r.Id.Value}"));
+
+        var rawVars = items.ToDictionary(
+            i => i,
+            i => solver.MakeNumVar(
+                0.0,
+                available.TryGetValue(i, out var cap) ? cap : 0.0,
+                $"raw_{i.Value}"));
+
+        var shortVars = items.ToDictionary(
+            i => i,
+            i => solver.MakeNumVar(0.0, double.PositiveInfinity, $"short_{i.Value}"));
+
+        // Supply ≥ Demand constraint per item:
+        //   raw_i + Σ_r x_r·(out_rate(r,i) − in_rate(r,i)) + short_i ≥ target_i
+        foreach (var i in items)
+        {
+            var targetI = targets.TryGetValue(i, out var t) ? t : 0.0;
+            var c = solver.MakeConstraint(targetI, double.PositiveInfinity, $"supply_{i.Value}");
+            c.SetCoefficient(rawVars[i], 1);
+            c.SetCoefficient(shortVars[i], 1);
+            foreach (var r in recipes)
+            {
+                var coeff = NetRatePerMinute(r, i);
+                if (Math.Abs(coeff) > Epsilon)
+                    c.SetCoefficient(xVars[r.Id], coeff);
+            }
+        }
+
+        // Objective: minimise total base power (Σ_r x_r · basePower(r)) plus
+        // a shortfall penalty per item. Raw items (no producer recipe in the
+        // catalogue) get a lighter penalty than produced items so the LP
+        // prefers to attribute shortfall upstream — "you need more iron ore"
+        // reads better than "you're short on ingots" when both are
+        // arithmetically equivalent.
+        var itemsWithProducers = new HashSet<ItemId>(
+            recipes.SelectMany(r => r.Outputs.Select(o => o.Item)));
+
+        var obj = solver.Objective();
+        foreach (var r in recipes)
+        {
+            var basePower = (double)(_catalog.FindBuilding(r.Building)?.BasePowerMw ?? 0);
+            if (Math.Abs(basePower) > Epsilon)
+                obj.SetCoefficient(xVars[r.Id], basePower);
+        }
+        foreach (var i in items)
+        {
+            var penalty = itemsWithProducers.Contains(i)
+                ? ShortfallPenaltyForProduced
+                : ShortfallPenaltyForRaw;
+            obj.SetCoefficient(shortVars[i], penalty);
+            obj.SetCoefficient(rawVars[i], RawDrawTieBreaker);
+        }
+        obj.SetMinimization();
+
+        var status = solver.Solve();
+        if (status != Solver.ResultStatus.OPTIMAL && status != Solver.ResultStatus.FEASIBLE)
+            throw new InvalidOperationException(
+                $"LP solver returned {status} — expected OPTIMAL or FEASIBLE.");
+
+        _logger?.LogInformation(
+            "LP solved: status={Status}, objective={Objective:F2}, recipes={RecipeCount}, items={ItemCount}",
+            status, obj.Value(), recipes.Count, items.Count);
+
+        var steps = new List<ProductionStep>();
+        foreach (var r in recipes)
+        {
+            var scaleDouble = xVars[r.Id].SolutionValue();
+            if (scaleDouble <= Epsilon) continue;
+            steps.Add(BuildStep(r, (decimal)scaleDouble));
+        }
+
+        var rawConsumed = new List<ItemAmount>();
+        foreach (var i in items)
+        {
+            var amount = rawVars[i].SolutionValue();
+            if (amount > Epsilon)
+                rawConsumed.Add(new ItemAmount(i, (decimal)amount));
+        }
+
+        var missing = new List<ItemAmount>();
+        foreach (var i in items)
+        {
+            var amount = shortVars[i].SolutionValue();
+            if (amount > Epsilon)
+                missing.Add(new ItemAmount(i, (decimal)amount));
+        }
+
+        return new ProductionPlan(
+            Targets: query.Targets,
+            Available: query.Available,
+            Steps: steps,
+            RawInputsConsumed: rawConsumed,
+            MissingInputs: missing);
+    }
+
+    private static double NetRatePerMinute(Recipe r, ItemId item)
+    {
+        var perMinuteFactor = 60.0 / r.Duration.TotalSeconds;
+        double net = 0;
+        foreach (var o in r.Outputs)
+            if (o.Item == item) net += (double)o.Quantity * perMinuteFactor;
+        foreach (var i in r.Inputs)
+            if (i.Item == item) net -= (double)i.Quantity * perMinuteFactor;
+        return net;
+    }
+
+    private ProductionStep BuildStep(Recipe recipe, decimal scale)
+    {
+        var perMinuteFactor = (decimal)(60.0 / recipe.Duration.TotalSeconds);
+        var inputs = recipe.Inputs
+            .Select(i => new ItemAmount(i.Item, i.Quantity * perMinuteFactor * scale))
+            .ToList();
+        var outputs = recipe.Outputs
+            .Select(o => new ItemAmount(o.Item, o.Quantity * perMinuteFactor * scale))
+            .ToList();
+        var basePower = (decimal)(_catalog.FindBuilding(recipe.Building)?.BasePowerMw ?? 0);
+        var powerMw = basePower * scale;
+        return new ProductionStep(recipe, scale, powerMw, inputs, outputs);
+    }
+}

--- a/src/ERP/Infrastructure/PlannerOptions.cs
+++ b/src/ERP/Infrastructure/PlannerOptions.cs
@@ -1,0 +1,20 @@
+namespace ERP.Infrastructure;
+
+/// <summary>
+/// Bound from configuration section <c>Planner</c>. Selects which
+/// <see cref="ERP.Application.IRecipePlanner"/> implementation gets wired in
+/// <c>AddErpInfrastructure</c>.
+/// </summary>
+public sealed class PlannerOptions
+{
+    public PlannerEngine Engine { get; set; } = PlannerEngine.Recursive;
+}
+
+public enum PlannerEngine
+{
+    /// <summary>Recursive recipe expansion (default; pre-#88 behaviour).</summary>
+    Recursive,
+
+    /// <summary>Linear-programming solver via Google OR-Tools (#88).</summary>
+    Lp,
+}

--- a/test/ERP/Infrastructure.Tests/ERP.Infrastructure.Tests.csproj
+++ b/test/ERP/Infrastructure.Tests/ERP.Infrastructure.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\ERP\Infrastructure\ERP.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
+++ b/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
@@ -1,0 +1,154 @@
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+using static ERP.Infrastructure.Tests.PlannerTestFixtures;
+
+namespace ERP.Infrastructure.Tests;
+
+public class OrToolsRecipePlannerTests
+{
+    private const decimal Tol = 0.001m;
+
+    [Fact]
+    public void Picks_Cheaper_Alt_Recipe_When_Available()
+    {
+        // Two recipes for iron ingot:
+        //   Standard: 1 ore → 1 ingot, 30/min, smelter @ 4 MW
+        //   Cheap:    1 ore → 1 ingot, 30/min, "cheap smelter" @ 1 MW
+        // LP must pick Cheap. Recursive would arbitrarily pick whichever
+        // FindDefaultProducerOf returns first — that's the test's contrast.
+        var cheapSmelter = new BuildingId("Build_SmelterCheap_C");
+        var cheapRecipe = new Recipe(
+            new RecipeId("Recipe_IngotIron_Cheap_C"),
+            "Iron Ingot (Cheap)",
+            cheapSmelter,
+            Inputs: [new ItemAmount(IronOre, 1)],
+            Outputs: [new ItemAmount(IronIngot, 1)],
+            Duration: TimeSpan.FromSeconds(2));
+
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+                new Building(cheapSmelter, "Cheap Smelter", BasePowerMw: 1),
+            ],
+            recipes: [IronIngotRecipe, cheapRecipe]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
+
+        var step = Assert.Single(plan.Steps);
+        Assert.Equal(cheapRecipe.Id, step.Recipe.Id);
+        Assert.InRange(step.BuildingCount, 1m - Tol, 1m + Tol);
+        Assert.InRange(step.PowerMw, 1m - Tol, 1m + Tol);
+    }
+
+    [Fact]
+    public void Mixes_Recipes_When_Cheap_Power_Recipe_Has_Higher_Ore_Cost()
+    {
+        // Setup forces the LP to pick a 50/50 mix:
+        //   Standard: 1 ore → 1 ingot per 2s (30 ore/min, 30 ingots/min), 4 MW
+        //   Cheap power: 2 ore → 1 ingot per 2s (60 ore/min, 30 ingots/min), 1 MW
+        // Target 30 ingots, available 45 ore.
+        //
+        // Cheap alone would need 60 ore (over cap). Standard alone needs only
+        // 30 ore (under cap) but costs 4 MW. The LP picks a 50/50 mix:
+        //   x_cheap = 0.5 (15 ingots, 30 ore, 0.5 MW)
+        //   x_standard = 0.5 (15 ingots, 15 ore, 2 MW)
+        //   total: 30 ingots, 45 ore, 2.5 MW.
+        // Standard-only would cost 4 MW (more), pure-cheap is infeasible (over
+        // cap by 15 ore + would incur shortfall penalty). Mix wins on power.
+        var cheapSmelter = new BuildingId("Build_SmelterCheap_C");
+        var cheapRecipe = new Recipe(
+            new RecipeId("Recipe_IngotIron_Cheap_C"),
+            "Iron Ingot (Cheap)",
+            cheapSmelter,
+            Inputs: [new ItemAmount(IronOre, 2)],
+            Outputs: [new ItemAmount(IronIngot, 1)],
+            Duration: TimeSpan.FromSeconds(2));
+
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+                new Building(cheapSmelter, "Cheap Smelter", BasePowerMw: 1),
+            ],
+            recipes: [IronIngotRecipe, cheapRecipe]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 45)]));
+
+        Assert.Empty(plan.MissingInputs);
+        Assert.Equal(2, plan.Steps.Count);
+        var totalPower = plan.Steps.Sum(s => s.PowerMw);
+        Assert.InRange(totalPower, 2.5m - Tol, 2.5m + Tol);
+        var oreConsumed = plan.RawInputsConsumed.Single(r => r.Item == IronOre).Quantity;
+        Assert.InRange(oreConsumed, 45m - Tol, 45m + Tol);
+    }
+
+    [Fact]
+    public void Reports_Shortfall_When_Demand_Exceeds_Available_Raw()
+    {
+        // Iron ingot only producible from iron ore; ask for 30 ingots with
+        // only 10 ore — shortfall 20.
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 10)]));
+
+        Assert.False(plan.IsFeasible);
+        var missing = plan.MissingInputs;
+        Assert.Contains(missing, m => m.Item == IronOre);
+        var oreShort = missing.Single(m => m.Item == IronOre).Quantity;
+        Assert.InRange(oreShort, 20m - Tol, 20m + Tol);
+    }
+
+    [Fact]
+    public void Byproducts_Reduce_Demand_On_Primary_Producer()
+    {
+        // Refinery recipe "Plastic" produces plastic + heavy oil residue as
+        // a byproduct. If the user already needs heavy oil residue elsewhere
+        // (or as a target), the plastic recipe's byproduct counts toward that
+        // demand — the LP picks up the credit "for free".
+        //
+        // Recipe Plastic: 30 crude oil/min → 20 plastic/min + 10 heavy oil residue/min.
+        // We'll simplify: have a recipe that produces plastic + residue from a
+        // raw input, and a target demanding both. Refinery only — no alt.
+        var crudeOil = new ItemId("Desc_LiquidOil_C");
+        var plasticRecipe = new Recipe(
+            new RecipeId("Recipe_Plastic_C"),
+            "Plastic",
+            RefineryId,
+            Inputs: [new ItemAmount(crudeOil, 3)],
+            Outputs: [
+                new ItemAmount(Plastic, 2),
+                new ItemAmount(HeavyOilResidue, 1),
+            ],
+            Duration: TimeSpan.FromSeconds(6));
+
+        var catalog = new FakeCatalog(
+            buildings: [new Building(RefineryId, "Refinery", BasePowerMw: 30)],
+            recipes: [plasticRecipe]);
+
+        // Target both 20 plastic/min AND 10 heavy oil residue/min. One refinery
+        // produces exactly that pair — running it once should satisfy both
+        // targets simultaneously, not require a second recipe for residue.
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [
+                new ProductionTarget(Plastic, 20),
+                new ProductionTarget(HeavyOilResidue, 10),
+            ],
+            Available: [new ResourceAvailability(crudeOil, 999)]));
+
+        var step = Assert.Single(plan.Steps);
+        Assert.Equal(plasticRecipe.Id, step.Recipe.Id);
+        Assert.InRange(step.BuildingCount, 1m - Tol, 1m + Tol);
+        Assert.Empty(plan.MissingInputs);
+    }
+}

--- a/test/ERP/Infrastructure.Tests/PlannerParityTests.cs
+++ b/test/ERP/Infrastructure.Tests/PlannerParityTests.cs
@@ -1,0 +1,108 @@
+using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+using static ERP.Infrastructure.Tests.PlannerTestFixtures;
+
+namespace ERP.Infrastructure.Tests;
+
+/// <summary>
+/// Both <see cref="RecursiveRecipePlanner"/> and <see cref="OrToolsRecipePlanner"/>
+/// must produce the same plan for any fixture where the recipe graph is
+/// unambiguous (single recipe per output item, no constrained inputs that
+/// would let the LP pick a different mix). The three existing planner
+/// fixtures fall in that class — they're the parity oracle.
+/// </summary>
+public class PlannerParityTests
+{
+    // GLOP returns doubles with ~1e-12 noise; converting back to decimal can
+    // introduce ~1e-10 drift. Tolerance is generous on either side.
+    private const decimal Tol = 0.0001m;
+
+    public static IEnumerable<object[]> Fixtures()
+    {
+        // 1) Single-step chain.
+        yield return new object[]
+        {
+            "single_step_30_ingots",
+            new FakeCatalog(
+                buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+                recipes: [IronIngotRecipe]),
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronIngot, 30)],
+                Available: [new ResourceAvailability(IronOre, 30)]),
+        };
+
+        // 2) Multi-step chain with scaling.
+        yield return new object[]
+        {
+            "multi_step_60_plates",
+            new FakeCatalog(
+                buildings: [
+                    new Building(SmelterId, "Smelter", BasePowerMw: 4),
+                    new Building(ConstructorId, "Constructor", BasePowerMw: 4),
+                ],
+                recipes: [IronIngotRecipe, IronPlateRecipe]),
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronPlate, 60)],
+                Available: [new ResourceAvailability(IronOre, 999)]),
+        };
+
+        // 3) Missing building → power defaults to 0 for that step in both
+        //    planners.
+        yield return new object[]
+        {
+            "missing_building_zero_power",
+            new FakeCatalog(buildings: [], recipes: [IronIngotRecipe]),
+            new PlanProductionQuery(
+                Targets: [new ProductionTarget(IronIngot, 30)],
+                Available: [new ResourceAvailability(IronOre, 30)]),
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Fixtures))]
+    public void Both_Planners_Produce_Equivalent_Plans(
+        string name, ICatalogProvider catalog, PlanProductionQuery query)
+    {
+        _ = name; // surfaced in xUnit run output for failure context
+
+        var recursive = new RecursiveRecipePlanner(catalog).Plan(query);
+        var lp = new OrToolsRecipePlanner(catalog).Plan(query);
+
+        // Same recipes activated, same building counts, same power.
+        var recursiveSteps = recursive.Steps.OrderBy(s => s.Recipe.Id.Value).ToList();
+        var lpSteps = lp.Steps.OrderBy(s => s.Recipe.Id.Value).ToList();
+        Assert.Equal(recursiveSteps.Count, lpSteps.Count);
+
+        for (var i = 0; i < recursiveSteps.Count; i++)
+        {
+            Assert.Equal(recursiveSteps[i].Recipe.Id, lpSteps[i].Recipe.Id);
+            Assert.InRange(lpSteps[i].BuildingCount,
+                recursiveSteps[i].BuildingCount - Tol,
+                recursiveSteps[i].BuildingCount + Tol);
+            Assert.InRange(lpSteps[i].PowerMw,
+                recursiveSteps[i].PowerMw - Tol,
+                recursiveSteps[i].PowerMw + Tol);
+        }
+
+        // Same total power.
+        var recursivePower = recursive.Steps.Sum(s => s.PowerMw);
+        var lpPower = lp.Steps.Sum(s => s.PowerMw);
+        Assert.InRange(lpPower, recursivePower - Tol, recursivePower + Tol);
+
+        // Same feasibility verdict.
+        Assert.Equal(recursive.IsFeasible, lp.IsFeasible);
+
+        // Same raw-input consumption per item.
+        var recursiveRaw = recursive.RawInputsConsumed.ToDictionary(r => r.Item, r => r.Quantity);
+        var lpRaw = lp.RawInputsConsumed.ToDictionary(r => r.Item, r => r.Quantity);
+        Assert.Equal(recursiveRaw.Keys.OrderBy(k => k.Value),
+                     lpRaw.Keys.OrderBy(k => k.Value));
+        foreach (var (item, expected) in recursiveRaw)
+        {
+            Assert.True(lpRaw.TryGetValue(item, out var actual),
+                $"LP plan missing raw input for {item.Value}.");
+            Assert.InRange(actual, expected - Tol, expected + Tol);
+        }
+    }
+}

--- a/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
+++ b/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
@@ -1,0 +1,82 @@
+using ERP.Application;
+using ERP.Domain;
+
+namespace ERP.Infrastructure.Tests;
+
+/// <summary>
+/// Shared recipe/building/item ids and an in-memory <see cref="ICatalogProvider"/>
+/// stand-in. The same fixture set powers both the LP-specific tests and the
+/// parity tests against <c>RecursiveRecipePlanner</c>.
+/// </summary>
+internal static class PlannerTestFixtures
+{
+    public static readonly BuildingId SmelterId = new("Build_SmelterMk1_C");
+    public static readonly BuildingId ConstructorId = new("Build_ConstructorMk1_C");
+    public static readonly BuildingId FoundryId = new("Build_FoundryMk1_C");
+    public static readonly BuildingId RefineryId = new("Build_OilRefinery_C");
+
+    public static readonly ItemId IronOre = new("Desc_OreIron_C");
+    public static readonly ItemId IronIngot = new("Desc_IronIngot_C");
+    public static readonly ItemId IronPlate = new("Desc_IronPlate_C");
+    public static readonly ItemId Coal = new("Desc_Coal_C");
+    public static readonly ItemId SteelIngot = new("Desc_SteelIngot_C");
+    public static readonly ItemId CopperOre = new("Desc_OreCopper_C");
+    public static readonly ItemId CopperIngot = new("Desc_CopperIngot_C");
+    public static readonly ItemId HeavyOilResidue = new("Desc_HeavyOilResidue_C");
+    public static readonly ItemId Plastic = new("Desc_Plastic_C");
+
+    public static readonly Recipe IronIngotRecipe = new(
+        new RecipeId("Recipe_IngotIron_C"),
+        "Iron Ingot",
+        SmelterId,
+        Inputs: [new ItemAmount(IronOre, 1)],
+        Outputs: [new ItemAmount(IronIngot, 1)],
+        Duration: TimeSpan.FromSeconds(2));
+
+    public static readonly Recipe IronPlateRecipe = new(
+        new RecipeId("Recipe_IronPlate_C"),
+        "Iron Plate",
+        ConstructorId,
+        Inputs: [new ItemAmount(IronIngot, 3)],
+        Outputs: [new ItemAmount(IronPlate, 2)],
+        Duration: TimeSpan.FromSeconds(6));
+
+    /// <summary>
+    /// In-memory catalogue stand-in. Planners only call
+    /// <see cref="FindDefaultProducerOf"/>, <see cref="FindBuilding"/>, and
+    /// iterate <see cref="Recipes"/>; everything else throws so unexpected
+    /// usage is caught in tests.
+    /// </summary>
+    public sealed class FakeCatalog : ICatalogProvider
+    {
+        private readonly Dictionary<BuildingId, Building> _buildings;
+        private readonly List<Recipe> _recipes;
+
+        public FakeCatalog(IEnumerable<Building> buildings, IEnumerable<Recipe> recipes)
+        {
+            _buildings = buildings.ToDictionary(b => b.Id);
+            _recipes = recipes.ToList();
+        }
+
+        public bool IsLoaded => true;
+        public string? Source => "fake";
+        public IReadOnlyList<Item> Items => [];
+        public IReadOnlyList<Building> Buildings => _buildings.Values.ToList();
+        public IReadOnlyList<Recipe> Recipes => _recipes;
+
+        public Item? FindItem(ItemId id) => null;
+        public Building? FindBuilding(BuildingId id) =>
+            _buildings.TryGetValue(id, out var b) ? b : null;
+        public Recipe? FindRecipe(RecipeId id) =>
+            _recipes.FirstOrDefault(r => r.Id == id);
+
+        public Recipe? FindDefaultProducerOf(ItemId item) =>
+            _recipes.FirstOrDefault(r => r.Outputs.Any(o => o.Item == item));
+
+        public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) =>
+            _recipes.Where(r => r.Outputs.Any(o => o.Item == item)).ToList();
+
+        public CatalogueStatus GetStatus() => throw new NotSupportedException();
+        public CatalogueStatus LoadFromPath(string docsJsonPath) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

Phase B of #88. Lands the LP planner as an **opt-in** `IRecipePlanner`. Default behaviour is unchanged — `RecursiveRecipePlanner` stays the registered engine until you flip `Planner:Engine = lp` in config. **No existing tests change**; new tests stand alone in a new `ERP.Infrastructure.Tests` project.

## What's in the box

- **`Google.OrTools 9.15.6755`** added to `ERP.Infrastructure`. Native deps verified for macOS dev + self-hosted Linux CI in the earlier PoC.
- **`OrToolsRecipePlanner`** using the GLOP solver. Decision vars = per-recipe activation rates; objective minimises Σ x_r · BasePowerMw. Supply ≥ Demand constraint per item; raw availability capped per `ResourceAvailability`.
- **`PlannerOptions` + factory registration** — `Planner:Engine = recursive | lp` in config selects the implementation. Recursive remains default.

## Two design wrinkles worth flagging

1. **Two-tier shortfall penalty.** Without it, the LP can find equal-shortfall solutions where the recipe runs partially and the unmet-demand gap surfaces on the *target* item instead of the bottlenecked *raw input*. Penalty: raw items (no producer recipe) → 1e6; produced items → 1e9. Net effect: \"you need more iron ore\" instead of \"you're short on ingots\" — matches the recursive planner's reporting and the user's mental model.

2. **Raw-draw tie-breaker.** Without it, the supply-≥-demand constraint is satisfied by any value in `[needed, available]` and GLOP picks the upper bound — so `RawInputsConsumed` ended up reporting `available` (e.g. 999) instead of `90` actually consumed. Adding a tiny positive coefficient on raw vars (1e-3, above GLOP's optimality tolerance, below typical recipe power coefficients) makes the LP minimise raw draw to exactly what's needed.

Both quirks have full comments in `OrToolsRecipePlanner.cs`.

## Tests

New `test/ERP/Infrastructure.Tests/` project (csproj follows the existing test-project pattern). 7 tests total:

**LP-specific** (4):
- `Picks_Cheaper_Alt_Recipe_When_Available` — two recipes for iron ingot, LP picks the lower-power one.
- `Mixes_Recipes_When_Cheap_Power_Recipe_Has_Higher_Ore_Cost` — capped raw forces a 50/50 mix; LP finds the optimal blend.
- `Reports_Shortfall_When_Demand_Exceeds_Available_Raw` — only 10 ore for 30-ingot target → shortfall reported on **ore**, not on ingots.
- `Byproducts_Reduce_Demand_On_Primary_Producer` — one refinery making plastic + heavy oil residue satisfies both targets simultaneously.

**Parity** (3, xUnit `[Theory]` + `MemberData`):
- The three existing `RecursiveRecipePlannerTests` fixtures, fed through both planners, asserting equivalent output within a decimal-from-double tolerance (`±0.0001m`).

All tests pass locally (`./build.sh TestNoUi`).

## Out of scope (deliberate)

- Flipping the default engine to `lp`. That's a separate decision; ship the option first.
- LP-aware infeasibility messages — that's #8, naturally lands on top.
- Integer programming / fractional building counts. v1 is LP relaxation; building counts can be fractional in the output (matches recursive's behaviour for non-divisible targets).
- Larger objective surface (minimise byproduct waste, minimise machine count, etc.). One objective for now.

## Verification plan

- [ ] CI passes the full lane (path filter from #113 routes this as code-touching).
- [ ] After merge: flip `Planner:Engine` to `lp` locally, hit `/plan` with a realistic Satisfactory catalogue, confirm the plan looks sane.
- [ ] After verification: open a follow-up tiny PR flipping the default if you're happy.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)