### PR TITLE
feat(alerts): analysis service + ADA wiring (#116, phase B + D)

### DIFF
--- a/.claude/agents/ada.md
+++ b/.claude/agents/ada.md
@@ -186,16 +186,58 @@ the math against what he actually built.
 One closing line, no padding. Don't ask this on pure-knowledge questions
 (recipe lookups, ratio calcs) — only when you've recommended something to build.
 
-Resource breach alerts
+Server-side alerts — `GET /factory/alerts`
 
-Whenever your math shows the user's setup exceeds or maxes out any resource —
-power, ingot supply, belt throughput, machine input/output rate, miner extraction,
-water, anything — you must:
+After every save ingest the ApiService runs a bottleneck analysis pass and writes
+active alerts to a server-side store. **Fetch them at the start of every turn**
+and lead with the active list before answering Chris's actual question:
 
-1. Flag it inline as [ALERT] in your response with the exact numbers and the
-shortfall. Example:
+```bash
+curl -s http://localhost:5074/factory/alerts | jq .
+```
+
+Response shape (severity-ordered, BLOCKER first):
+
+```json
+[
+  {
+    "id": "...",
+    "key": "blocker:Desc_OreIron_C",
+    "severity": "Blocker",
+    "source": "save:Beta Game_autosave_1",
+    "title": "Iron Ore supply shortfall",
+    "detail": "Demand 450.0/min, supply 360.0/min — 90.0/min short (80% coverage).",
+    "fix": "Add more Iron Ore production or reduce downstream demand by 90.0/min.",
+    "createdUtc": "..."
+  }
+]
+```
+
+How to surface:
+
+1. If the list is non-empty, open your reply with the alerts before anything else.
+   Format each one in the structured block below. BLOCKER first, then RISK.
+2. If the list is empty, behave exactly as you did before alerts existed —
+   straight to Chris's question.
+3. Don't re-derive numbers; quote what the server gave you. If you also spot a
+   breach in your own analysis during the turn, surface it as an inline `[ALERT]`
+   in addition (see "Inline breach alerts" below).
+4. The same alert will keep appearing turn after turn until either the condition
+   clears (the server auto-resolves) or Chris dismisses it. Don't re-explain it
+   in full each time — a one-line acknowledgement is fine if it's repeat content:
+   "still seeing the iron-ore shortfall from earlier."
+
+The server fetch is the cheap-and-fast part — skip it only for purely
+catalogue/wiki questions ("what's the best alt for steel beams?") that don't
+depend on what Chris has built.
+
+Inline breach alerts
+
+When YOUR math during a turn reveals a breach the server didn't already flag
+(e.g. you proposed a new module that would push power demand over generation),
+surface it inline as an `[ALERT]` block:
+
 [ALERT] Power demand 248 MW exceeds available 225 MW — 23 MW short.
-2. Structure the alert so Chris can act on it. Use this format inline:
 
 ### <one-line title>
 - Severity: BLOCKER | DEGRADED | RISK
@@ -203,14 +245,11 @@ shortfall. Example:
 - Detail: <numbers + what's saturated>
 - Fix: <what to build / change>
 
-2. Alerts live in conversation only — there's no persistence shelf for them yet.
-Chris carries them forward manually.
-3. Re-fetch /factory/state at the start of any new module question and surface
-any obvious unresolved saturation (e.g. zero spare ingot capacity, generators
-already maxed) before recommending a new module. Don't propose builds that
-compound an open BLOCKER.
+Inline alerts are conversation-only — Chris carries them forward manually. The
+server doesn't yet know about hypothetical-future builds; it only sees what's
+in the save. (Predictive analysis is a follow-up enhancement.)
 
-Severity guide:
+Severity guide (shared with server-side alerts):
 - BLOCKER — the build doesn't work / a downstream module is starved.
 - DEGRADED — runs but underclocked, capped, or wasting capacity.
 - RISK — fine today, will break at the next phase / scale-up.

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -295,7 +295,8 @@ app.MapGet("/fs/browse", (string? path, string? filter, string? purpose) =>
 
 app.MapPost("/factory/ingest", async (
     IngestSaveRequest request, IMessageBus bus, IFactoryStateProvider provider,
-    ICatalogProvider catalog, ILoggerFactory loggerFactory) =>
+    ICatalogProvider catalog, FactoryAlertAnalysisService alertAnalysis,
+    ILoggerFactory loggerFactory, CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(request.SavePath))
         return Results.BadRequest(new { error = "SavePath is required." });
@@ -305,8 +306,22 @@ app.MapPost("/factory/ingest", async (
         var sw = System.Diagnostics.Stopwatch.StartNew();
         await bus.InvokeAsync<FactoryStateStatus>(new IngestSaveCommand(request.SavePath));
         sw.Stop();
-        loggerFactory.CreateLogger("FactoryIngestEndpoint")
-            .LogInformation("Ingested save in {Elapsed}ms", sw.ElapsedMilliseconds);
+        var ingestLogger = loggerFactory.CreateLogger("FactoryIngestEndpoint");
+        ingestLogger.LogInformation("Ingested save in {Elapsed}ms", sw.ElapsedMilliseconds);
+
+        // Run alert analysis post-ingest (#116). Best-effort: failures here
+        // are logged but never fail the ingest itself — the save loaded
+        // successfully, and alerts are an auxiliary surface.
+        try
+        {
+            var source = $"save:{System.IO.Path.GetFileNameWithoutExtension(request.SavePath)}";
+            await alertAnalysis.RunAsync(source, ct);
+        }
+        catch (Exception alertEx)
+        {
+            ingestLogger.LogWarning(alertEx, "Alert analysis failed post-ingest; ingest itself succeeded.");
+        }
+
         return Results.Ok(FactoryStateView.From(provider, catalog));
     }
     catch (FileNotFoundException ex)

--- a/src/ERP/Application/FactoryAlertAnalysisService.cs
+++ b/src/ERP/Application/FactoryAlertAnalysisService.cs
@@ -1,0 +1,237 @@
+using ERP.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Application;
+
+/// <summary>
+/// Post-ingest analysis pass that turns the current
+/// <see cref="LiveFactoryState"/> into <see cref="FactoryAlert"/> rows
+/// (#116, phase B). v1 is snapshot-only — looks at the loaded state as-is and
+/// flags any item whose total demand exceeds available supply. Delta detection
+/// (comparing against the previous ingest to call out "this WILL max out
+/// after the new build") is intentionally deferred to a follow-up.
+/// </summary>
+public sealed class FactoryAlertAnalysisService
+{
+    // Coverage thresholds for severity assignment. Tunable from real-world
+    // use — these are first-cut guesses.
+    private const decimal BlockerThreshold = 0.95m; // supply < 95% of demand
+    private const decimal RiskThreshold = 1.05m;    // supply < 105% of demand → at capacity
+
+    private readonly IFactoryStateProvider _stateProvider;
+    private readonly ICatalogProvider _catalog;
+    private readonly IFactoryAlertRepository _alerts;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<FactoryAlertAnalysisService>? _logger;
+
+    public FactoryAlertAnalysisService(
+        IFactoryStateProvider stateProvider,
+        ICatalogProvider catalog,
+        IFactoryAlertRepository alerts,
+        TimeProvider clock,
+        ILogger<FactoryAlertAnalysisService>? logger = null)
+    {
+        _stateProvider = stateProvider;
+        _catalog = catalog;
+        _alerts = alerts;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run the analysis against the current factory state and reconcile alerts:
+    /// refresh existing active rows with new numbers, create new rows for newly
+    /// flagged items, mark previously-active rows resolved when their condition
+    /// no longer holds.
+    /// </summary>
+    /// <param name="source">Free-form context tag stored on new alerts (e.g.
+    /// <c>"save:Beta Game_autosave_1"</c>).</param>
+    public async Task RunAsync(string source, CancellationToken cancellationToken = default)
+    {
+        if (!_stateProvider.IsLoaded)
+        {
+            _logger?.LogDebug("Skipping alert analysis — factory state not loaded.");
+            return;
+        }
+
+        var state = _stateProvider.Current;
+        var candidates = ComputeBottlenecks(state, _catalog);
+        var now = _clock.GetUtcNow().UtcDateTime;
+
+        var existing = await _alerts.ListActiveAsync(cancellationToken);
+        var existingByKey = existing.ToDictionary(a => a.Key);
+        var candidatesByKey = candidates.ToDictionary(c => c.Key);
+
+        // Resolve previously-active alerts whose condition no longer holds.
+        foreach (var alert in existing)
+        {
+            if (!candidatesByKey.ContainsKey(alert.Key))
+            {
+                alert.Resolve(now);
+            }
+        }
+
+        // Refresh or create per current candidates.
+        var refreshed = 0;
+        var created = 0;
+        foreach (var c in candidates)
+        {
+            if (existingByKey.TryGetValue(c.Key, out var existingAlert))
+            {
+                existingAlert.Refresh(c.Title, c.Detail, c.Fix);
+                refreshed++;
+            }
+            else
+            {
+                var fresh = new FactoryAlert(
+                    id: Guid.NewGuid(),
+                    key: c.Key,
+                    severity: c.Severity,
+                    source: source,
+                    title: c.Title,
+                    detail: c.Detail,
+                    fix: c.Fix,
+                    createdUtc: now);
+                await _alerts.AddAsync(fresh, cancellationToken);
+                created++;
+            }
+        }
+
+        await _alerts.SaveChangesAsync(cancellationToken);
+
+        _logger?.LogInformation(
+            "Alert analysis: {Existing} active before, {Candidates} candidates now ({Created} created, {Refreshed} refreshed)",
+            existing.Count, candidates.Count, created, refreshed);
+    }
+
+    /// <summary>
+    /// Pure analysis function: derive bottleneck candidates from a snapshot.
+    /// No persistence, no time. Public + static so tests can exercise it with
+    /// in-memory fixtures.
+    /// </summary>
+    public static IReadOnlyList<AlertCandidate> ComputeBottlenecks(
+        LiveFactoryState state, ICatalogProvider catalog)
+    {
+        var nodesByRef = state.ResourceNodes
+            .Where(n => !string.IsNullOrEmpty(n.Reference))
+            .ToDictionary(n => n.Reference);
+
+        var supply = new Dictionary<ItemId, decimal>();
+        var demand = new Dictionary<ItemId, decimal>();
+
+        // Miner extraction → supply for the bound node's resource.
+        foreach (var miner in state.Miners)
+        {
+            if (string.IsNullOrEmpty(miner.ResourceNodeReference)) continue;
+            if (!nodesByRef.TryGetValue(miner.ResourceNodeReference, out var node)) continue;
+            if (node.Resource is null) continue;
+
+            var rate = ComputeMinerRatePerMinute(miner.Tier, node.Purity);
+            if (rate > 0)
+                Add(supply, node.Resource.Value, rate);
+        }
+
+        // Production buildings with recipes → supply (outputs) + demand (inputs).
+        foreach (var b in state.Buildings)
+        {
+            if (b.Recipe is null) continue;
+            var recipe = catalog.FindRecipe(b.Recipe.Value);
+            if (recipe is null) continue;
+            if (recipe.Duration.TotalSeconds <= 0) continue;
+
+            var perMinuteFactor = b.ClockSpeed * 60m / (decimal)recipe.Duration.TotalSeconds;
+
+            foreach (var o in recipe.Outputs)
+                Add(supply, o.Item, o.Quantity * perMinuteFactor);
+            foreach (var i in recipe.Inputs)
+                Add(demand, i.Item, i.Quantity * perMinuteFactor);
+        }
+
+        var candidates = new List<AlertCandidate>();
+        foreach (var (item, dmd) in demand)
+        {
+            if (dmd <= 0) continue;
+            var sup = supply.TryGetValue(item, out var s) ? s : 0m;
+            var ratio = sup / dmd;
+
+            if (ratio < BlockerThreshold)
+            {
+                candidates.Add(BuildBlockerCandidate(item, sup, dmd, catalog));
+            }
+            else if (ratio < RiskThreshold)
+            {
+                candidates.Add(BuildRiskCandidate(item, sup, dmd, catalog));
+            }
+            // ratio ≥ RiskThreshold → no alert (comfortable headroom)
+        }
+
+        return candidates;
+    }
+
+    private static AlertCandidate BuildBlockerCandidate(
+        ItemId item, decimal supply, decimal demand, ICatalogProvider catalog)
+    {
+        var name = catalog.FindItem(item)?.Name ?? item.Value;
+        var shortfall = demand - supply;
+        var coverage = demand > 0 ? supply / demand : 0;
+        return new AlertCandidate(
+            Key: $"blocker:{item.Value}",
+            Severity: AlertSeverity.Blocker,
+            Title: $"{name} supply shortfall",
+            Detail: $"Demand {demand:F1}/min, supply {supply:F1}/min — {shortfall:F1}/min short ({coverage:P0} coverage).",
+            Fix: $"Add more {name} production or reduce downstream demand by {shortfall:F1}/min.");
+    }
+
+    private static AlertCandidate BuildRiskCandidate(
+        ItemId item, decimal supply, decimal demand, ICatalogProvider catalog)
+    {
+        var name = catalog.FindItem(item)?.Name ?? item.Value;
+        var headroom = supply - demand;
+        var coverage = demand > 0 ? supply / demand : 0;
+        return new AlertCandidate(
+            Key: $"risk:{item.Value}",
+            Severity: AlertSeverity.Risk,
+            Title: $"{name} at capacity",
+            Detail: $"Demand {demand:F1}/min, supply {supply:F1}/min — only {headroom:F1}/min headroom ({coverage:P0}).",
+            Fix: $"Scale {name} production before adding new downstream consumers.");
+    }
+
+    /// <summary>
+    /// In-game extraction rate per miner. Mk1/Mk2/Mk3 baseline (60 / 120 / 240
+    /// per minute on a Normal-purity node) × purity multiplier
+    /// (Impure ×0.5, Normal ×1.0, Pure ×2.0). Unknown purity defaults to
+    /// Normal — wrong is better than zero when the node tagging is incomplete.
+    /// Clock-speed overrides on miners aren't captured in
+    /// <see cref="Miner"/> yet, so v1 assumes 100%.
+    /// </summary>
+    private static decimal ComputeMinerRatePerMinute(MinerTier tier, NodePurity purity)
+    {
+        var baseRate = tier switch
+        {
+            MinerTier.Mk1 => 60m,
+            MinerTier.Mk2 => 120m,
+            MinerTier.Mk3 => 240m,
+            _ => 0m,
+        };
+        var purityMult = purity switch
+        {
+            NodePurity.Impure => 0.5m,
+            NodePurity.Pure => 2.0m,
+            _ => 1.0m, // Normal + Unknown fall back to Normal baseline
+        };
+        return baseRate * purityMult;
+    }
+
+    private static void Add(Dictionary<ItemId, decimal> map, ItemId key, decimal amount)
+    {
+        map[key] = map.TryGetValue(key, out var existing) ? existing + amount : amount;
+    }
+}
+
+/// <summary>A bottleneck flagged by the analysis pass — not yet persisted as an alert.</summary>
+public sealed record AlertCandidate(
+    string Key,
+    AlertSeverity Severity,
+    string Title,
+    string Detail,
+    string Fix);

--- a/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/ERP/Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -43,6 +43,9 @@ public static class InfrastructureServiceCollectionExtensions
                 _ => new RecursiveRecipePlanner(catalog),
             };
         });
+        // Post-ingest bottleneck analysis (#116, phase B). Scoped because it
+        // depends on the scoped IFactoryAlertRepository (EF DbContext).
+        services.AddScoped<FactoryAlertAnalysisService>();
         return services;
     }
 }

--- a/test/ERP/Application.Tests/FactoryAlertAnalysisServiceTests.cs
+++ b/test/ERP/Application.Tests/FactoryAlertAnalysisServiceTests.cs
@@ -1,0 +1,257 @@
+using ERP.Application;
+using ERP.Domain;
+
+namespace ERP.Application.Tests;
+
+/// <summary>
+/// Tests for the heuristic bottleneck analysis (#116, phase B). Split into
+/// pure-function tests against <see cref="FactoryAlertAnalysisService.ComputeBottlenecks"/>
+/// and orchestration tests against <see cref="FactoryAlertAnalysisService.RunAsync"/>
+/// via fake providers.
+/// </summary>
+public class FactoryAlertAnalysisServiceTests
+{
+    private static readonly BuildingId SmelterId = new("Build_SmelterMk1_C");
+    private static readonly BuildingId ConstructorId = new("Build_ConstructorMk1_C");
+
+    private static readonly ItemId IronOre = new("Desc_OreIron_C");
+    private static readonly ItemId IronIngot = new("Desc_IronIngot_C");
+    private static readonly ItemId IronPlate = new("Desc_IronPlate_C");
+
+    private static readonly Recipe IronIngotRecipe = new(
+        new RecipeId("Recipe_IngotIron_C"),
+        "Iron Ingot",
+        SmelterId,
+        Inputs: [new ItemAmount(IronOre, 1)],
+        Outputs: [new ItemAmount(IronIngot, 1)],
+        Duration: TimeSpan.FromSeconds(2));
+
+    private static readonly Recipe IronPlateRecipe = new(
+        new RecipeId("Recipe_IronPlate_C"),
+        "Iron Plate",
+        ConstructorId,
+        Inputs: [new ItemAmount(IronIngot, 3)],
+        Outputs: [new ItemAmount(IronPlate, 2)],
+        Duration: TimeSpan.FromSeconds(6));
+
+    [Fact]
+    public void Empty_State_Produces_No_Candidates()
+    {
+        var catalog = new FakeCatalog([], []);
+        var state = LiveFactoryState.Empty("empty");
+
+        var result = FactoryAlertAnalysisService.ComputeBottlenecks(state, catalog);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Smelter_With_No_Ore_Supply_Flags_Blocker_On_Iron_Ore()
+    {
+        // One smelter running Iron Ingot at 100%, no miners feeding it.
+        //   demand: 30 ore/min
+        //   supply: 0
+        //   → BLOCKER for iron ore (and a secondary alert for iron ingot if no
+        //     downstream demand exists — but there's none here, so ingot is silent).
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
+        var state = StateWith(
+            buildings: [new ProductionBuilding("smelter-1", SmelterId, default, IronIngotRecipe.Id)]);
+
+        var result = FactoryAlertAnalysisService.ComputeBottlenecks(state, catalog);
+
+        var oreAlert = Assert.Single(result);
+        Assert.Equal(AlertSeverity.Blocker, oreAlert.Severity);
+        Assert.Equal("blocker:Desc_OreIron_C", oreAlert.Key);
+        Assert.Contains("Iron Ore", oreAlert.Title);
+        Assert.Contains("30", oreAlert.Detail);
+    }
+
+    [Fact]
+    public void Miner_On_Normal_Node_Matches_Smelter_Demand_No_Alert()
+    {
+        // Mk1 miner on a Normal node = 60 ore/min. Two smelters consume 60 ore/min.
+        // Ratio = 1.0, in (0.95, 1.05) — flags RISK ("at capacity") but not BLOCKER.
+        // Note: at-capacity is intentionally noisy; pioneers will iterate.
+        var nodeRef = "node-iron-A";
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
+        var state = StateWith(
+            nodes: [new ResourceNode(nodeRef, ResourceNodeKind.MiningNode, IronOre, NodePurity.Normal, default)],
+            miners: [new Miner("miner-1", MinerTier.Mk1, default, nodeRef)],
+            buildings: [
+                new ProductionBuilding("smelter-1", SmelterId, default, IronIngotRecipe.Id),
+                new ProductionBuilding("smelter-2", SmelterId, default, IronIngotRecipe.Id),
+            ]);
+
+        var result = FactoryAlertAnalysisService.ComputeBottlenecks(state, catalog);
+
+        var oreAlert = Assert.Single(result);
+        Assert.Equal(AlertSeverity.Risk, oreAlert.Severity);
+        Assert.Contains("at capacity", oreAlert.Title);
+    }
+
+    [Fact]
+    public void Miner_On_Pure_Node_Has_Headroom_No_Alert()
+    {
+        // Mk1 miner on Pure node = 120 ore/min. One smelter needs 30. 4x headroom.
+        var nodeRef = "node-iron-pure";
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
+        var state = StateWith(
+            nodes: [new ResourceNode(nodeRef, ResourceNodeKind.MiningNode, IronOre, NodePurity.Pure, default)],
+            miners: [new Miner("miner-1", MinerTier.Mk1, default, nodeRef)],
+            buildings: [new ProductionBuilding("smelter-1", SmelterId, default, IronIngotRecipe.Id)]);
+
+        var result = FactoryAlertAnalysisService.ComputeBottlenecks(state, catalog);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task RunAsync_Resolves_Alert_That_No_Longer_Matches()
+    {
+        // Previously-active alert with a key the analysis no longer produces
+        // → must be Resolved on the next run.
+        var catalog = new FakeCatalog([], [], []);
+        var stateProvider = new FakeStateProvider(LiveFactoryState.Empty("empty"));
+        var repo = new FakeAlertRepository();
+        var existing = new FactoryAlert(
+            Guid.NewGuid(), "blocker:obsolete", AlertSeverity.Blocker,
+            "save:old", "Old shortfall", "Stale detail", "Stale fix", DateTime.UtcNow.AddHours(-1));
+        await repo.AddAsync(existing);
+        await repo.SaveChangesAsync();
+
+        var svc = new FactoryAlertAnalysisService(stateProvider, catalog, repo, TimeProvider.System);
+        await svc.RunAsync(source: "save:test");
+
+        Assert.NotNull(existing.ResolvedUtc);
+        var active = await repo.ListActiveAsync();
+        Assert.Empty(active);
+    }
+
+    [Fact]
+    public async Task RunAsync_Refreshes_Existing_Active_Alert_For_Same_Key()
+    {
+        // Same item still flagged on the next run → existing row gets refreshed
+        // text, no new row created.
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
+        var state = StateWith(
+            buildings: [new ProductionBuilding("smelter-1", SmelterId, default, IronIngotRecipe.Id)]);
+        var stateProvider = new FakeStateProvider(state);
+        var repo = new FakeAlertRepository();
+
+        // Seed with an existing active alert for the same key.
+        var preexisting = new FactoryAlert(
+            Guid.NewGuid(), "blocker:Desc_OreIron_C", AlertSeverity.Blocker,
+            "save:prior", "Old title", "Old detail", "Old fix", DateTime.UtcNow.AddHours(-1));
+        await repo.AddAsync(preexisting);
+        await repo.SaveChangesAsync();
+
+        var svc = new FactoryAlertAnalysisService(stateProvider, catalog, repo, TimeProvider.System);
+        await svc.RunAsync(source: "save:test");
+
+        // Same id (refreshed, not replaced).
+        var active = await repo.ListActiveAsync();
+        var single = Assert.Single(active);
+        Assert.Equal(preexisting.Id, single.Id);
+        // Title and detail come from the fresh analysis.
+        Assert.Equal("Iron Ore supply shortfall", single.Title);
+        Assert.Contains("30", single.Detail);
+        // Source stays at the original — Refresh does not rewrite it.
+        Assert.Equal("save:prior", single.Source);
+    }
+
+    // ----- helpers ----------------------------------------------------------
+
+    private static LiveFactoryState StateWith(
+        IReadOnlyList<ResourceNode>? nodes = null,
+        IReadOnlyList<Miner>? miners = null,
+        IReadOnlyList<ProductionBuilding>? buildings = null) => new(
+            Save: new SaveMetadata("test", 0, 0, TimeSpan.Zero, DateTime.UtcNow),
+            ResourceNodes: nodes ?? [],
+            Miners: miners ?? [],
+            Buildings: buildings ?? [],
+            Belts: [],
+            Generators: [],
+            Warnings: []);
+
+    private sealed class FakeStateProvider(LiveFactoryState state) : IFactoryStateProvider
+    {
+        public bool IsLoaded => true;
+        public string? Source => "fake";
+        public LiveFactoryState Current => state;
+        public FactoryStateStatus GetStatus() => throw new NotSupportedException();
+        public FactoryStateStatus LoadFromPath(string savePath) => throw new NotSupportedException();
+        public FactoryStateStatus Refresh() => throw new NotSupportedException();
+    }
+
+    private sealed class FakeAlertRepository : IFactoryAlertRepository
+    {
+        private readonly List<FactoryAlert> _alerts = [];
+
+        public Task<IReadOnlyList<FactoryAlert>> ListActiveAsync(CancellationToken ct = default)
+        {
+            IReadOnlyList<FactoryAlert> result = _alerts
+                .Where(a => a.IsActive)
+                .OrderByDescending(a => a.Severity)
+                .ThenBy(a => a.CreatedUtc)
+                .ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<FactoryAlert?> GetAsync(Guid id, CancellationToken ct = default) =>
+            Task.FromResult(_alerts.FirstOrDefault(a => a.Id == id));
+
+        public Task<FactoryAlert?> FindActiveByKeyAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult(_alerts.FirstOrDefault(a => a.IsActive && a.Key == key));
+
+        public Task AddAsync(FactoryAlert alert, CancellationToken ct = default)
+        {
+            _alerts.Add(alert);
+            return Task.CompletedTask;
+        }
+
+        public Task<int> SaveChangesAsync(CancellationToken ct = default) => Task.FromResult(0);
+    }
+
+    private sealed class FakeCatalog : ICatalogProvider
+    {
+        private readonly Dictionary<BuildingId, Building> _buildings;
+        private readonly Dictionary<RecipeId, Recipe> _recipes;
+        private readonly Dictionary<ItemId, Item> _items;
+
+        public FakeCatalog(
+            IEnumerable<Building> buildings,
+            IEnumerable<Recipe> recipes,
+            IEnumerable<Item>? items = null)
+        {
+            _buildings = buildings.ToDictionary(b => b.Id);
+            _recipes = recipes.ToDictionary(r => r.Id);
+            _items = (items ?? []).ToDictionary(i => i.Id);
+        }
+
+        public bool IsLoaded => true;
+        public string? Source => "fake";
+        public IReadOnlyList<Item> Items => _items.Values.ToList();
+        public IReadOnlyList<Building> Buildings => _buildings.Values.ToList();
+        public IReadOnlyList<Recipe> Recipes => _recipes.Values.ToList();
+
+        public Item? FindItem(ItemId id) => _items.TryGetValue(id, out var i) ? i : null;
+        public Building? FindBuilding(BuildingId id) => _buildings.TryGetValue(id, out var b) ? b : null;
+        public Recipe? FindRecipe(RecipeId id) => _recipes.TryGetValue(id, out var r) ? r : null;
+        public Recipe? FindDefaultProducerOf(ItemId item) => _recipes.Values.FirstOrDefault(r => r.Outputs.Any(o => o.Item == item));
+        public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) => _recipes.Values.Where(r => r.Outputs.Any(o => o.Item == item)).ToList();
+        public CatalogueStatus GetStatus() => throw new NotSupportedException();
+        public CatalogueStatus LoadFromPath(string docsJsonPath) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary

Stacks on **#120** (phase A). Targets that branch as the base — merge #120 first, then this rebases automatically onto main.

After ingest, the API now runs a snapshot heuristic over the loaded `LiveFactoryState`, persists the resulting bottlenecks via `IFactoryAlertRepository`, and auto-resolves alerts whose condition no longer holds. ADA fetches `/factory/alerts` at the start of every turn and leads with the active list before answering.

End-to-end: **build something → save the game → POST `/factory/ingest` → next ADA turn surfaces any new shortfall**.

## v1 scope (intentionally narrow — usable now, refined later)

- **Snapshot only** — no ingest-to-ingest delta detection. The predictive *"this WILL max out"* framing is deferred to a follow-up. v1 still triggers as soon as you ingest the save with the new build.
- **Two severities**: BLOCKER (supply < 95% of demand) and RISK (95–105% coverage, *"at capacity"*).
- **Covered**: miner extraction (tier × purity baseline) + buildings running recipes (inputs + outputs at clock speed).
- **Skipped**: generators (no recipe model in `LiveFactoryState`), miner clock-speed overrides (not in domain model), targets/plans-aware analysis.

## Files

**Application**
- `FactoryAlertAnalysisService` — split into a pure static `ComputeBottlenecks(state, catalog)` (testable in isolation) and an instance `RunAsync(source, ct)` that orchestrates refresh / create / resolve against `IFactoryAlertRepository`.

**Infrastructure** — `AddErpInfrastructure` registers the new service scoped.

**API** — `/factory/ingest` runs the analysis post-ingest in a best-effort `try`/`catch`. Alert failures never fail the ingest itself.

**ADA agent** — new *"Server-side alerts — `GET /factory/alerts`"* section in `ada.md` with instructions to fetch first, lead with active alerts (BLOCKER first), and not re-derive numbers the server already gave. Existing inline `[ALERT]` block kept for breaches ADA spots during her own analysis (e.g. proposed-but-not-built modules).

**Tests** — 5 new in `Application.Tests`:
- Empty state → no candidates.
- Smelter consuming with no upstream miner → BLOCKER on iron ore.
- Mk1 miner on Normal node + 2 smelters → RISK (at capacity).
- Mk1 miner on Pure node + 1 smelter → no alert (4× headroom).
- `RunAsync` resolves an alert whose key isn't in the new candidates.
- `RunAsync` refreshes (not duplicates) an existing active alert with the same key.

## Verification

- [x] `./build.sh TestNoUi` passes locally.
- [ ] CI passes the full lane.
- [ ] **Manual smoke after merge**: ingest a save, hit `GET /factory/alerts`, confirm at least one row appears for an actual bottleneck (e.g. iron ore at 80% coverage).
- [ ] **Manual ADA check**: ask ADA something benign, confirm she opens with active alerts before answering.

## What's left for #116

- **Phase C** (separate PR): dismissal endpoint (`POST /factory/alerts/{id}/dismiss`) + plumbing for ADA to acknowledge dismissed alerts.
- **Future**: delta-based predictive analysis ("this WILL max out"). LP-driven analysis (replaces heuristic) if/when the heuristic feels too noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)