### PR TITLE
feat(alerts): POST /factory/alerts/{id}/dismiss (#116, phase C)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -120,11 +120,26 @@ app.MapGet("/factory/saves", () =>
 
 // Active factory bottleneck alerts (#116). Read by the ADA agent so she leads
 // with active alerts on each user turn. Empty list when nothing's flagged.
-// Writes happen post-ingest via the analysis service (separate PR).
+// Writes happen post-ingest via the analysis service.
 app.MapGet("/factory/alerts", async (IFactoryAlertRepository repo, CancellationToken ct) =>
 {
     var alerts = await repo.ListActiveAsync(ct);
     return Results.Ok(alerts.Select(FactoryAlertView.From).ToList());
+});
+
+// Manual dismissal (#116, phase C). Marks an alert as dismissed; subsequent
+// analysis passes that re-detect the same condition will create a *new* alert
+// rather than re-fire the dismissed one. Idempotent — re-dismissing an
+// already-dismissed alert is a 204, not an error.
+app.MapPost("/factory/alerts/{id:guid}/dismiss", async (
+    Guid id, IFactoryAlertRepository repo, TimeProvider clock, CancellationToken ct) =>
+{
+    var alert = await repo.GetAsync(id, ct);
+    if (alert is null) return Results.NotFound();
+
+    alert.Dismiss(clock.GetUtcNow().UtcDateTime);
+    await repo.SaveChangesAsync(ct);
+    return Results.NoContent();
 });
 
 // Backing endpoint for the in-app filesystem picker (issue #84). Lists the

--- a/test/ApiService.Tests/FactoryAlertDismissalEndpointTests.cs
+++ b/test/ApiService.Tests/FactoryAlertDismissalEndpointTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using ERP.Application;
+using ERP.Domain;
+using ERP.Infrastructure.Persistence;
+using ERP.Infrastructure.Persistence.Repositories;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ApiService.Tests;
+
+/// <summary>
+/// Integration tests for the dismissal endpoint (#116, phase C). Boots the
+/// real <see cref="Program"/> via <see cref="WebApplicationFactory{TEntryPoint}"/>
+/// against a per-test SQLite file. Seeds an alert directly through the
+/// repository (no create endpoint exists by design — alerts are written
+/// by the analysis service), then POSTs the dismiss endpoint and verifies
+/// state.
+/// </summary>
+public sealed class FactoryAlertDismissalEndpointTests : IClassFixture<FactoryAlertDismissalEndpointTests.AlertsApiFactory>
+{
+    private readonly AlertsApiFactory _factory;
+
+    public FactoryAlertDismissalEndpointTests(AlertsApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Dismiss_persists_DismissedUtc_and_removes_from_active_list()
+    {
+        var alertId = Guid.NewGuid();
+        await SeedAlertAsync(new FactoryAlert(
+            id: alertId,
+            key: "blocker:Desc_OreIron_C",
+            severity: AlertSeverity.Blocker,
+            source: "save:test",
+            title: "Iron Ore supply shortfall",
+            detail: "Demand 450/min, supply 360/min — 90/min short.",
+            fix: "Add 3 MK1 miners.",
+            createdUtc: DateTime.UtcNow));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/factory/alerts/{alertId}/dismiss", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        // Subsequent GET /factory/alerts must not include this row.
+        var listResponse = await client.GetAsync("/factory/alerts");
+        var body = await listResponse.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        Assert.DoesNotContain(alertId.ToString(), body);
+
+        // Direct DB check — DismissedUtc set.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanDbContext>();
+        var stored = await db.FactoryAlerts.AsNoTracking().FirstAsync(a => a.Id == alertId);
+        Assert.NotNull(stored.DismissedUtc);
+    }
+
+    [Fact]
+    public async Task Dismiss_unknown_id_returns_404()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/factory/alerts/{Guid.NewGuid()}/dismiss", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Dismiss_is_idempotent()
+    {
+        // Dismissing the same alert twice is a 204 both times — the user
+        // double-clicking the dismiss button shouldn't surface an error.
+        var alertId = Guid.NewGuid();
+        await SeedAlertAsync(new FactoryAlert(
+            id: alertId,
+            key: "risk:Desc_Coal_C",
+            severity: AlertSeverity.Risk,
+            source: "save:test",
+            title: "Coal at capacity",
+            detail: "Demand 30/min, supply 30/min — 0/min headroom.",
+            fix: "Scale coal extraction.",
+            createdUtc: DateTime.UtcNow));
+
+        var client = _factory.CreateClient();
+        var first = await client.PostAsync($"/factory/alerts/{alertId}/dismiss", content: null);
+        var second = await client.PostAsync($"/factory/alerts/{alertId}/dismiss", content: null);
+
+        Assert.Equal(HttpStatusCode.NoContent, first.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, second.StatusCode);
+    }
+
+    private async Task SeedAlertAsync(FactoryAlert alert)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IFactoryAlertRepository>();
+        await repo.AddAsync(alert);
+        await repo.SaveChangesAsync();
+    }
+
+    public sealed class AlertsApiFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"erp-alerts-tests-{Guid.NewGuid():N}.db");
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Persistence:Provider"] = "sqlite",
+                    ["ConnectionStrings:Plans"] = $"Data Source={_dbPath}",
+                });
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase C of #116. Stacks on #121 (analysis + ADA wiring) — manual dismissal endpoint that lets the user silence a known/accepted alert without \"fixing\" it.

End-to-end after the trio (A + B+D + C) lands: alerts appear automatically post-ingest, ADA surfaces them, you can `curl -X POST /factory/alerts/{id}/dismiss` (or eventually click in a UI) to silence one. Re-fires by the analysis pass create a *new* alert if the condition recurs — dismissals don't suppress permanently.

## Endpoint

```
POST /factory/alerts/{id}/dismiss
```

- **204 NoContent** on success — alert is marked `DismissedUtc=<now>` and drops off `GET /factory/alerts`.
- **404 NotFound** if the id is unknown.
- **Idempotent**: re-dismissing returns 204 (the user double-clicking shouldn't surface an error).

The repository's `FindActiveByKey` filter (added in Phase A) already excludes dismissed rows, so the analysis service won't refresh a dismissed alert — it'll create a new one if and when the condition recurs.

## Tests

3 new integration tests in `test/ApiService.Tests/FactoryAlertDismissalEndpointTests.cs`, using the existing `WebApplicationFactory<Program>` pattern from `PlanShareEndpointsTests`:
- Dismiss persists `DismissedUtc` and removes the alert from `GET /factory/alerts`.
- Dismiss with unknown id returns 404.
- Dismiss is idempotent.

## Heads-up about CI coverage

`ApiService.Tests` is currently **outside the slnx** (per commit `c94658e refactor(tests): remove unnecessary project entry for ApiService.Tests`), so the build.sh `TestNoUi` lane skips it — meaning **CI won't actually run these tests** until the project is re-added. They pass locally via `dotnet test test/ApiService.Tests/ApiService.Tests.csproj`.

If you want CI to cover them, the fix is to re-add the project to `ERP.Satisfactory.slnx`:

```xml
<Folder Name=\"/test/ApiService.Tests/\">
  <Project Path=\"test/ApiService.Tests/ApiService.Tests.csproj\" />
</Folder>
```

Happy to do that as part of this PR or leave it untouched — your call.

## Verification

- [x] `dotnet test test/ApiService.Tests/ApiService.Tests.csproj` passes (5/5: 2 existing + 3 new).
- [ ] CI passes the full lane (excluding `ApiService.Tests` per slnx state).
- [ ] Manual smoke after merge: seed an alert (via analysis service post-ingest), POST dismiss, confirm 204 + alert disappears from GET.

## #116 wrap-up

Phase C completes the core scope from the issue:
- ✅ Phase A — persistence + read endpoint (#120)
- ✅ Phase B+D — analysis service + ADA wiring (#121)
- ✅ Phase C — manual dismissal (this PR)
- 🔜 **Deferred**: delta-based predictive analysis (\"this WILL max out\"). The snapshot heuristic from Phase B is the v1 — refine if real-world play shows it's too noisy or misses things.

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)