### PR TITLE
release: bump to 0.3 — LP solver + proactive alerts milestone

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2",
+  "version": "0.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Summary

Bump `version.json` from `0.2` → `0.3`. Single-line config change; CI's auto-release job will tag **v0.3.0** on the merge commit.

## Why 0.3 (not 0.2.11)

The 0.2 line conceptually represented \"plan persistence & sharing\" (the milestone that landed in #109). Since then we've shipped:

- **#88** — LP solver via Google OR-Tools (opt-in `IRecipePlanner`, alt-recipe selection, byproduct handling, capped inputs).
- **#116** — Proactive bottleneck alerts (post-ingest analysis, EF persistence, ADA leads with active alerts, manual dismissal).
- **#102** — Path-filter CI triggers (doc-only PRs skip heavy jobs while keeping required checks green).
- **#112** — Retired `.satisfactory/stocktake.md`.
- Self-hosted runner migration.

That's a meaningful enough leap that a fresh minor (0.3) tells the story better than v0.2.11 would.

## Heads-up about release history

The 0.2 line has had **no GitHub release** at all — every recent main push had its CI run cancelled by the next push (`concurrency.cancel-in-progress: true` in the workflow, which is correct for PR iteration but skipped the auto-release on rapid-fire merges this week). v0.3.0 will be the first new release since **v0.1.9** (2026-05-13).

Once this merges and CI completes, the Release job will:
1. Read `0.3` from `version.json` + git height from nbgv → produce `0.3.0`
2. `gh release create v0.3.0 --generate-notes --target <sha>` — auto-builds notes from commits since v0.1.9
3. Tag + release land on GitHub

## Test plan

- [x] Single-line config change. Local `dotnet nbgv get-version` confirms it'd compute 0.3.0 after merge.
- [ ] CI passes the full lane (path filter from #113 routes this as code-touching since `version.json` is in the build-input list).
- [ ] After merge: confirm v0.3.0 appears in `gh release list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)