### PR TITLE
fix(ci): release target no longer redundantly runs UI tests

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -246,7 +246,14 @@ class Build : NukeBuild
 
     Target Release => _ => _
         .Description("Creates a GitHub release for the current commit. Auto-runs on push to main.")
-        .DependsOn(Test)
+        // No test dep — CI's release job is gated on the `build-and-test`,
+        // `lint`, `migration-drift`, and `postgres-smoke` jobs via `needs:`,
+        // so the tests already ran. Depending on `Test` here would
+        // redundantly install Playwright + Chromium on the release runner
+        // and hang on the host-deps step. Re-add a `DependsOn(TestNoUi)`
+        // if/when we want this target to be safe to invoke locally.
+        // Backlog issue tracks running UI tests in CI proper.
+        .DependsOn(Compile)
         .OnlyWhenStatic(() => IsServerBuild
                               && GitHubActions is not null
                               && GitHubActions.Ref == "refs/heads/main"


### PR DESCRIPTION
## Summary

`Target Release` in `build/Build.cs` used to `.DependsOn(Test)`, which transitively pulls in `InstallPlaywrightBrowsers` + the full UI test suite. The Release job's runner is plain `ubuntu-latest` (no `sudo apt-get install --with-deps chromium`), so Playwright's host-deps install hangs — explaining why **no auto-release has cut since v0.1.9** despite many main pushes.

CI's release job already gates on `lint`, `build-and-test`, `migration-drift`, and `postgres-smoke` via `needs:`, so re-running tests from inside the NUKE Release target was redundant anyway.

Dropping the dep to `Compile`. v0.3.0 was cut manually for `ea8e67b` to unblock; this fix means subsequent auto-releases will Just Work.

## Followup

Filed a backlog issue for "wire UI tests into CI properly" so the Playwright lane comes back when it's worth the runner cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)