### PR TITLE
feat(planner): enriched infeasibility diagnostics (#8, phase 1)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -877,17 +877,43 @@ public sealed record SavedPlanDto(
             p.Available.Select(a => new AvailabilityDto(a.Item.Value, a.ItemsPerMinute)).ToList());
 }
 
+/// <summary>Diagnostic entry for an item the planner couldn't supply (#8).
+/// Existing <c>ItemId</c>, <c>ItemName</c>, <c>ItemsPerMinute</c> fields kept
+/// so older JSON readers keep working; new <c>Reason</c> + alternate-recipe
+/// + top-consumer arrays surface the actionable info.</summary>
+public sealed record MissingInputDto(
+    string ItemId,
+    string ItemName,
+    decimal ItemsPerMinute,
+    string Reason,
+    IReadOnlyList<RecipeRefDto> CouldBeProducedBy,
+    IReadOnlyList<RecipeRefDto> TopConsumers);
+
+public sealed record RecipeRefDto(string Id, string Name);
+
 public sealed record PlanDto(
     bool IsFeasible,
     IReadOnlyList<StepDto> Steps,
     decimal TotalPowerMw,
     IReadOnlyList<AmountDto> RawInputsConsumed,
-    IReadOnlyList<AmountDto> MissingInputs)
+    IReadOnlyList<MissingInputDto> MissingInputs)
 {
     public static PlanDto From(ProductionPlan plan, ICatalogProvider catalog)
     {
         AmountDto ToAmount(ItemAmount a) =>
             new(a.Item.Value, catalog.FindItem(a.Item)?.Name ?? a.Item.Value, Math.Round(a.Quantity, 4));
+
+        RecipeRefDto ToRecipeRef(RecipeId id) =>
+            new(id.Value, catalog.FindRecipe(id)?.Name ?? id.Value);
+
+        MissingInputDto ToMissing(InfeasibleItem m) =>
+            new(
+                ItemId: m.Item.Value,
+                ItemName: catalog.FindItem(m.Item)?.Name ?? m.Item.Value,
+                ItemsPerMinute: Math.Round(m.QuantityShort, 4),
+                Reason: m.Reason,
+                CouldBeProducedBy: m.CouldBeProducedBy.Select(ToRecipeRef).ToList(),
+                TopConsumers: m.TopConsumers.Select(ToRecipeRef).ToList());
 
         var steps = plan.Steps.Select(s => new StepDto(
             s.Recipe.Id.Value,
@@ -904,6 +930,6 @@ public sealed record PlanDto(
             Steps: steps,
             TotalPowerMw: Math.Round(steps.Sum(s => s.PowerMw), 4),
             RawInputsConsumed: plan.RawInputsConsumed.Select(ToAmount).ToList(),
-            MissingInputs: plan.MissingInputs.Select(ToAmount).ToList());
+            MissingInputs: plan.MissingInputs.Select(ToMissing).ToList());
     }
 }

--- a/src/ERP/Application/Queries/PlanProduction/InfeasibilityDiagnostics.cs
+++ b/src/ERP/Application/Queries/PlanProduction/InfeasibilityDiagnostics.cs
@@ -1,0 +1,85 @@
+using ERP.Domain;
+
+namespace ERP.Application.Queries.PlanProduction;
+
+/// <summary>
+/// Shared post-solve helper that turns the raw shortfall map both planners
+/// produce into <see cref="InfeasibleItem"/> records with reason + alternate
+/// + top-consumer enrichment (#8). Lives in Application alongside the planner
+/// so both <c>RecursiveRecipePlanner</c> and the LP adapter can call it.
+/// </summary>
+public static class InfeasibilityDiagnostics
+{
+    /// <summary>Cap on the top-consumers list — five is enough to point a finger.</summary>
+    private const int MaxTopConsumers = 5;
+
+    public static IReadOnlyList<InfeasibleItem> Build(
+        IEnumerable<KeyValuePair<ItemId, decimal>> shortfalls,
+        ICatalogProvider catalog,
+        IReadOnlyList<ProductionStep> activatedSteps)
+    {
+        var result = new List<InfeasibleItem>();
+
+        foreach (var (item, qty) in shortfalls)
+        {
+            if (qty <= 0) continue;
+
+            var producers = catalog.FindAllProducersOf(item)
+                .Select(r => r.Id)
+                .ToList();
+
+            var consumers = activatedSteps
+                .Where(s => s.InputsPerMinute.Any(i => i.Item == item))
+                .Select(s => new
+                {
+                    s.Recipe.Id,
+                    Rate = s.InputsPerMinute.First(i => i.Item == item).Quantity,
+                })
+                .OrderByDescending(x => x.Rate)
+                .Take(MaxTopConsumers)
+                .Select(x => x.Id)
+                .ToList();
+
+            var reason = BuildReason(item, qty, producers, consumers, catalog);
+
+            result.Add(new InfeasibleItem(
+                Item: item,
+                QuantityShort: qty,
+                Reason: reason,
+                CouldBeProducedBy: producers,
+                TopConsumers: consumers));
+        }
+
+        return result;
+    }
+
+    private static string BuildReason(
+        ItemId item,
+        decimal qty,
+        IReadOnlyList<RecipeId> producers,
+        IReadOnlyList<RecipeId> consumers,
+        ICatalogProvider catalog)
+    {
+        var name = catalog.FindItem(item)?.Name ?? item.Value;
+
+        // Raw item — no producer recipe in the catalog. User has to either
+        // raise availability or pick a recipe that doesn't need it.
+        if (producers.Count == 0)
+        {
+            return $"No recipe produces {name}. " +
+                   $"Short {qty:0.##}/min — raise the AvailableInputs cap or substitute downstream.";
+        }
+
+        // Producible but still short — usually means an UPSTREAM raw input is
+        // also short and capped the producers' activation. Point at the
+        // alternates as the most actionable fix.
+        var altCount = producers.Count;
+        var altSuffix = altCount switch
+        {
+            1 => "1 recipe could produce it",
+            _ => $"{altCount} recipes could produce it",
+        };
+
+        return $"{name} short by {qty:0.##}/min. {altSuffix}; consider enabling one or scaling the chain.";
+    }
+}

--- a/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
+++ b/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
@@ -46,7 +46,7 @@ public sealed class RecursiveRecipePlanner : IRecipePlanner
             Available: query.Available,
             Steps: steps,
             RawInputsConsumed: rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList(),
-            MissingInputs: missing.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList());
+            MissingInputs: InfeasibilityDiagnostics.Build(missing, _catalog, steps));
     }
 
     private void Expand(

--- a/src/ERP/Domain/InfeasibleItem.cs
+++ b/src/ERP/Domain/InfeasibleItem.cs
@@ -1,0 +1,18 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// Diagnostic entry for an item the planner couldn't fully supply (#8).
+/// Replaces the bare <see cref="ItemAmount"/> entries that
+/// <see cref="ProductionPlan.MissingInputs"/> used to hold — same item +
+/// quantity, plus enrichment so the UI / ADA can surface actionable info:
+/// what recipes could have produced this item (alternates worth considering),
+/// what recipes are currently consuming it (so the user can scale or remove
+/// downstream demand), and a one-line natural-language reason for the
+/// shortfall.
+/// </summary>
+public sealed record InfeasibleItem(
+    ItemId Item,
+    decimal QuantityShort,
+    string Reason,
+    IReadOnlyList<RecipeId> CouldBeProducedBy,
+    IReadOnlyList<RecipeId> TopConsumers);

--- a/src/ERP/Domain/ProductionPlan.cs
+++ b/src/ERP/Domain/ProductionPlan.cs
@@ -5,7 +5,7 @@ public sealed record ProductionPlan(
     IReadOnlyList<ResourceAvailability> Available,
     IReadOnlyList<ProductionStep> Steps,
     IReadOnlyList<ItemAmount> RawInputsConsumed,
-    IReadOnlyList<ItemAmount> MissingInputs)
+    IReadOnlyList<InfeasibleItem> MissingInputs)
 {
     public bool IsFeasible => MissingInputs.Count == 0;
 }

--- a/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
+++ b/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
@@ -158,12 +158,12 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
                 rawConsumed.Add(new ItemAmount(i, (decimal)amount));
         }
 
-        var missing = new List<ItemAmount>();
+        var missingByItem = new Dictionary<ItemId, decimal>();
         foreach (var i in items)
         {
             var amount = shortVars[i].SolutionValue();
             if (amount > Epsilon)
-                missing.Add(new ItemAmount(i, (decimal)amount));
+                missingByItem[i] = (decimal)amount;
         }
 
         return new ProductionPlan(
@@ -171,7 +171,7 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
             Available: query.Available,
             Steps: steps,
             RawInputsConsumed: rawConsumed,
-            MissingInputs: missing);
+            MissingInputs: InfeasibilityDiagnostics.Build(missingByItem, _catalog, steps));
     }
 
     private static double NetRatePerMinute(Recipe r, ItemId item)

--- a/src/Web/Components/Pages/Planner.razor
+++ b/src/Web/Components/Pages/Planner.razor
@@ -332,18 +332,35 @@ else
     @if (plan.MissingInputs.Count > 0)
     {
         <MudText Typo="Typo.h5" Color="Color.Error" Class="mt-4 mb-1">Missing inputs</MudText>
-        <MudText Typo="Typo.caption" Color="Color.Default" Class="d-block mb-2">No recipe and no source available.</MudText>
-        <div class="fx-amount-list">
-            @foreach (var amount in plan.MissingInputs)
-            {
-                <span class="fx-amount fx-amount-missing" title="@amount.ItemName">
-                    <img src="/assets/icons/items/@(amount.ItemId).png"
+        <MudText Typo="Typo.caption" Color="Color.Default" Class="d-block mb-2">
+            The planner couldn't fully cover these items. Each row lists the shortfall, why it happened, and any alternate recipes that could unblock it.
+        </MudText>
+        @foreach (var missing in plan.MissingInputs)
+        {
+            <div class="fx-missing-row mt-2">
+                <span class="fx-amount fx-amount-missing" title="@missing.ItemName">
+                    <img src="/assets/icons/items/@(missing.ItemId).png"
                          onerror="this.style.visibility='hidden'"
                          alt="" />
-                    <span class="fx-amount-text">@FormatRate(amount.ItemsPerMinute) @amount.ItemName / min</span>
+                    <span class="fx-amount-text">@FormatRate(missing.ItemsPerMinute) @missing.ItemName / min</span>
                 </span>
-            }
-        </div>
+                <MudText Typo="Typo.body2" Class="ml-1 mt-1">@missing.Reason</MudText>
+                @if (missing.CouldBeProducedBy.Count > 0)
+                {
+                    <MudText Typo="Typo.caption" Class="d-block ml-1">
+                        <strong>Alternates:</strong>
+                        @string.Join(", ", missing.CouldBeProducedBy.Select(r => r.Name))
+                    </MudText>
+                }
+                @if (missing.TopConsumers.Count > 0)
+                {
+                    <MudText Typo="Typo.caption" Class="d-block ml-1">
+                        <strong>Top consumers:</strong>
+                        @string.Join(", ", missing.TopConsumers.Select(r => r.Name))
+                    </MudText>
+                }
+            </div>
+        }
     }
 }
 

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -207,7 +207,22 @@ public sealed record PlanResponse(
     IReadOnlyList<StepView> Steps,
     decimal TotalPowerMw,
     IReadOnlyList<AmountView> RawInputsConsumed,
-    IReadOnlyList<AmountView> MissingInputs);
+    IReadOnlyList<MissingInputView> MissingInputs);
+
+/// <summary>Per-item diagnostic for an unsatisfied target (#8).
+/// <c>ItemId</c> + <c>ItemName</c> + <c>ItemsPerMinute</c> match the previous
+/// <see cref="AmountView"/> shape so anything that just rendered the bare
+/// list keeps working; <c>Reason</c>, <c>CouldBeProducedBy</c>, and
+/// <c>TopConsumers</c> are the new actionable surface.</summary>
+public sealed record MissingInputView(
+    string ItemId,
+    string ItemName,
+    decimal ItemsPerMinute,
+    string Reason,
+    IReadOnlyList<RecipeRefView> CouldBeProducedBy,
+    IReadOnlyList<RecipeRefView> TopConsumers);
+
+public sealed record RecipeRefView(string Id, string Name);
 
 public sealed record CatalogueStatusView(
     bool IsLoaded,

--- a/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
+++ b/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
@@ -94,7 +94,8 @@ public class OrToolsRecipePlannerTests
         // only 10 ore — shortfall 20.
         var catalog = new FakeCatalog(
             buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
-            recipes: [IronIngotRecipe]);
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
 
         var planner = new OrToolsRecipePlanner(catalog);
         var plan = planner.Plan(new PlanProductionQuery(
@@ -104,8 +105,12 @@ public class OrToolsRecipePlannerTests
         Assert.False(plan.IsFeasible);
         var missing = plan.MissingInputs;
         Assert.Contains(missing, m => m.Item == IronOre);
-        var oreShort = missing.Single(m => m.Item == IronOre).Quantity;
-        Assert.InRange(oreShort, 20m - Tol, 20m + Tol);
+        var oreEntry = missing.Single(m => m.Item == IronOre);
+        Assert.InRange(oreEntry.QuantityShort, 20m - Tol, 20m + Tol);
+        // Iron ore is a raw with no producer in this catalogue — diagnostic
+        // should reflect that.
+        Assert.Empty(oreEntry.CouldBeProducedBy);
+        Assert.Contains("Iron Ore", oreEntry.Reason);
     }
 
     [Fact]

--- a/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
+++ b/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
@@ -51,20 +51,25 @@ internal static class PlannerTestFixtures
     {
         private readonly Dictionary<BuildingId, Building> _buildings;
         private readonly List<Recipe> _recipes;
+        private readonly Dictionary<ItemId, Item> _items;
 
-        public FakeCatalog(IEnumerable<Building> buildings, IEnumerable<Recipe> recipes)
+        public FakeCatalog(
+            IEnumerable<Building> buildings,
+            IEnumerable<Recipe> recipes,
+            IEnumerable<Item>? items = null)
         {
             _buildings = buildings.ToDictionary(b => b.Id);
             _recipes = recipes.ToList();
+            _items = (items ?? []).ToDictionary(i => i.Id);
         }
 
         public bool IsLoaded => true;
         public string? Source => "fake";
-        public IReadOnlyList<Item> Items => [];
+        public IReadOnlyList<Item> Items => _items.Values.ToList();
         public IReadOnlyList<Building> Buildings => _buildings.Values.ToList();
         public IReadOnlyList<Recipe> Recipes => _recipes;
 
-        public Item? FindItem(ItemId id) => null;
+        public Item? FindItem(ItemId id) => _items.TryGetValue(id, out var item) ? item : null;
         public Building? FindBuilding(BuildingId id) =>
             _buildings.TryGetValue(id, out var b) ? b : null;
         public Recipe? FindRecipe(RecipeId id) =>


### PR DESCRIPTION
## Summary

Phase 1 of #8. Replaces `ProductionPlan.MissingInputs`'s bare `ItemAmount` entries with **`InfeasibleItem`** records carrying actionable diagnostic info:

- `Item` + `QuantityShort` — same as before.
- `Reason` — one-line natural-language explanation.
- `CouldBeProducedBy` — recipe ids that would produce this item (alternates the planner skipped; empty for raws with no producer).
- `TopConsumers` — top recipe ids consuming this item, sorted by their input rate.

A shared post-solve helper (`InfeasibilityDiagnostics.Build`) is called by both planners — recursive expander populates from its in-recursion missing map; OR-Tools adapter populates from the shortfall-var solution values. So the enrichment works regardless of which engine you've selected.

## Reason string examples

- Raw item with no producer: *\"No recipe produces Iron Ore. Short 20/min — raise the AvailableInputs cap or substitute downstream.\"*
- Producible but short because upstream is capped: *\"Iron Ingot short by 30/min. 2 recipes could produce it; consider enabling one or scaling the chain.\"*

## Wire format

`PlanDto.MissingInputs` swaps from `AmountDto` to a new `MissingInputDto` that keeps `ItemId` / `ItemName` / `ItemsPerMinute` (backwards-readable for any JSON client that only used those) and **adds** `Reason` / `CouldBeProducedBy` / `TopConsumers`. The Web client (`PlannerApiClient.cs`) mirrors, and `Planner.razor` renders the new fields inline below each missing-item amount.

Per the project's [SemVer policy](https://github.com/ChrisonSimtian/ERP.Satisfactory/issues/8): **additive** — no fields removed, only added. Strictly a minor bump on the next release.

## Phase 2 follow-up

Filed separately for LP sensitivity analysis (shadow prices, reduced costs, constraint slack) — the original #8 mentioned this as research-grade, LP-only. Phase 1 covers the actionable UX; Phase 2 covers the engineering/LP-research surface.

## Test plan

- [x] `./build.sh TestNoUi` passes locally — existing planner + alert tests still pass under the new type.
- [x] `OrToolsRecipePlannerTests.Reports_Shortfall_*` updated to assert the new diagnostic fields (Reason mentions item name; CouldBeProducedBy is empty for raws).
- [ ] CI passes the full lane.
- [ ] After merge: trigger an infeasible plan in the Web UI, confirm the new alternates + consumers lists render.

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)