### PR TITLE
fix(ui): display names for nodes + buildings; deposit layer toggle (#124, #125, #126)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -626,6 +626,7 @@ public sealed record CountView(string Key, int Count);
 /// <summary>One row in the "buildings by type × recipe" table on /factory/ingest.</summary>
 public sealed record BuildingGroupView(
     string Building,
+    string? BuildingName,
     string? Recipe,
     string? RecipeName,
     int Count);
@@ -669,6 +670,7 @@ public sealed record FactoryStateView(
                 .GroupBy(b => (Building: b.Building.Value, Recipe: b.Recipe?.Value))
                 .Select(g => new BuildingGroupView(
                     Building: g.Key.Building,
+                    BuildingName: catalog.FindBuilding(new BuildingId(g.Key.Building))?.Name,
                     Recipe: g.Key.Recipe,
                     RecipeName: g.Key.Recipe is { Length: > 0 } r
                         ? catalog.FindRecipe(new RecipeId(r))?.Name
@@ -758,7 +760,15 @@ public sealed record FactoryStateGeoJson(
         var features = new List<GeoFeature>();
 
         foreach (var n in s.ResourceNodes)
-            features.Add(GeoFeature.Make("resource-node", n.Reference, n.Position, new()
+        {
+            // #125 — Deposits (small destructible scenery piles, ~hundreds per
+            // save) get their own category so the map can hide them by default
+            // via a layer toggle. Mining nodes / geysers / fracking cores stay
+            // under `resource-node` (visible by default).
+            var category = n.Kind == ResourceNodeKind.Deposit
+                ? "resource-deposit"
+                : "resource-node";
+            features.Add(GeoFeature.Make(category, n.Reference, n.Position, new()
             {
                 ["nodeKind"] = n.Kind.ToString(),
                 ["purity"] = n.Purity.ToString(),
@@ -767,6 +777,7 @@ public sealed record FactoryStateGeoJson(
                     ? catalog.FindItem(id)?.Name
                     : null,
             }));
+        }
 
         foreach (var m in s.Miners)
             features.Add(GeoFeature.Make("miner", m.Reference, m.Position, new()
@@ -778,6 +789,7 @@ public sealed record FactoryStateGeoJson(
         foreach (var b in s.Buildings)
             features.Add(GeoFeature.Make("building", b.Building.Value, b.Position, new()
             {
+                ["buildingName"] = catalog.FindBuilding(b.Building)?.Name,
                 ["recipe"] = b.Recipe?.Value,
                 ["recipeName"] = b.Recipe is { Value: { Length: > 0 } } id
                     ? catalog.FindRecipe(id)?.Name

--- a/src/Web/Components/Pages/FactoryIngest.razor
+++ b/src/Web/Components/Pages/FactoryIngest.razor
@@ -298,7 +298,16 @@ else
                 @foreach (var row in rows)
                 {
                     <tr>
-                        <td><code>@row.Building</code></td>
+                        <td title="@row.Building">
+                            @if (row.BuildingName is not null)
+                            {
+                                <span>@row.BuildingName</span>
+                            }
+                            else
+                            {
+                                <code>@row.Building</code>
+                            }
+                        </td>
                         <td>
                             @if (row.RecipeName is not null)
                             {

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -246,6 +246,7 @@ public sealed record CountViewModel(string Key, int Count);
 
 public sealed record BuildingGroupViewModel(
     string Building,
+    string? BuildingName,
     string? Recipe,
     string? RecipeName,
     int Count);

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -15,16 +15,20 @@ let backdropLayer = null;
 let dotNetCallback = null; // Optional Blazor handle for resource-node clicks (#42).
 
 const STYLE = {
-    'resource-node': { color: '#FFC53D', radius: 3.5, opacity: 0.85, label: 'Resource nodes' },
-    'miner':         { color: '#FA9549', radius: 6,   opacity: 1.0,  label: 'Miners' },
-    'building':      { color: '#5FB0C9', radius: 5,   opacity: 1.0,  label: 'Production buildings' },
-    'belt':          { color: '#7BB66B', radius: 1.8, opacity: 0.5,  label: 'Conveyor belts' },
-    'generator':     { color: '#E5604A', radius: 6,   opacity: 1.0,  label: 'Generators' },
+    'resource-node':    { color: '#FFC53D', radius: 3.5, opacity: 0.85, label: 'Resource nodes' },
+    // Deposits (#125) — small destructible scenery piles, ~hundreds per save.
+    // Same renderer as resource-node (grey dots from NODE_KIND_FALLBACK) but
+    // their own category so the layer toggle can hide them by default.
+    'resource-deposit': { color: '#9A9AA0', radius: 3,   opacity: 0.6,  label: 'Loose deposits', defaultOff: true },
+    'miner':            { color: '#FA9549', radius: 6,   opacity: 1.0,  label: 'Miners' },
+    'building':         { color: '#5FB0C9', radius: 5,   opacity: 1.0,  label: 'Production buildings' },
+    'belt':             { color: '#7BB66B', radius: 1.8, opacity: 0.5,  label: 'Conveyor belts' },
+    'generator':        { color: '#E5604A', radius: 6,   opacity: 1.0,  label: 'Generators' },
     // Flora (#62) — Bacon Agaric / Paleberry / Beryl Nut / Mycelia. Off by
     // default (lots of plants — clutters the map). Markers use per-species
     // item icons from /assets/icons/items/ (ADR-0016); the color below is
     // just the legend swatch + fallback dot tint when an icon is missing.
-    'flora':         { color: '#9CCC65', radius: 4,   opacity: 0.9,  label: 'Flora', defaultOff: true },
+    'flora':            { color: '#9CCC65', radius: 4,   opacity: 0.9,  label: 'Flora', defaultOff: true },
 };
 
 // Fallback styling for resource nodes whose resource isn't known yet (no
@@ -438,6 +442,19 @@ function tooltipText(feature) {
     // the category prefix isn't useful since the icon already conveys it.
     if (p.category === 'flora') {
         return p.speciesName ?? shortName(p.species ?? p.kind);
+    }
+    // Resource nodes + deposits (#124): prefer the catalog display name of
+    // the resource over the raw actor class. Falls back to the kind's short
+    // name when the resource isn't known yet (mod actors, unmapped nodes).
+    if (p.category === 'resource-node' || p.category === 'resource-deposit') {
+        const name = p.resourceName ?? shortName(p.kind);
+        return `${p.category} · ${name}`;
+    }
+    // Buildings (#126): prefer the catalog display name of the building over
+    // the raw class id (Build_AssemblerMk1_C → "Assembler Mk.1").
+    if (p.category === 'building') {
+        const name = p.buildingName ?? shortName(p.kind);
+        return `${p.category} · ${name}`;
     }
     return `${p.category} · ${shortName(p.kind)}`;
 }


### PR DESCRIPTION
## Summary

Three playtest bugs, one focused PR — all live on the live-state ingestion + map surface.

| # | Fix |
|---|---|
| **#124** | Map tooltips for resource nodes / deposits use the catalog display name (e.g. *"Iron Ore"*) instead of the raw class id (`BP_ResourceNode_Iron_C`). |
| **#126** | Factory-state building groups + map building features now carry a `BuildingName` (`Build_AssemblerMk1_C` → *"Assembler Mk.1"*). The class id is preserved as hover-tooltip secondary metadata. |
| **#125** | "Grey dots" identified — they're `Deposit`-kind resource nodes (destructible scenery piles, hundreds per save). Split into their own `resource-deposit` GeoJSON category with `defaultOff: true` in the Leaflet layer toggle. Mining nodes / geysers / fracking remain in `resource-node` (visible by default). |

## Files touched

- `src/ApiService/Program.cs` — `BuildingGroupView` gets `BuildingName`; resource-node loop branches on `Kind == Deposit` to emit `resource-deposit`; building features carry `buildingName`.
- `src/Web/PlannerApiClient.cs` — client `BuildingGroupViewModel` mirrors the new field.
- `src/Web/Components/Pages/FactoryIngest.razor` — buildings table renders the display name; class id on hover.
- `src/Web/wwwroot/js/factory-map.js` — new `resource-deposit` style entry; `tooltipText` uses `resourceName` / `buildingName` with graceful fallback to `shortName(kind)` for unmapped / mod actors.

## Acceptance

- [x] `dotnet build ERP.Satisfactory.slnx` succeeds; `./build.sh TestNoUi` passes.
- [ ] Manual smoke: ingest a save, confirm nodes labelled "Iron Ore" etc.; deposits toggle off by default; buildings table shows "Assembler Mk.1" etc.
- [ ] Mod / unknown classes fall back to the raw key without crashing (covered by the `??` fallbacks in JS + null-coalescing in C#).

Closes #124, #125, #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)