### PR TITLE
feat(planner): variance warning for plans with miners/extractors (#91 v1)

### DIFF
--- a/docs/power-generators.md
+++ b/docs/power-generators.md
@@ -1,0 +1,46 @@
+# Power generators (reference)
+
+Starting point for the generator-aware planning follow-up to issue #91. The
+v1 ship of #91 added the [variable-power variance warning](../src/ERP/Application/Queries/PlanProduction/PowerVarianceWarning.cs) —
+this table covers the *other* half of the issue (the generator side) so a
+future LP-backed "produce N MW of power" target has the canonical numbers in
+one place. **No planner code reads this file today** — these figures are not
+yet wired into the catalogue or the LP objective.
+
+All numbers are nominal Update-8/1.0 values from the in-game wiki; the
+parser-exposed `GeneratorKind` enum (see `src/ERP/Domain/GeneratorKind.cs`)
+already maps save-state generators to the same five kinds.
+
+| Generator kind | Building ID                  | Base power (MW) | Fuel inputs (per generator at 100%)               | Notes                                                                              |
+|----------------|------------------------------|-----------------|----------------------------------------------------|------------------------------------------------------------------------------------|
+| Biomass        | `Build_GeneratorBiomass_C`   | 30              | varies by fuel (Leaves / Wood / Biomass / Solid Biofuel) | Manual-feed only — no belt input. Practical only in early game.                    |
+| Coal           | `Build_GeneratorCoal_C`      | 75              | 15 Coal/min + 45 m³ Water/min                      | Also accepts Compacted Coal (7.5/min) or Petroleum Coke (25/min) with rate trade-off. |
+| Fuel           | `Build_GeneratorFuel_C`      | 250             | 20 m³ Fuel/min                                     | Also accepts Turbofuel (7.5/min) or Liquid Biofuel (20/min); no water input.       |
+| Nuclear        | `Build_GeneratorNuclear_C`   | 2 500           | 0.2 Uranium Fuel Rod/min + 240 m³ Water/min        | Produces 10 Uranium Waste / min as byproduct (50 Plutonium Waste / min for Pu rods). |
+| Geothermal     | `Build_GeneratorGeoThermal_C`| ~200 (variable) | None — placed on geyser node                       | Output varies with node purity (Impure 100 / Normal 200 / Pure 400 MW avg).        |
+
+## Why this lives here, not in `ProductionPlan.cs`
+
+- Generators don't fit `Recipe.Outputs` cleanly today — they produce **power**
+  (not an item), and `ItemAmount` is item-typed. Wiring them in needs either
+  a synthetic `Desc_Power_C` item or a new `PowerOutputPerMinute` field on
+  `Recipe`. That choice is the v2 (#91 phase 2) design call.
+- Geothermal's purity-tied variable output is the same modelling problem as
+  the miner variance warning we just shipped — best handled once across both
+  consumers (miners) and producers (geothermal) rather than ad-hoc per side.
+
+## What v2 (generator-aware planning) needs
+
+Tracked in the #91 phase 2 follow-up. At minimum:
+
+1. A way to express **power as a planner target** (`ProductionTarget` with a
+   power-typed item, or a new `PowerTarget` record).
+2. Per-generator decision variables in `OrToolsRecipePlanner` (count of each
+   `Build_GeneratorX_C`) plus the fuel constraints from the table above.
+3. Generator selection trade-off in the objective (cheapest fuel vs.
+   simplest setup) — likely a multi-objective LP with a power-cost weight.
+4. Catalogue ingestion: today the `Docs.json` parser drops generator buildings
+   into the building set with `BasePowerMw` populated, but doesn't expose the
+   fuel-input metadata. The fork's `SatisfactorySaveNet` already parses this
+   for save-state diagnostics — porting it into `DocsCatalogProvider` is the
+   plumbing prerequisite.

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -974,7 +974,8 @@ public sealed record PlanDto(
     decimal TotalPowerMw,
     IReadOnlyList<AmountDto> RawInputsConsumed,
     IReadOnlyList<MissingInputDto> MissingInputs,
-    IReadOnlyList<ExtractorAllocationDto> ExtractorAllocations)
+    IReadOnlyList<ExtractorAllocationDto> ExtractorAllocations,
+    IReadOnlyList<string> Warnings)
 {
     public static PlanDto From(ProductionPlan plan, ICatalogProvider catalog)
     {
@@ -1019,6 +1020,7 @@ public sealed record PlanDto(
             TotalPowerMw: Math.Round(steps.Sum(s => s.PowerMw), 4),
             RawInputsConsumed: plan.RawInputsConsumed.Select(ToAmount).ToList(),
             MissingInputs: plan.MissingInputs.Select(ToMissing).ToList(),
-            ExtractorAllocations: plan.Allocations.Select(ToAllocation).ToList());
+            ExtractorAllocations: plan.Allocations.Select(ToAllocation).ToList(),
+            Warnings: plan.WarningsOrEmpty);
     }
 }

--- a/src/ERP/Application/Queries/PlanProduction/PowerVarianceWarning.cs
+++ b/src/ERP/Application/Queries/PlanProduction/PowerVarianceWarning.cs
@@ -1,0 +1,69 @@
+using ERP.Domain;
+
+namespace ERP.Application.Queries.PlanProduction;
+
+/// <summary>
+/// Detects plan-wide power-variance caveats and produces user-facing warnings
+/// (issue #91, v1). Miners and fluid extractors have variable in-game draw —
+/// the catalogue only exposes <c>BasePowerMw</c>, so <see cref="ProductionStep.PowerMw"/>
+/// and <see cref="ProductionPlan"/>'s aggregate are base × count, which
+/// systematically under-reports peak load. When a plan touches any of these
+/// buildings, we attach a single advisory string so the user knows to over-size
+/// their generator budget rather than treat the figure as ground truth.
+/// <para>
+/// Detection is intentionally a hard-coded building-ID set, not a name regex —
+/// names vary by locale / catalogue update, but the BPID is stable across
+/// Satisfactory versions. Add to the set if new variable-draw buildings ship.
+/// </para>
+/// <para>
+/// Out of scope here: actually <em>modelling</em> peak power, generator-aware
+/// planning, fuse limits — those are the larger #91 follow-up.
+/// </para>
+/// </summary>
+public static class PowerVarianceWarning
+{
+    /// <summary>
+    /// Buildings whose in-game power draw can exceed the documented base
+    /// figure under normal operation — miners follow a dig-cycle that spikes
+    /// to ~150% of base, fluid extractors have similar pump-cycle variance.
+    /// Anything in this set causes <see cref="Build"/> to emit the variance
+    /// advisory.
+    /// </summary>
+    public static readonly IReadOnlySet<BuildingId> VariablePowerBuildings = new HashSet<BuildingId>
+    {
+        new("Build_MinerMk1_C"),
+        new("Build_MinerMk2_C"),
+        new("Build_MinerMk3_C"),
+        new("Build_OilPump_C"),
+        new("Build_FrackingExtractor_C"),
+        new("Build_WaterPump_C"),
+    };
+
+    /// <summary>
+    /// The single advisory string emitted when a plan touches any
+    /// <see cref="VariablePowerBuildings"/> entry. Kept as a constant so tests
+    /// can assert the wording and so it appears verbatim wherever the plan is
+    /// rendered.
+    /// </summary>
+    public const string MinerVarianceAdvisory =
+        "Power draw shown is base × count; miners and fluid extractors draw up to ~150% during dig/pump cycles. " +
+        "Over-size your generator budget by ~20% to be safe.";
+
+    /// <summary>
+    /// Inspect the steps and return any warnings that apply. Returns an empty
+    /// list (never null) when nothing to flag, so call-sites can hand the
+    /// result straight to <see cref="ProductionPlan.Warnings"/>.
+    /// </summary>
+    public static IReadOnlyList<string> Build(IEnumerable<ProductionStep> steps)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+
+        foreach (var step in steps)
+        {
+            if (VariablePowerBuildings.Contains(step.Recipe.Building))
+                return new[] { MinerVarianceAdvisory };
+        }
+
+        return Array.Empty<string>();
+    }
+}

--- a/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
+++ b/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
@@ -46,7 +46,8 @@ public sealed class RecursiveRecipePlanner : IRecipePlanner
             Available: query.Available,
             Steps: steps,
             RawInputsConsumed: rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList(),
-            MissingInputs: InfeasibilityDiagnostics.Build(missing, _catalog, steps));
+            MissingInputs: InfeasibilityDiagnostics.Build(missing, _catalog, steps),
+            Warnings: PowerVarianceWarning.Build(steps));
     }
 
     private void Expand(

--- a/src/ERP/Domain/ProductionPlan.cs
+++ b/src/ERP/Domain/ProductionPlan.cs
@@ -1,13 +1,32 @@
 namespace ERP.Domain;
 
+/// <summary>
+/// The output of a planning run. <see cref="Steps"/> covers the recipes /
+/// building counts; <see cref="RawInputsConsumed"/> shows what was drawn from
+/// the user-declared <see cref="ResourceAvailability"/>; <see cref="MissingInputs"/>
+/// flags any unsatisfied demand.
+/// <para>
+/// <see cref="ExtractorAllocations"/> reports per-node miner placement (#92).
+/// <see cref="Warnings"/> is a list of advisory, plan-wide caveats — strings
+/// that the UI / API surface as informational text alongside the plan. Today
+/// the only producer is the variable-power-buildings notice (#91 v1): when a
+/// plan contains miners / extractors, the <c>PowerMw</c> figures are base
+/// draw, not the higher peak draw those buildings hit in-game. The field
+/// defaults to empty so older call-sites and serialised JSON keep working
+/// unchanged.
+/// </para>
+/// </summary>
 public sealed record ProductionPlan(
     IReadOnlyList<ProductionTarget> Targets,
     IReadOnlyList<ResourceAvailability> Available,
     IReadOnlyList<ProductionStep> Steps,
     IReadOnlyList<ItemAmount> RawInputsConsumed,
     IReadOnlyList<InfeasibleItem> MissingInputs,
-    IReadOnlyList<ExtractorAllocation>? ExtractorAllocations = null)
+    IReadOnlyList<ExtractorAllocation>? ExtractorAllocations = null,
+    IReadOnlyList<string>? Warnings = null)
 {
+    public IReadOnlyList<string> WarningsOrEmpty => Warnings ?? Array.Empty<string>();
+
     public bool IsFeasible => MissingInputs.Count == 0;
 
     /// <summary>

--- a/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
+++ b/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
@@ -267,7 +267,8 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
             Steps: steps,
             RawInputsConsumed: rawConsumed,
             MissingInputs: InfeasibilityDiagnostics.Build(missingByItem, _catalog, steps),
-            ExtractorAllocations: allocations);
+            ExtractorAllocations: allocations,
+            Warnings: PowerVarianceWarning.Build(steps));
     }
 
     private static readonly IReadOnlyList<MinerTier> AllMinerTiers =

--- a/src/Web/Components/Pages/Planner.razor
+++ b/src/Web/Components/Pages/Planner.razor
@@ -261,6 +261,18 @@ else
         }
     </div>
 
+    @if (plan.Warnings.Count > 0)
+    {
+        @* Plan-wide advisories (#91 v1). Today: variable-power buildings (miners,
+           extractors) where the displayed PowerMw is base × count, not peak. *@
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-3" Icon="@Icons.Material.Filled.Bolt">
+            @foreach (var warning in plan.Warnings)
+            {
+                <div>@warning</div>
+            }
+        </MudAlert>
+    }
+
     @if (plan.Steps.Count == 0)
     {
         <MudText><em>No production steps required (everything covered by sources, or no targets given).</em></MudText>

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -236,7 +236,18 @@ public sealed record PlanResponse(
     decimal TotalPowerMw,
     IReadOnlyList<AmountView> RawInputsConsumed,
     IReadOnlyList<MissingInputView> MissingInputs,
-    IReadOnlyList<ExtractorAllocationView> ExtractorAllocations);
+    IReadOnlyList<ExtractorAllocationView> ExtractorAllocations,
+    IReadOnlyList<string>? Warnings = null)
+{
+    /// <summary>
+    /// Plan-wide advisory strings (e.g. the variable-power-buildings notice
+    /// from #91 v1). Older API builds won't include this field — the nullable
+    /// default keeps the JSON binder happy, and the property below normalises
+    /// to an empty list so render-side code can call <c>.Count</c> without a
+    /// null check.
+    /// </summary>
+    public IReadOnlyList<string> WarningsOrEmpty => Warnings ?? Array.Empty<string>();
+}
 
 /// <summary>Per-node extraction breakdown (#92). Empty when the request
 /// didn't include any node bindings.</summary>

--- a/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
+++ b/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
@@ -96,6 +96,63 @@ public class RecursiveRecipePlannerTests
         Assert.Equal(0m, step.PowerMw);
     }
 
+    // ---- #91 v1: variance warning for plans that include miners --------------
+
+    private static readonly BuildingId MinerMk1Id = new("Build_MinerMk1_C");
+
+    // Synthetic "mine iron ore" recipe — the catalogue parser exposes node
+    // extraction the same way (a recipe whose building is a miner BPID, no
+    // inputs, ore as output). Power is variable in-game, but the catalogue
+    // exposes only BasePowerMw so the planner reports base × count.
+    private static readonly Recipe MineIronOreRecipe = new(
+        new RecipeId("Recipe_MineIron_C"),
+        "Mine Iron Ore",
+        MinerMk1Id,
+        Inputs: [],
+        Outputs: [new ItemAmount(IronOre, 1)],
+        Duration: TimeSpan.FromSeconds(1));
+
+    [Fact]
+    public void Plan_With_Miner_Gets_Variance_Warning()
+    {
+        // No availability → planner has to use the miner recipe → step uses a
+        // variable-power building → warning attaches.
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+                new Building(MinerMk1Id, "Miner Mk.1", BasePowerMw: 5),
+            ],
+            recipes: [IronIngotRecipe, MineIronOreRecipe]);
+
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: []));
+
+        var warning = Assert.Single(plan.Warnings);
+        Assert.Equal(PowerVarianceWarning.MinerVarianceAdvisory, warning);
+    }
+
+    [Fact]
+    public void Plan_Without_Miner_Has_No_Warning()
+    {
+        // Iron ore comes from raw availability, not from a miner → no variable-
+        // power building in the plan → no warning. Guards against false-positives
+        // where the advisory pops up for plans that don't include miners.
+        var catalog = new FakeCatalog(
+            buildings: [
+                new Building(SmelterId, "Smelter", BasePowerMw: 4),
+            ],
+            recipes: [IronIngotRecipe]);
+
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
+
+        Assert.Empty(plan.Warnings);
+    }
+
     /// <summary>
     /// Minimal in-memory catalogue stand-in. The planner only calls
     /// <see cref="FindDefaultProducerOf"/> and <see cref="FindBuilding"/>, so

--- a/test/Web/Web.UiTests/PlannerGraphLayoutTests.cs
+++ b/test/Web/Web.UiTests/PlannerGraphLayoutTests.cs
@@ -15,7 +15,8 @@ public class PlannerGraphLayoutTests
             Steps: [],
             TotalPowerMw: 0,
             RawInputsConsumed: [],
-            MissingInputs: []);
+            MissingInputs: [],
+            ExtractorAllocations: []);
 
         var layout = PlannerGraphLayout.Build(plan);
 
@@ -41,7 +42,7 @@ public class PlannerGraphLayoutTests
             BuildingCount: 1m, PowerMw: 4m,
             Inputs:  [new AmountView("ingot", "Iron Ingot", 30m)],
             Outputs: [new AmountView("plate", "Iron Plate", 20m)]);
-        var plan = new PlanResponse(true, [ingot, plate], 8m, [], []);
+        var plan = new PlanResponse(true, [ingot, plate], 8m, [], [], []);
 
         var layout = PlannerGraphLayout.Build(plan);
 
@@ -75,7 +76,7 @@ public class PlannerGraphLayoutTests
             Inputs:  [new AmountView("mid2", "Mid2", 10)],
             Outputs: [new AmountView("final", "Final", 10)]);
 
-        var layout = PlannerGraphLayout.Build(new PlanResponse(true, [a, b, c], 3, [], []));
+        var layout = PlannerGraphLayout.Build(new PlanResponse(true, [a, b, c], 3, [], [], []));
 
         var xs = new[] { "A", "B", "C" }
             .Select(id => layout.Nodes.Single(n => n.Step.RecipeId == id).X)
@@ -93,7 +94,7 @@ public class PlannerGraphLayoutTests
             Inputs:  [new AmountView("ore", "Ore", 10)],
             Outputs: [new AmountView("out", "Out", 10)]);
         var soloLayout = PlannerGraphLayout.Build(
-            new PlanResponse(true, [solo], 1, [], []));
+            new PlanResponse(true, [solo], 1, [], [], []));
 
         var a = new StepView("A", "A", "b", "B", 1, 1,
             Inputs:  [new AmountView("ore", "Ore", 10)],
@@ -105,7 +106,7 @@ public class PlannerGraphLayoutTests
             Inputs:  [new AmountView("m2", "M2", 10)],
             Outputs: [new AmountView("out", "Out", 10)]);
         var chainLayout = PlannerGraphLayout.Build(
-            new PlanResponse(true, [a, b, c], 3, [], []));
+            new PlanResponse(true, [a, b, c], 3, [], [], []));
 
         Assert.True(chainLayout.Width > soloLayout.Width,
             $"Chained layout ({chainLayout.Width}) should be wider than solo ({soloLayout.Width}).");


### PR DESCRIPTION
## Summary

Partially addresses #91. The issue sweeps wide (generator-aware planning, fuse limits, peak-vs-average power, variance flags) — this PR ships the smallest piece with value and files a follow-up for the rest.

## v1 scope (intentionally narrow)

- **Variance flag.** When a plan contains a miner (Mk1 / Mk2 / Mk3), oil pump, fracking extractor, or water pump, attach a single advisory to the plan: *"Power draw shown is base × count; miners and fluid extractors draw up to ~150% during dig/pump cycles. Over-size your generator budget by ~20% to be safe."*
- **Domain.** New optional `ProductionPlan.Warnings` (`IReadOnlyList<string>`, defaults empty so older constructors / serialised JSON keep working). Detection lives in a shared `PowerVarianceWarning` static helper in Application so both planners emit it consistently.
- **Wire.** Added `Warnings` to `PlanDto` (API) and `PlanResponse` (Web client). `Planner.razor` renders the list as a `MudAlert` (Info, Bolt icon) above the steps grid when non-empty.
- **Tests.** Two cases in `RecursiveRecipePlannerTests`: plan-with-miner → has variance warning, plan-without-miner → no warning. Parity tests across the LP/recursive planners still pass.
- **Docs.** New `docs/power-generators.md` reference table — canonical generator types (Biomass / Coal / Fuel / Nuclear / Geothermal) and their fuel/power numbers, so a future generator-aware planner starts from one place. No planner code reads it today.

## What's deferred to follow-up

Tracked in the #91 phase-2 issue:

- Generator-aware planning: LP decision variables for generator counts + fuel inputs, "produce N MW of power" as an expressible target.
- Fuse / power-line throughput limits (MK-gated belts of the power network).
- Network topology / live brownout diagnostics.
- Peak-vs-average modelling that actually folds into the LP objective (not just a flag).

Each of those is a sizeable design call that warrants its own discussion — the variance flag is the no-regrets first move.

## Test plan

- [x] `dotnet build ERP.Satisfactory.slnx` clean (warnings only, no errors).
- [x] `./build.sh TestNoUi` — all 33 ERP application/infrastructure tests pass, including the new `Plan_With_Miner_Gets_Variance_Warning` + `Plan_Without_Miner_Has_No_Warning` cases and the existing planner parity suite.
- [ ] Manual: run a plan that includes mined iron ore; verify the blue advisory banner appears above the steps grid.
- [ ] Manual: run a plan with all raw ore supplied via Availability; verify no banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)