### PR TITLE
feat(map): scaffold pipe polyline rendering (#65)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -651,6 +651,7 @@ public sealed record FactoryStateView(
     IReadOnlyList<BuildingGroupView> Buildings,
     int BuildingsWithRecipe,
     IReadOnlyList<CountView> Belts,
+    IReadOnlyList<CountView> Pipelines,
     IReadOnlyList<CountView> Generators,
     int ResourceNodeCount,
     IReadOnlyList<string> Warnings)
@@ -693,6 +694,11 @@ public sealed record FactoryStateView(
             BuildingsWithRecipe: state.Buildings.Count(b => b.Recipe is not null),
             Belts: state.Belts
                 .GroupBy(b => b.Tier.ToString())
+                .Select(g => new CountView(g.Key, g.Count()))
+                .OrderBy(c => c.Key, StringComparer.Ordinal)
+                .ToList(),
+            Pipelines: state.Pipelines
+                .GroupBy(p => p.Tier.ToString())
                 .Select(g => new CountView(g.Key, g.Count()))
                 .OrderBy(c => c.Key, StringComparer.Ordinal)
                 .ToList(),
@@ -818,6 +824,22 @@ public sealed record FactoryStateGeoJson(
                 features.Add(GeoFeature.MakeLine("belt", belt.Reference, poly, belt.Position, props));
             else
                 features.Add(GeoFeature.Make("belt", belt.Reference, belt.Position, props));
+        }
+
+        // Pipelines mirror the belt shape exactly — LineString when the
+        // polyline has ≥2 points, point fallback otherwise. Polylines will
+        // stay empty until the SatisfactorySaveNet fork parses pipe
+        // `mSplineData` (Array<Struct<FSplinePointData>>); see issue #65.
+        foreach (var pipe in s.Pipelines)
+        {
+            var props = new Dictionary<string, object?>
+            {
+                ["tier"] = pipe.Tier.ToString(),
+            };
+            if (pipe.Polyline is { Count: >= 2 } poly)
+                features.Add(GeoFeature.MakeLine("pipe", pipe.Reference, poly, pipe.Position, props));
+            else
+                features.Add(GeoFeature.Make("pipe", pipe.Reference, pipe.Position, props));
         }
 
         foreach (var g in s.Generators)

--- a/src/ERP/Domain/LiveFactoryState.cs
+++ b/src/ERP/Domain/LiveFactoryState.cs
@@ -6,11 +6,12 @@ public sealed record LiveFactoryState(
     IReadOnlyList<Miner> Miners,
     IReadOnlyList<ProductionBuilding> Buildings,
     IReadOnlyList<ConveyorBelt> Belts,
+    IReadOnlyList<Pipeline> Pipelines,
     IReadOnlyList<PowerGenerator> Generators,
     IReadOnlyList<string> Warnings)
 {
     public static LiveFactoryState Empty(string reason) => new(
         new SaveMetadata("(none)", 0, 0, TimeSpan.Zero, DateTime.MinValue),
-        [], [], [], [], [],
+        [], [], [], [], [], [],
         [reason]);
 }

--- a/src/ERP/Domain/Pipeline.cs
+++ b/src/ERP/Domain/Pipeline.cs
@@ -1,0 +1,22 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// A placed fluid pipeline. <paramref name="Position"/> is the pipe actor's
+/// origin (typically the first connector); <paramref name="Polyline"/> traces
+/// the pipe's route when known.
+/// <para>
+/// Polyline coordinates come from the actor's <c>mSplineData</c>
+/// (<c>Array&lt;Struct&lt;FSplinePointData&gt;&gt;</c>). The vendored
+/// SatisfactorySaveNet fork does not yet deserialize that property shape
+/// (its <c>RawProperty</c> typed slots cover <c>Array&lt;ObjectProperty&gt;</c>
+/// but not <c>Array&lt;Struct&gt;</c>), so <c>Polyline</c> is currently
+/// always <c>null</c>. The app-side plumbing here is intentional scaffolding
+/// so that LineString rendering activates the moment the fork catches up —
+/// tracked in issue #65 (this domain field) and the follow-up parser issue.
+/// </para>
+/// </summary>
+public sealed record Pipeline(
+    string Reference,
+    PipelineTier Tier,
+    Position Position,
+    IReadOnlyList<Position>? Polyline = null);

--- a/src/ERP/Domain/PipelineTier.cs
+++ b/src/ERP/Domain/PipelineTier.cs
@@ -1,0 +1,11 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// Fluid pipeline tier. Satisfactory ships two tiers; Mk2 raises throughput
+/// from 300 m³/min to 600 m³/min but uses the same domain shape.
+/// </summary>
+public enum PipelineTier
+{
+    Mk1 = 1,
+    Mk2 = 2,
+}

--- a/src/Satisfactory/Save/BuildingIdentifiers.cs
+++ b/src/Satisfactory/Save/BuildingIdentifiers.cs
@@ -31,6 +31,13 @@ internal static class BuildingIdentifiers
         _ => null,
     };
 
+    public static PipelineTier? PipelineTier(string typePath) => ShortName(typePath) switch
+    {
+        "Build_Pipeline_C" => ERP.Domain.PipelineTier.Mk1,
+        "Build_PipelineMk2_C" => ERP.Domain.PipelineTier.Mk2,
+        _ => null,
+    };
+
     public static GeneratorKind? GeneratorKind(string typePath) => ShortName(typePath) switch
     {
         "Build_GeneratorBiomass_Automated_C" or

--- a/src/Satisfactory/Save/SaveFileReader.cs
+++ b/src/Satisfactory/Save/SaveFileReader.cs
@@ -37,7 +37,7 @@ public sealed class SaveFileReader
         if (save.Body is not BodyV8 body)
         {
             return new LiveFactoryState(
-                metadata, [], [], [], [], [],
+                metadata, [], [], [], [], [], [],
                 [$"Unsupported body version: {save.Body?.GetType().Name ?? "null"}. v1.2 saves are expected to be BodyV8."]);
         }
 
@@ -45,6 +45,7 @@ public sealed class SaveFileReader
         var miners = new List<Miner>();
         var buildings = new List<ProductionBuilding>();
         var belts = new List<ConveyorBelt>();
+        var pipelines = new List<Pipeline>();
         var generators = new List<PowerGenerator>();
         var warnings = new List<string>();
 
@@ -89,6 +90,15 @@ public sealed class SaveFileReader
                 var polyline = beltSplines.GetValueOrDefault(reference);
                 belts.Add(new ConveyorBelt(reference, beltTier, position, polyline));
             }
+            else if (BuildingIdentifiers.PipelineTier(typePath) is { } pipeTier)
+            {
+                // Polyline stays null until the vendored fork can parse the
+                // pipe actor's `mSplineData` (Array<Struct<FSplinePointData>>);
+                // see Pipeline.cs xmldoc + issue #65 for the wiring rationale.
+                // Once the fork lands the new property reader, populate here
+                // from the FSplinePointData entries.
+                pipelines.Add(new Pipeline(reference, pipeTier, position, Polyline: null));
+            }
             else if (BuildingIdentifiers.GeneratorKind(typePath) is { } genKind)
             {
                 generators.Add(new PowerGenerator(reference, genKind, position));
@@ -99,7 +109,7 @@ public sealed class SaveFileReader
             }
         }
 
-        return new LiveFactoryState(metadata, resourceNodes, miners, buildings, belts, generators, warnings);
+        return new LiveFactoryState(metadata, resourceNodes, miners, buildings, belts, pipelines, generators, warnings);
     }
 
     /// <summary>

--- a/src/Web/Components/Pages/FactoryIngest.razor
+++ b/src/Web/Components/Pages/FactoryIngest.razor
@@ -52,9 +52,16 @@ else
 
         <MudGrid Spacing="3" Class="mt-3">
             <MudItem xs="12" md="6">
+                <MudText Typo="Typo.h5" Class="mb-2">Pipelines <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by tier</MudText></MudText>
+                @CountTable(state.Pipelines, "No pipelines.")
+            </MudItem>
+            <MudItem xs="12" md="6">
                 <MudText Typo="Typo.h5" Class="mb-2">Generators <MudText HtmlTag="span" Typo="Typo.caption" Color="Color.Default">by kind</MudText></MudText>
                 @CountTable(state.Generators, "No generators.")
             </MudItem>
+        </MudGrid>
+
+        <MudGrid Spacing="3" Class="mt-3">
             <MudItem xs="12" md="6">
                 <MudText Typo="Typo.h5" Class="mb-2">Resource nodes</MudText>
                 <MudText Class="display-6">@state.ResourceNodeCount.ToString("N0")</MudText>

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -275,6 +275,7 @@ public sealed record FactoryStateViewModel(
     IReadOnlyList<BuildingGroupViewModel> Buildings,
     int BuildingsWithRecipe,
     IReadOnlyList<CountViewModel> Belts,
+    IReadOnlyList<CountViewModel> Pipelines,
     IReadOnlyList<CountViewModel> Generators,
     int ResourceNodeCount,
     IReadOnlyList<string> Warnings);

--- a/src/Web/wwwroot/js/factory-map.js
+++ b/src/Web/wwwroot/js/factory-map.js
@@ -23,6 +23,12 @@ const STYLE = {
     'miner':            { color: '#FA9549', radius: 6,   opacity: 1.0,  label: 'Miners' },
     'building':         { color: '#5FB0C9', radius: 5,   opacity: 1.0,  label: 'Production buildings' },
     'belt':             { color: '#7BB66B', radius: 1.8, opacity: 0.5,  label: 'Conveyor belts' },
+    // Pipes (#65). Mk1 = base teal, Mk2 = brighter cyan; per-tier overrides
+    // applied in buildShape() when the feature's `tier` property is present.
+    // Polylines stay sparse until the SatisfactorySaveNet fork can parse
+    // `Array<Struct<FSplinePointData>>` — see follow-up parser issue.
+    'pipe':             { color: '#4FB3BF', radius: 1.8, opacity: 0.5,  label: 'Pipelines',
+                          tierColors: { 'Mk1': '#4FB3BF', 'Mk2': '#9CDEE0' } },
     'generator':        { color: '#E5604A', radius: 6,   opacity: 1.0,  label: 'Generators' },
     // Flora (#62) — Bacon Agaric / Paleberry / Beryl Nut / Mycelia. Off by
     // default (lots of plants — clutters the map). Markers use per-species
@@ -235,13 +241,17 @@ function buildCategoryLayers(featureCollection) {
 
 function buildShape(feature, style) {
     const g = feature.geometry;
+    // Per-tier stroke / dot colour when the category opts in via `tierColors`
+    // (#65 — pipes use this so Mk1 vs Mk2 are distinguishable on the map).
+    const tier = feature.properties?.tier;
+    const strokeColor = (style.tierColors && tier && style.tierColors[tier]) || style.color;
     if (g.type === 'LineString') {
         const latlngs = g.coordinates.map(([x, y]) => unrealToLatLng(x, y));
-        // Belts use the canvas renderer (preferCanvas: true on the map) so even
-        // dense Mk1 cluster routes stay performant. Stroke weight is small but
-        // visible; tier-coloured via the category STYLE.
+        // Belts + pipes use the canvas renderer (preferCanvas: true on the map)
+        // so even dense Mk1 cluster routes stay performant. Stroke weight is
+        // small but visible; tier-coloured via STYLE / tierColors.
         return L.polyline(latlngs, {
-            color: style.color,
+            color: strokeColor,
             weight: 1.5,
             opacity: Math.min(0.9, (style.opacity ?? 0.5) + 0.3),
         });
@@ -262,8 +272,8 @@ function buildShape(feature, style) {
 
     return L.circleMarker(latlng, {
         radius: style.radius,
-        color: style.color,
-        fillColor: style.color,
+        color: strokeColor,
+        fillColor: strokeColor,
         fillOpacity: style.opacity,
         weight: 1,
         opacity: style.opacity,

--- a/test/ApiService.Tests/FactoryStateGeoJsonPipelineTests.cs
+++ b/test/ApiService.Tests/FactoryStateGeoJsonPipelineTests.cs
@@ -1,0 +1,129 @@
+using ERP.Application;
+using ERP.Domain;
+using Satisfactory.Save;
+
+namespace ApiService.Tests;
+
+/// <summary>
+/// Unit tests for the GeoJSON producer's pipe-feature emission (#65). Builds
+/// a <see cref="LiveFactoryState"/> directly (no save file needed) and asserts
+/// that:
+/// <list type="bullet">
+///   <item><c>Pipeline.Polyline</c> with ≥2 points → <c>LineString</c> feature.</item>
+///   <item><c>Pipeline.Polyline</c> null / single point → <c>Point</c> feature at the actor's position.</item>
+///   <item>Both flavours surface category=<c>"pipe"</c> + the tier on properties.</item>
+/// </list>
+/// The empty-polyline path is the one that runs in production today — the
+/// vendored SatisfactorySaveNet fork doesn't parse <c>Array&lt;Struct&gt;</c>
+/// (pipes' <c>mSplineData</c> shape) yet — but the LineString branch is what
+/// will activate the moment the fork lands the new reader.
+/// </summary>
+public sealed class FactoryStateGeoJsonPipelineTests
+{
+    [Fact]
+    public void Emits_LineString_when_polyline_has_two_or_more_points()
+    {
+        var state = StateWithPipelines(
+            new Pipeline(
+                Reference: "Persistent_Level:PersistentLevel.Build_Pipeline_C_42",
+                Tier: PipelineTier.Mk1,
+                Position: new Position(100, 200, 0),
+                Polyline: new[]
+                {
+                    new Position(100, 200, 0),
+                    new Position(150, 250, 0),
+                    new Position(200, 300, 0),
+                }));
+
+        var feature = SingleFeatureOfCategory(state, "pipe");
+
+        Assert.Equal("LineString", feature.Geometry.Type);
+        var coords = Assert.IsType<double[][]>(feature.Geometry.Coordinates);
+        Assert.Equal(3, coords.Length);
+        Assert.Equal(new[] { 100d, 200d }, coords[0]);
+        Assert.Equal(new[] { 200d, 300d }, coords[2]);
+        Assert.Equal("Mk1", feature.Properties["tier"]);
+    }
+
+    [Fact]
+    public void Emits_Point_when_polyline_is_null()
+    {
+        var state = StateWithPipelines(
+            new Pipeline(
+                Reference: "Persistent_Level:PersistentLevel.Build_PipelineMk2_C_7",
+                Tier: PipelineTier.Mk2,
+                Position: new Position(50, -25, 0),
+                Polyline: null));
+
+        var feature = SingleFeatureOfCategory(state, "pipe");
+
+        Assert.Equal("Point", feature.Geometry.Type);
+        var coords = Assert.IsType<double[]>(feature.Geometry.Coordinates);
+        Assert.Equal(new[] { 50d, -25d }, coords);
+        Assert.Equal("Mk2", feature.Properties["tier"]);
+    }
+
+    [Fact]
+    public void Emits_Point_when_polyline_has_a_single_point()
+    {
+        // GeoJSON spec wise a single-point LineString is invalid; the
+        // producer must fall back to Point so the wire shape stays valid.
+        var state = StateWithPipelines(
+            new Pipeline(
+                Reference: "Persistent_Level:PersistentLevel.Build_Pipeline_C_99",
+                Tier: PipelineTier.Mk1,
+                Position: new Position(10, 20, 0),
+                Polyline: new[] { new Position(10, 20, 0) }));
+
+        var feature = SingleFeatureOfCategory(state, "pipe");
+
+        Assert.Equal("Point", feature.Geometry.Type);
+    }
+
+    // ----- helpers ----------------------------------------------------------
+
+    private static LiveFactoryState StateWithPipelines(params Pipeline[] pipes) => new(
+        Save: new SaveMetadata("test", 1, 1, TimeSpan.Zero, DateTime.UtcNow),
+        ResourceNodes: [],
+        Miners: [],
+        Buildings: [],
+        Belts: [],
+        Pipelines: pipes,
+        Generators: [],
+        Warnings: []);
+
+    private static GeoFeature SingleFeatureOfCategory(LiveFactoryState state, string category)
+    {
+        var provider = new StubStateProvider(state);
+        var catalog = new StubCatalog();
+        var geo = FactoryStateGeoJson.From(provider, catalog, KnownFlora.Empty);
+        var feature = Assert.Single(geo.Features, f => (string?)f.Properties["category"] == category);
+        return feature;
+    }
+
+    private sealed class StubStateProvider(LiveFactoryState state) : IFactoryStateProvider
+    {
+        public bool IsLoaded => true;
+        public string? Source => "stub";
+        public LiveFactoryState Current { get; } = state;
+        public FactoryStateStatus GetStatus() => throw new NotSupportedException();
+        public FactoryStateStatus LoadFromPath(string savePath) => throw new NotSupportedException();
+        public FactoryStateStatus Refresh() => throw new NotSupportedException();
+    }
+
+    private sealed class StubCatalog : ICatalogProvider
+    {
+        public bool IsLoaded => false;
+        public string? Source => null;
+        public IReadOnlyList<Item> Items => [];
+        public IReadOnlyList<Building> Buildings => [];
+        public IReadOnlyList<Recipe> Recipes => [];
+        public Item? FindItem(ItemId id) => null;
+        public Building? FindBuilding(BuildingId id) => null;
+        public Recipe? FindRecipe(RecipeId id) => null;
+        public Recipe? FindDefaultProducerOf(ItemId item) => null;
+        public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) => [];
+        public CatalogueStatus GetStatus() => throw new NotSupportedException();
+        public CatalogueStatus LoadFromPath(string docsJsonPath) => throw new NotSupportedException();
+    }
+}

--- a/test/ERP/Application.Tests/FactoryAlertAnalysisServiceTests.cs
+++ b/test/ERP/Application.Tests/FactoryAlertAnalysisServiceTests.cs
@@ -182,6 +182,7 @@ public class FactoryAlertAnalysisServiceTests
             Miners: miners ?? [],
             Buildings: buildings ?? [],
             Belts: [],
+            Pipelines: [],
             Generators: [],
             Warnings: []);
 


### PR DESCRIPTION
## Summary

Adds the app-side plumbing so fluid pipes can render as LineStrings on
`/factory/map` the moment the SatisfactorySaveNet fork starts
deserialising pipe `mSplineData` (`Array<Struct<FSplinePointData>>`).
Until that lands, pipes fall back to point markers — same shape the
belt code uses today.

Partially addresses #65. Follow-up parser work tracked in #138.

## Path taken (A vs B)

**Path A (pragmatic scaffolding).** Issue #65 is explicitly nice-to-have;
the heavier Path B (Array<Struct> reader in the vendored fork) is a lot
of work for a niche feature. This PR lays the entire app-side surface so
the moment the fork lands the new property reader, the producer flips
pipes from Point to LineString without any further app-side change.

Path B is filed as #138, referenced from the new `Pipeline.cs` xmldoc
and the parser fallback comment in `SaveFileReader`.

## What's in the box

- `Pipeline` / `PipelineTier` domain types mirroring `ConveyorBelt` /
  `BeltTier`. `Polyline` is `IReadOnlyList<Position>?`, currently always
  `null` — see the xmldoc on `Pipeline.cs`.
- `LiveFactoryState` gains a `Pipelines` list; `SaveFileReader`
  recognises `Build_Pipeline_C` (Mk1) and `Build_PipelineMk2_C` (Mk2)
  actors and emits `Pipeline` records with `Polyline: null`.
- `FactoryStateGeoJson.From` emits a `pipe` category — `LineString` when
  `Polyline.Count >= 2`, `Point` at the actor's position otherwise.
  Mirrors the belt code path exactly.
- `factory-map.js` STYLE entry for `pipe` with a `tierColors` map
  (Mk1 teal `#4FB3BF`, Mk2 brighter cyan `#9CDEE0`). `buildShape` reads
  `feature.properties.tier` and applies the per-tier colour to both
  LineString strokes and the Point fallback.
- `FactoryStateView` + `FactoryIngest.razor` surface a "Pipelines (by
  tier)" panel so the new field has visibility on the ingest page.
- Unit tests in `test/ApiService.Tests/FactoryStateGeoJsonPipelineTests.cs`
  cover all three producer branches (LineString ≥2 points, Point when
  null, Point when single-point — the last one because a single-point
  LineString is GeoJSON-invalid).

## Test plan

- [x] `dotnet build ERP.Satisfactory.slnx` passes
- [x] `./build.sh TestNoUi` passes (all suites green)
- [x] `dotnet test test/ApiService.Tests/ApiService.Tests.csproj --filter "FullyQualifiedName~FactoryStateGeoJsonPipelineTests"` — 3/3 pass
- [ ] Manual: ingest a v1.2 save with pipes; confirm `/factory/state.geojson`
      includes `category: "pipe"` features (currently as Points until #138).
- [ ] Manual: visit `/factory/map`, toggle the new "Pipelines" layer in
      the legend, confirm Mk1/Mk2 dots are tier-coloured.

Note: `ApiService.Tests` is not in `ERP.Satisfactory.slnx` (folder is
present but no project reference). It builds + tests cleanly via the
csproj directly. Not touching the slnx per project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)