### PR TITLE
feat(planner): model fluid throughput constraints (#90)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -968,6 +968,14 @@ public sealed record MissingInputDto(
 
 public sealed record RecipeRefDto(string Id, string Name);
 
+/// <summary>Per-fluid pipe-throughput summary (#90). <c>RecommendedTier</c>
+/// is the enum name ("Mk1" / "Mk2" / "OverMk2") for clean JSON.</summary>
+public sealed record FluidPipeRequirementDto(
+    string ItemId,
+    string ItemName,
+    decimal MaxRatePerMinute,
+    string RecommendedTier);
+
 public sealed record PlanDto(
     bool IsFeasible,
     IReadOnlyList<StepDto> Steps,
@@ -975,7 +983,8 @@ public sealed record PlanDto(
     IReadOnlyList<AmountDto> RawInputsConsumed,
     IReadOnlyList<MissingInputDto> MissingInputs,
     IReadOnlyList<ExtractorAllocationDto> ExtractorAllocations,
-    IReadOnlyList<string> Warnings)
+    IReadOnlyList<string> Warnings,
+    IReadOnlyList<FluidPipeRequirementDto> FluidPipeRequirements)
 {
     public static PlanDto From(ProductionPlan plan, ICatalogProvider catalog)
     {
@@ -1004,6 +1013,13 @@ public sealed record PlanDto(
                 MinerFraction: Math.Round(a.MinerFraction, 4),
                 OutputPerMinute: Math.Round(a.OutputPerMinute, 4));
 
+        FluidPipeRequirementDto ToFluidPipe(FluidPipeRequirement f) =>
+            new(
+                ItemId: f.Item.Value,
+                ItemName: catalog.FindItem(f.Item)?.Name ?? f.Item.Value,
+                MaxRatePerMinute: Math.Round(f.MaxRatePerMinute, 4),
+                RecommendedTier: f.RecommendedTier.ToString());
+
         var steps = plan.Steps.Select(s => new StepDto(
             s.Recipe.Id.Value,
             s.Recipe.Name,
@@ -1021,6 +1037,7 @@ public sealed record PlanDto(
             RawInputsConsumed: plan.RawInputsConsumed.Select(ToAmount).ToList(),
             MissingInputs: plan.MissingInputs.Select(ToMissing).ToList(),
             ExtractorAllocations: plan.Allocations.Select(ToAllocation).ToList(),
-            Warnings: plan.WarningsOrEmpty);
+            Warnings: plan.WarningsOrEmpty,
+            FluidPipeRequirements: plan.Pipes.Select(ToFluidPipe).ToList());
     }
 }

--- a/src/ERP/Application/Queries/PlanProduction/FluidPipeRequirements.cs
+++ b/src/ERP/Application/Queries/PlanProduction/FluidPipeRequirements.cs
@@ -1,0 +1,109 @@
+using ERP.Domain;
+
+namespace ERP.Application.Queries.PlanProduction;
+
+/// <summary>
+/// Shared post-solve helper that scans a plan's steps + raw inputs for fluid
+/// items, computes the max single-edge rate per fluid, and recommends a pipe
+/// tier (#90). Both <c>RecursiveRecipePlanner</c> (Application) and
+/// <c>OrToolsRecipePlanner</c> (Infrastructure) call this — fluid throughput
+/// is a property of the solved plan, not the engine that produced it.
+///
+/// <para>
+/// <strong>Heuristic — v1.</strong> "Max single-edge rate" is the largest
+/// per-step input or output rate for the fluid across all steps (plus any
+/// raw-input rate). It's the floor of "what one Mk of pipe must carry"; the
+/// actual physical network might aggregate several edges onto one pipe run
+/// and need a higher Mk, but that requires topology we don't have yet (issue
+/// #90 calls topology and headlift out of scope).
+/// </para>
+/// </summary>
+public static class FluidPipeRequirements
+{
+    /// <summary>Mk1 pipe throughput cap in m³/min.</summary>
+    public const decimal Mk1CapPerMinute = 300m;
+
+    /// <summary>Mk2 pipe throughput cap in m³/min.</summary>
+    public const decimal Mk2CapPerMinute = 600m;
+
+    /// <summary>
+    /// Catalogue doesn't expose an <c>ItemForm</c> field yet, so we hard-code
+    /// the set of Satisfactory fluids (liquids + gases) we know about. When
+    /// the catalogue grows a form flag (issue follow-up), swap this for a
+    /// catalogue lookup.
+    /// </summary>
+    private static readonly HashSet<string> KnownFluidItemIds =
+    [
+        "Desc_Water_C",
+        "Desc_LiquidOil_C",
+        "Desc_HeavyOilResidue_C",
+        "Desc_LiquidFuel_C",
+        "Desc_LiquidBiofuel_C",
+        "Desc_LiquidTurboFuel_C",
+        "Desc_AluminaSolution_C",
+        "Desc_SulfuricAcid_C",
+        "Desc_NitricAcid_C",
+        "Desc_NitrogenGas_C",
+        "Desc_RocketFuel_C",
+        "Desc_IonizedFuel_C",
+    ];
+
+    public static bool IsFluid(ItemId item) => KnownFluidItemIds.Contains(item.Value);
+
+    /// <summary>
+    /// Builds the fluid-pipe summary list. Iterates raw inputs + every step's
+    /// per-minute inputs and outputs, keeping the max rate seen per fluid
+    /// item. Returns an empty list when no fluids participate.
+    /// </summary>
+    public static IReadOnlyList<FluidPipeRequirement> Build(
+        IReadOnlyList<ProductionStep> steps,
+        IReadOnlyList<ItemAmount> rawInputsConsumed)
+    {
+        var maxByItem = new Dictionary<ItemId, decimal>();
+
+        foreach (var raw in rawInputsConsumed)
+        {
+            if (!IsFluid(raw.Item)) continue;
+            Track(maxByItem, raw.Item, raw.Quantity);
+        }
+
+        foreach (var step in steps)
+        {
+            foreach (var amount in step.InputsPerMinute)
+            {
+                if (!IsFluid(amount.Item)) continue;
+                Track(maxByItem, amount.Item, amount.Quantity);
+            }
+            foreach (var amount in step.OutputsPerMinute)
+            {
+                if (!IsFluid(amount.Item)) continue;
+                Track(maxByItem, amount.Item, amount.Quantity);
+            }
+        }
+
+        return maxByItem
+            .OrderBy(kv => kv.Key.Value, StringComparer.Ordinal)
+            .Select(kv => new FluidPipeRequirement(kv.Key, kv.Value, RecommendTier(kv.Value)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Maps a single-edge throughput to the smallest pipe Mk that can carry
+    /// it. Rates above Mk2's 600 m³/min cap return <see cref="PipeTier.OverMk2"/>
+    /// — the planner can't fix that with a higher Mk; the user has to split
+    /// the edge across multiple physical pipes.
+    /// </summary>
+    public static PipeTier RecommendTier(decimal ratePerMinute)
+    {
+        if (ratePerMinute <= Mk1CapPerMinute) return PipeTier.Mk1;
+        if (ratePerMinute <= Mk2CapPerMinute) return PipeTier.Mk2;
+        return PipeTier.OverMk2;
+    }
+
+    private static void Track(Dictionary<ItemId, decimal> max, ItemId item, decimal rate)
+    {
+        if (rate <= 0) return;
+        if (!max.TryGetValue(item, out var current) || rate > current)
+            max[item] = rate;
+    }
+}

--- a/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
+++ b/src/ERP/Application/Queries/PlanProduction/RecursiveRecipePlanner.cs
@@ -41,13 +41,16 @@ public sealed class RecursiveRecipePlanner : IRecipePlanner
             .Select(a => BuildStep(a.Recipe, a.OutputRatePerMinute))
             .ToList();
 
+        var rawInputs = rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList();
+
         return new ProductionPlan(
             Targets: query.Targets,
             Available: query.Available,
             Steps: steps,
-            RawInputsConsumed: rawConsumed.Select(kv => new ItemAmount(kv.Key, kv.Value)).ToList(),
+            RawInputsConsumed: rawInputs,
             MissingInputs: InfeasibilityDiagnostics.Build(missing, _catalog, steps),
-            Warnings: PowerVarianceWarning.Build(steps));
+            Warnings: PowerVarianceWarning.Build(steps),
+            FluidPipes: FluidPipeRequirements.Build(steps, rawInputs));
     }
 
     private void Expand(

--- a/src/ERP/Domain/FluidPipeRequirement.cs
+++ b/src/ERP/Domain/FluidPipeRequirement.cs
@@ -1,0 +1,25 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// Per-fluid pipe-throughput summary added to the plan (#90). One entry per
+/// fluid item that shows up anywhere in the plan (raw inputs, recipe inputs,
+/// recipe outputs); reports the max single-edge rate seen and the recommended
+/// pipe tier that can carry that edge.
+///
+/// <para>
+/// <em>Single-edge</em> is the v1 heuristic — we don't yet model how recipes
+/// share pipe runs in the physical factory, only "no recipe in the plan emits
+/// or consumes more than X m³/min of this fluid on its own edge". The single
+/// recipe is the lower bound for the pipe Mk you need; the actual aggregated
+/// network throughput is at least that and possibly more.
+/// </para>
+///
+/// <para>
+/// Headlift / vertical transport is deliberately out of scope (issue #90 calls
+/// this out as a separate concern).
+/// </para>
+/// </summary>
+public sealed record FluidPipeRequirement(
+    ItemId Item,
+    decimal MaxRatePerMinute,
+    PipeTier RecommendedTier);

--- a/src/ERP/Domain/PipeTier.cs
+++ b/src/ERP/Domain/PipeTier.cs
@@ -1,0 +1,22 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// In-game pipe tier recommendation for a fluid line (#90).
+///
+/// <para>
+/// Throughput caps:
+/// <list type="bullet">
+///   <item><c>Mk1</c>: ≤ 300 m³/min</item>
+///   <item><c>Mk2</c>: ≤ 600 m³/min</item>
+///   <item><c>OverMk2</c>: &gt; 600 m³/min — no single pipe can carry it; the
+///     user has to split the line across multiple pipes. The recommendation is
+///     informational rather than a solver constraint.</item>
+/// </list>
+/// </para>
+/// </summary>
+public enum PipeTier
+{
+    Mk1 = 1,
+    Mk2 = 2,
+    OverMk2 = 3,
+}

--- a/src/ERP/Domain/ProductionPlan.cs
+++ b/src/ERP/Domain/ProductionPlan.cs
@@ -7,6 +7,7 @@ namespace ERP.Domain;
 /// flags any unsatisfied demand.
 /// <para>
 /// <see cref="ExtractorAllocations"/> reports per-node miner placement (#92).
+/// <see cref="FluidPipes"/> reports per-fluid pipe-Mk recommendations (#90).
 /// <see cref="Warnings"/> is a list of advisory, plan-wide caveats — strings
 /// that the UI / API surface as informational text alongside the plan. Today
 /// the only producer is the variable-power-buildings notice (#91 v1): when a
@@ -23,7 +24,8 @@ public sealed record ProductionPlan(
     IReadOnlyList<ItemAmount> RawInputsConsumed,
     IReadOnlyList<InfeasibleItem> MissingInputs,
     IReadOnlyList<ExtractorAllocation>? ExtractorAllocations = null,
-    IReadOnlyList<string>? Warnings = null)
+    IReadOnlyList<string>? Warnings = null,
+    IReadOnlyList<FluidPipeRequirement>? FluidPipes = null)
 {
     public IReadOnlyList<string> WarningsOrEmpty => Warnings ?? Array.Empty<string>();
 
@@ -35,4 +37,12 @@ public sealed record ProductionPlan(
     /// </summary>
     public IReadOnlyList<ExtractorAllocation> Allocations =>
         ExtractorAllocations ?? Array.Empty<ExtractorAllocation>();
+
+    /// <summary>
+    /// Non-null shorthand for the optional <see cref="FluidPipes"/> field.
+    /// Plans with no fluids in their inputs/outputs leave it as the empty list
+    /// — callers that want to iterate can use this without null checks.
+    /// </summary>
+    public IReadOnlyList<FluidPipeRequirement> Pipes =>
+        FluidPipes ?? Array.Empty<FluidPipeRequirement>();
 }

--- a/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
+++ b/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
@@ -268,7 +268,8 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
             RawInputsConsumed: rawConsumed,
             MissingInputs: InfeasibilityDiagnostics.Build(missingByItem, _catalog, steps),
             ExtractorAllocations: allocations,
-            Warnings: PowerVarianceWarning.Build(steps));
+            Warnings: PowerVarianceWarning.Build(steps),
+            FluidPipes: FluidPipeRequirements.Build(steps, rawConsumed));
     }
 
     private static readonly IReadOnlyList<MinerTier> AllMinerTiers =

--- a/src/Web/Components/Pages/Planner.razor
+++ b/src/Web/Components/Pages/Planner.razor
@@ -325,6 +325,53 @@ else
         </MudDataGrid>
     }
 
+    @if (plan.Pipes.Count > 0)
+    {
+        <MudText Typo="Typo.h5" Class="mt-4 mb-1">Fluid pipes</MudText>
+        <MudText Typo="Typo.caption" Color="Color.Default" Class="d-block mb-2">
+            Recommended pipe Mk per fluid based on the max single-edge rate in the plan.
+            Mk1 carries 300 m³/min, Mk2 carries 600 m³/min. Headlift (vertical transport)
+            isn't modelled yet.
+        </MudText>
+        <MudSimpleTable Dense="true" Hover="true" Class="fx-fluid-pipes">
+            <thead>
+                <tr>
+                    <th>Fluid</th>
+                    <th style="text-align: right;">Max rate (m³/min)</th>
+                    <th>Recommended pipe</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var pipe in plan.Pipes)
+                {
+                    <tr>
+                        <td>
+                            <span class="fx-amount" title="@pipe.ItemName">
+                                <img src="/assets/icons/items/@(pipe.ItemId).png"
+                                     onerror="this.style.visibility='hidden'"
+                                     alt="" />
+                                <span class="fx-amount-text">@pipe.ItemName</span>
+                            </span>
+                        </td>
+                        <td style="text-align: right;">@FormatRate(pipe.MaxRatePerMinute)</td>
+                        <td>
+                            @{
+                                var (label, color) = pipe.RecommendedTier switch
+                                {
+                                    "Mk1" => ("Mk1 pipe", Color.Success),
+                                    "Mk2" => ("Mk2 pipe", Color.Info),
+                                    "OverMk2" => ("Over Mk2 — split line", Color.Warning),
+                                    _ => (pipe.RecommendedTier, Color.Default),
+                                };
+                            }
+                            <MudChip T="string" Color="@color" Variant="Variant.Outlined" Size="Size.Small">@label</MudChip>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </MudSimpleTable>
+    }
+
     @if (plan.RawInputsConsumed.Count > 0)
     {
         <MudText Typo="Typo.h5" Class="mt-4 mb-2">Raw inputs consumed (from sources)</MudText>

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -237,7 +237,8 @@ public sealed record PlanResponse(
     IReadOnlyList<AmountView> RawInputsConsumed,
     IReadOnlyList<MissingInputView> MissingInputs,
     IReadOnlyList<ExtractorAllocationView> ExtractorAllocations,
-    IReadOnlyList<string>? Warnings = null)
+    IReadOnlyList<string>? Warnings = null,
+    IReadOnlyList<FluidPipeRequirementView>? FluidPipeRequirements = null)
 {
     /// <summary>
     /// Plan-wide advisory strings (e.g. the variable-power-buildings notice
@@ -247,6 +248,15 @@ public sealed record PlanResponse(
     /// null check.
     /// </summary>
     public IReadOnlyList<string> WarningsOrEmpty => Warnings ?? Array.Empty<string>();
+
+    /// <summary>
+    /// Non-null shorthand for the optional <see cref="FluidPipeRequirements"/>
+    /// field — older API responses (and any future server that omits the
+    /// section) read as the empty list, so Razor can iterate without null
+    /// checks.
+    /// </summary>
+    public IReadOnlyList<FluidPipeRequirementView> Pipes =>
+        FluidPipeRequirements ?? [];
 }
 
 /// <summary>Per-node extraction breakdown (#92). Empty when the request
@@ -259,6 +269,14 @@ public sealed record ExtractorAllocationView(
     string Tier,
     decimal MinerFraction,
     decimal OutputPerMinute);
+
+/// <summary>Per-fluid pipe-throughput summary surfaced in the planner UI (#90).
+/// <c>RecommendedTier</c> is the enum name ("Mk1" / "Mk2" / "OverMk2").</summary>
+public sealed record FluidPipeRequirementView(
+    string ItemId,
+    string ItemName,
+    decimal MaxRatePerMinute,
+    string RecommendedTier);
 
 /// <summary>Per-item diagnostic for an unsatisfied target (#8).
 /// <c>ItemId</c> + <c>ItemName</c> + <c>ItemsPerMinute</c> match the previous

--- a/test/ERP/Application.Tests/FluidPipeRequirementsTests.cs
+++ b/test/ERP/Application.Tests/FluidPipeRequirementsTests.cs
@@ -1,0 +1,133 @@
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+
+namespace ERP.Application.Tests;
+
+/// <summary>
+/// Direct tests for <see cref="FluidPipeRequirements"/> — the shared post-solve
+/// helper both planners call. Covers issue #90's acceptance edges (exactly at
+/// Mk1, over Mk1, well under) plus the tier-mapping function in isolation.
+/// </summary>
+public class FluidPipeRequirementsTests
+{
+    private static readonly ItemId Water = new("Desc_Water_C");
+    private static readonly ItemId HeavyOilResidue = new("Desc_HeavyOilResidue_C");
+    private static readonly ItemId LiquidFuel = new("Desc_LiquidFuel_C");
+    private static readonly ItemId IronOre = new("Desc_OreIron_C"); // solid — must be ignored
+
+    private static readonly BuildingId Refinery = new("Build_OilRefinery_C");
+
+    private static Recipe FluidRecipe(string id, ItemAmount[] inputs, ItemAmount[] outputs) =>
+        new(new RecipeId(id), id, Refinery, inputs, outputs, TimeSpan.FromSeconds(60));
+
+    [Fact]
+    public void Recommends_Mk1_When_Exactly_At_Mk1_Limit()
+    {
+        // 300/min sits on the Mk1 cap — should still pick Mk1 (not bump to Mk2)
+        // since Mk1 *can* carry exactly that. This is the boundary the issue's
+        // acceptance criteria flag as "no warning".
+        Assert.Equal(PipeTier.Mk1, FluidPipeRequirements.RecommendTier(300m));
+    }
+
+    [Fact]
+    public void Recommends_Mk2_When_Over_Mk1_Limit()
+    {
+        // 480/min Heavy Oil Residue (issue's acceptance example) needs Mk2.
+        Assert.Equal(PipeTier.Mk2, FluidPipeRequirements.RecommendTier(480m));
+    }
+
+    [Fact]
+    public void Recommends_Mk1_When_Well_Under_Mk1_Limit()
+    {
+        // 50/min is comfortably under 300 — Mk1 is the recommendation.
+        Assert.Equal(PipeTier.Mk1, FluidPipeRequirements.RecommendTier(50m));
+    }
+
+    [Fact]
+    public void Recommends_OverMk2_When_Above_Mk2_Limit()
+    {
+        // > 600/min can't be carried by a single pipe at any tier; v1 surfaces
+        // OverMk2 as a "split the line" hint rather than a hard error.
+        Assert.Equal(PipeTier.OverMk2, FluidPipeRequirements.RecommendTier(750m));
+    }
+
+    [Fact]
+    public void Build_Picks_Max_Single_Edge_Rate_Across_Steps()
+    {
+        // Two steps that each consume water — the helper should report the
+        // *max* of the two, not the sum (issue calls out single-edge as the v1
+        // heuristic; network aggregation is out of scope).
+        var stepA = new ProductionStep(
+            FluidRecipe("A", inputs: [new(Water, 1)], outputs: [new(HeavyOilResidue, 1)]),
+            BuildingCount: 1m,
+            PowerMw: 0,
+            InputsPerMinute: [new ItemAmount(Water, 120m)],
+            OutputsPerMinute: [new ItemAmount(HeavyOilResidue, 80m)]);
+        var stepB = new ProductionStep(
+            FluidRecipe("B", inputs: [new(Water, 1)], outputs: [new(LiquidFuel, 1)]),
+            BuildingCount: 1m,
+            PowerMw: 0,
+            InputsPerMinute: [new ItemAmount(Water, 480m)],   // bigger edge → drives the Mk
+            OutputsPerMinute: [new ItemAmount(LiquidFuel, 40m)]);
+
+        var pipes = FluidPipeRequirements.Build(
+            steps: [stepA, stepB],
+            rawInputsConsumed: []);
+
+        var water = pipes.Single(p => p.Item == Water);
+        Assert.Equal(480m, water.MaxRatePerMinute);
+        Assert.Equal(PipeTier.Mk2, water.RecommendedTier);
+    }
+
+    [Fact]
+    public void Build_Skips_Solid_Items()
+    {
+        // A step pulling 600 iron ore/min on the input edge is fine — iron ore
+        // travels on belts, not pipes. The helper must not emit it.
+        var step = new ProductionStep(
+            FluidRecipe("Smelt", inputs: [new(IronOre, 1)], outputs: [new(Water, 1)]),
+            BuildingCount: 1m,
+            PowerMw: 0,
+            InputsPerMinute: [new ItemAmount(IronOre, 600m)],
+            OutputsPerMinute: [new ItemAmount(Water, 60m)]);
+
+        var pipes = FluidPipeRequirements.Build(steps: [step], rawInputsConsumed: []);
+
+        Assert.DoesNotContain(pipes, p => p.Item == IronOre);
+        Assert.Contains(pipes, p => p.Item == Water);
+    }
+
+    [Fact]
+    public void Build_Includes_Raw_Fluid_Inputs()
+    {
+        // When a plan draws crude oil from the user's available inputs without
+        // any recipe-edge consumption (rare but possible if the target *is*
+        // the raw), the helper should still recommend a pipe for it.
+        var pipes = FluidPipeRequirements.Build(
+            steps: [],
+            rawInputsConsumed: [new ItemAmount(Water, 250m)]);
+
+        var water = pipes.Single(p => p.Item == Water);
+        Assert.Equal(250m, water.MaxRatePerMinute);
+        Assert.Equal(PipeTier.Mk1, water.RecommendedTier);
+    }
+
+    [Fact]
+    public void Build_Returns_Empty_For_All_Solid_Plan()
+    {
+        var step = new ProductionStep(
+            FluidRecipe("IronPlate",
+                inputs: [new(IronOre, 1)],
+                outputs: [new(new ItemId("Desc_IronIngot_C"), 1)]),
+            BuildingCount: 1m,
+            PowerMw: 0,
+            InputsPerMinute: [new ItemAmount(IronOre, 60m)],
+            OutputsPerMinute: [new ItemAmount(new ItemId("Desc_IronIngot_C"), 60m)]);
+
+        var pipes = FluidPipeRequirements.Build(
+            steps: [step],
+            rawInputsConsumed: [new ItemAmount(IronOre, 60m)]);
+
+        Assert.Empty(pipes);
+    }
+}

--- a/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
+++ b/test/ERP/Application.Tests/RecursiveRecipePlannerTests.cs
@@ -80,6 +80,38 @@ public class RecursiveRecipePlannerTests
     }
 
     [Fact]
+    public void Populates_Fluid_Pipe_Requirements_For_Fluid_Outputs()
+    {
+        // RecursiveRecipePlanner must also call FluidPipeRequirements (#90) —
+        // it's a post-solve property, not an engine-specific concern. Build a
+        // recipe that emits 480/min of Heavy Oil Residue (the issue's
+        // acceptance example) and check the plan flags Mk2.
+        var refineryId = new BuildingId("Build_OilRefinery_C");
+        var crudeOil = new ItemId("Desc_LiquidOil_C");
+        var heavyOilResidue = new ItemId("Desc_HeavyOilResidue_C");
+        var residueRecipe = new Recipe(
+            new RecipeId("Recipe_ResidueOverMk1_C"),
+            "Residue (over Mk1)",
+            refineryId,
+            Inputs: [new ItemAmount(crudeOil, 1)],
+            Outputs: [new ItemAmount(heavyOilResidue, 8)],
+            Duration: TimeSpan.FromSeconds(1));
+
+        var catalog = new FakeCatalog(
+            buildings: [new Building(refineryId, "Refinery", BasePowerMw: 30)],
+            recipes: [residueRecipe]);
+
+        var planner = new RecursiveRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(heavyOilResidue, 480)],
+            Available: [new ResourceAvailability(crudeOil, 999)]));
+
+        var residue = plan.Pipes.Single(p => p.Item == heavyOilResidue);
+        Assert.Equal(480m, residue.MaxRatePerMinute);
+        Assert.Equal(PipeTier.Mk2, residue.RecommendedTier);
+    }
+
+    [Fact]
     public void Power_Is_Zero_When_Building_Missing_From_Catalogue()
     {
         // Missing building entry → defensive zero rather than throwing.

--- a/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
+++ b/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
@@ -244,4 +244,92 @@ public class OrToolsRecipePlannerTests
         Assert.InRange(step.BuildingCount, 1m - Tol, 1m + Tol);
         Assert.Empty(plan.MissingInputs);
     }
+
+    // --------------------- Fluid pipe requirements (#90) ---------------------
+    //
+    // After solving, both planners populate ProductionPlan.FluidPipes with the
+    // max single-edge rate per fluid + a recommended pipe Mk. The three cases
+    // below are the issue's acceptance edges: exactly at the Mk1 cap (300/min),
+    // over Mk1 (480/min → Mk2), and well under (50/min → Mk1).
+
+    [Fact]
+    public void Fluid_Pipes_Recommend_Mk1_Exactly_At_Limit()
+    {
+        // Build a refinery recipe whose Heavy Oil Residue output is exactly
+        // 300/min — the Mk1 cap. The helper must still pick Mk1 (not bump up).
+        // 5 residue per 1s = 300/min. Crude oil input is well under the cap.
+        var residueAtCap = new Recipe(
+            new RecipeId("Recipe_ResidueAtMk1_C"),
+            "Residue (Mk1 boundary)",
+            RefineryId,
+            Inputs: [new ItemAmount(CrudeOil, 1)],
+            Outputs: [new ItemAmount(HeavyOilResidue, 5)],
+            Duration: TimeSpan.FromSeconds(1));
+
+        var catalog = new FakeCatalog(
+            buildings: [new Building(RefineryId, "Refinery", BasePowerMw: 30)],
+            recipes: [residueAtCap]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(HeavyOilResidue, 300)],
+            Available: [new ResourceAvailability(CrudeOil, 999)]));
+
+        var residue = plan.Pipes.Single(p => p.Item == HeavyOilResidue);
+        Assert.InRange(residue.MaxRatePerMinute, 300m - Tol, 300m + Tol);
+        Assert.Equal(PipeTier.Mk1, residue.RecommendedTier);
+    }
+
+    [Fact]
+    public void Fluid_Pipes_Recommend_Mk2_When_Over_Mk1()
+    {
+        // 480/min Heavy Oil Residue — the issue's acceptance example. Needs Mk2.
+        // 8 residue per 1s = 480/min.
+        var residueOverMk1 = new Recipe(
+            new RecipeId("Recipe_ResidueOverMk1_C"),
+            "Residue (over Mk1)",
+            RefineryId,
+            Inputs: [new ItemAmount(CrudeOil, 1)],
+            Outputs: [new ItemAmount(HeavyOilResidue, 8)],
+            Duration: TimeSpan.FromSeconds(1));
+
+        var catalog = new FakeCatalog(
+            buildings: [new Building(RefineryId, "Refinery", BasePowerMw: 30)],
+            recipes: [residueOverMk1]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(HeavyOilResidue, 480)],
+            Available: [new ResourceAvailability(CrudeOil, 999)]));
+
+        var residue = plan.Pipes.Single(p => p.Item == HeavyOilResidue);
+        Assert.InRange(residue.MaxRatePerMinute, 480m - Tol, 480m + Tol);
+        Assert.Equal(PipeTier.Mk2, residue.RecommendedTier);
+    }
+
+    [Fact]
+    public void Fluid_Pipes_Recommend_Mk1_When_Well_Under_Limit()
+    {
+        // 50/min water — comfortably under 300 — should pick Mk1 with no fuss.
+        var smallWaterRecipe = new Recipe(
+            new RecipeId("Recipe_WaterTrickle_C"),
+            "Water (trickle)",
+            RefineryId,
+            Inputs: [],
+            Outputs: [new ItemAmount(Water, 50)],
+            Duration: TimeSpan.FromSeconds(60));
+
+        var catalog = new FakeCatalog(
+            buildings: [new Building(RefineryId, "Refinery", BasePowerMw: 30)],
+            recipes: [smallWaterRecipe]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(Water, 50)],
+            Available: []));
+
+        var water = plan.Pipes.Single(p => p.Item == Water);
+        Assert.InRange(water.MaxRatePerMinute, 50m - Tol, 50m + Tol);
+        Assert.Equal(PipeTier.Mk1, water.RecommendedTier);
+    }
 }

--- a/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
+++ b/test/ERP/Infrastructure.Tests/PlannerTestFixtures.cs
@@ -24,6 +24,9 @@ internal static class PlannerTestFixtures
     public static readonly ItemId CopperIngot = new("Desc_CopperIngot_C");
     public static readonly ItemId HeavyOilResidue = new("Desc_HeavyOilResidue_C");
     public static readonly ItemId Plastic = new("Desc_Plastic_C");
+    public static readonly ItemId Water = new("Desc_Water_C");
+    public static readonly ItemId CrudeOil = new("Desc_LiquidOil_C");
+    public static readonly ItemId LiquidFuel = new("Desc_LiquidFuel_C");
 
     public static readonly Recipe IronIngotRecipe = new(
         new RecipeId("Recipe_IngotIron_C"),


### PR DESCRIPTION
## Summary

Plans now surface a per-fluid pipe-Mk recommendation: max single-edge rate seen in the plan plus the pipe tier that can carry it (Mk1 ≤ 300 m³/min, Mk2 ≤ 600 m³/min, OverMk2 above that). Closes #90.

## What's new

**Domain**
- `PipeTier` enum (`Mk1` / `Mk2` / `OverMk2`).
- `FluidPipeRequirement(Item, MaxRatePerMinute, RecommendedTier)` record.
- `ProductionPlan` gains an optional `FluidPipes` list and a non-null `Pipes` helper property — same additive shape used for `ExtractorAllocations` in #92.

**Application**
- New `FluidPipeRequirements` shared helper (mirrors the `InfeasibilityDiagnostics` pattern — pure post-solve computation, engine-agnostic). Both `RecursiveRecipePlanner` and `OrToolsRecipePlanner` call it.
- Hard-coded set of known Satisfactory fluids (Water, Crude Oil, Heavy Oil Residue, Fuels, Alumina Solution, Sulfuric/Nitric Acid, Nitrogen Gas, Rocket/Ionized Fuel) — `Item` doesn't have an `ItemForm` flag yet; swap for catalogue lookup when one lands.

**Wire format / UI**
- `PlanDto.FluidPipeRequirements` on the ApiService side; mirrored on the Web client as `PlanResponse.FluidPipeRequirements` with a `Pipes` helper so older API responses degrade to an empty list.
- Planner page renders a small "Fluid pipes" table between the steps grid and the raw-inputs section — fluid name + max rate + Mk chip. Renders nothing when the plan has no fluids.

**Tests**
- `FluidPipeRequirementsTests` (Application) exercises the helper directly: three issue-acceptance edges (exactly 300/min → Mk1, 480/min → Mk2, 50/min → Mk1), tier-mapping above Mk2, max-single-edge selection across multiple steps, solid-item skipping, raw-fluid inclusion.
- `OrToolsRecipePlannerTests` adds end-to-end Mk1-boundary / Mk2 / well-under tests through the LP.
- `RecursiveRecipePlannerTests` adds a sanity test confirming the recursive engine also populates `FluidPipes`.

## Heuristic notes / out of scope

- **Single-edge rate** is the v1 heuristic — the largest input or output rate on any one step. Real per-pipe-line throughput would need network topology, which the issue explicitly defers.
- **Headlift / pump count** is deferred per the issue. Worth filing a follow-up ("Model fluid headlift constraints") in the same milestone if vertical transport ever becomes a planning concern.
- Mk recommendation is **informational only** — the LP does not auto-bump to Mk2 to keep a recipe feasible.

## Test plan

- [x] `dotnet build ERP.Satisfactory.slnx` — green
- [x] `./build.sh TestNoUi` — green (10 + 9 + others, all passing)
- [ ] Manual: open `/planner`, add a sink that produces 480/min of a fluid (e.g. Heavy Oil Residue), confirm "Fluid pipes" table shows Mk2 chip
- [ ] Manual: a plan with only solids shows no fluid-pipes section

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)