### PR TITLE
feat(planner): LP sensitivity analysis on plans (#129)

### DIFF
--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -976,6 +976,24 @@ public sealed record FluidPipeRequirementDto(
     decimal MaxRatePerMinute,
     string RecommendedTier);
 
+/// <summary>LP sensitivity surface attached to <see cref="PlanDto"/> when
+/// the OR-Tools engine ran the plan (#129). <c>null</c> on plans produced
+/// by the recursive engine.</summary>
+public sealed record LpSensitivityDto(
+    IReadOnlyList<ItemShadowPriceDto> SupplyConstraints,
+    IReadOnlyList<RecipeReducedCostDto> ProductionRecipes);
+
+public sealed record ItemShadowPriceDto(
+    string ItemId,
+    string ItemName,
+    decimal ShadowPrice,
+    decimal Slack);
+
+public sealed record RecipeReducedCostDto(
+    string RecipeId,
+    string RecipeName,
+    decimal ReducedCost);
+
 public sealed record PlanDto(
     bool IsFeasible,
     IReadOnlyList<StepDto> Steps,
@@ -984,7 +1002,8 @@ public sealed record PlanDto(
     IReadOnlyList<MissingInputDto> MissingInputs,
     IReadOnlyList<ExtractorAllocationDto> ExtractorAllocations,
     IReadOnlyList<string> Warnings,
-    IReadOnlyList<FluidPipeRequirementDto> FluidPipeRequirements)
+    IReadOnlyList<FluidPipeRequirementDto> FluidPipeRequirements,
+    LpSensitivityDto? Sensitivity)
 {
     public static PlanDto From(ProductionPlan plan, ICatalogProvider catalog)
     {
@@ -1020,6 +1039,25 @@ public sealed record PlanDto(
                 MaxRatePerMinute: Math.Round(f.MaxRatePerMinute, 4),
                 RecommendedTier: f.RecommendedTier.ToString());
 
+        LpSensitivityDto? ToSensitivity(LpSensitivity? s)
+        {
+            if (s is null) return null;
+            return new LpSensitivityDto(
+                SupplyConstraints: s.SupplyConstraints
+                    .Select(sp => new ItemShadowPriceDto(
+                        ItemId: sp.Item.Value,
+                        ItemName: catalog.FindItem(sp.Item)?.Name ?? sp.Item.Value,
+                        ShadowPrice: Math.Round(sp.ShadowPrice, 6),
+                        Slack: Math.Round(sp.Slack, 4)))
+                    .ToList(),
+                ProductionRecipes: s.ProductionRecipes
+                    .Select(rc => new RecipeReducedCostDto(
+                        RecipeId: rc.Recipe.Value,
+                        RecipeName: catalog.FindRecipe(rc.Recipe)?.Name ?? rc.Recipe.Value,
+                        ReducedCost: Math.Round(rc.ReducedCost, 6)))
+                    .ToList());
+        }
+
         var steps = plan.Steps.Select(s => new StepDto(
             s.Recipe.Id.Value,
             s.Recipe.Name,
@@ -1038,6 +1076,7 @@ public sealed record PlanDto(
             MissingInputs: plan.MissingInputs.Select(ToMissing).ToList(),
             ExtractorAllocations: plan.Allocations.Select(ToAllocation).ToList(),
             Warnings: plan.WarningsOrEmpty,
-            FluidPipeRequirements: plan.Pipes.Select(ToFluidPipe).ToList());
+            FluidPipeRequirements: plan.Pipes.Select(ToFluidPipe).ToList(),
+            Sensitivity: ToSensitivity(plan.Sensitivity));
     }
 }

--- a/src/ERP/Domain/LpSensitivity.cs
+++ b/src/ERP/Domain/LpSensitivity.cs
@@ -1,0 +1,52 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// LP sensitivity analysis attached to a <see cref="ProductionPlan"/> when
+/// the planner is the OR-Tools / GLOP engine (#129). The recursive engine
+/// can't produce these numbers; <see cref="ProductionPlan.Sensitivity"/>
+/// is <c>null</c> on plans it produced.
+///
+/// <para>
+/// Two surfaces here, both straight off the LP solve:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="SupplyConstraints"/> — per-item dual values + slack.</item>
+///   <item><see cref="ProductionRecipes"/> — per-recipe reduced costs for the
+///     recipes the LP did NOT activate (helps explain "why didn't the LP
+///     pick this alt?").</item>
+/// </list>
+/// </summary>
+public sealed record LpSensitivity(
+    IReadOnlyList<ItemShadowPrice> SupplyConstraints,
+    IReadOnlyList<RecipeReducedCost> ProductionRecipes);
+
+/// <summary>
+/// Per-item dual analysis on the LP's <c>supply ≥ demand</c> constraint.
+/// </summary>
+/// <param name="Item">The item the constraint is for.</param>
+/// <param name="ShadowPrice">
+/// Marginal objective improvement per additional unit of supply for this
+/// item (units: MW per items/min, since the objective is power). Zero on
+/// non-binding constraints; positive on binding ones — the higher the
+/// number, the more leveraged the bottleneck.
+/// </param>
+/// <param name="Slack">
+/// How much the constraint's LHS exceeds the RHS at the optimum (units:
+/// items/min). Zero on binding constraints; positive on non-binding ones.
+/// Slack > 0 ⇒ headroom you could spend on additional downstream demand.
+/// </param>
+public sealed record ItemShadowPrice(
+    ItemId Item,
+    decimal ShadowPrice,
+    decimal Slack);
+
+/// <summary>
+/// Per-recipe reduced cost: how much the objective coefficient (power)
+/// would have to *drop* for this recipe to be worth activating at the
+/// optimum. Always ≥ 0 in this LP (minimisation). Recipes that are
+/// already active have reduced cost ≈ 0. Surfaces the "this alt is just
+/// barely not worth it" recipes most clearly.
+/// </summary>
+public sealed record RecipeReducedCost(
+    RecipeId Recipe,
+    decimal ReducedCost);

--- a/src/ERP/Domain/ProductionPlan.cs
+++ b/src/ERP/Domain/ProductionPlan.cs
@@ -25,7 +25,8 @@ public sealed record ProductionPlan(
     IReadOnlyList<InfeasibleItem> MissingInputs,
     IReadOnlyList<ExtractorAllocation>? ExtractorAllocations = null,
     IReadOnlyList<string>? Warnings = null,
-    IReadOnlyList<FluidPipeRequirement>? FluidPipes = null)
+    IReadOnlyList<FluidPipeRequirement>? FluidPipes = null,
+    LpSensitivity? Sensitivity = null)
 {
     public IReadOnlyList<string> WarningsOrEmpty => Warnings ?? Array.Empty<string>();
 

--- a/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
+++ b/src/ERP/Infrastructure/OrToolsRecipePlanner.cs
@@ -140,6 +140,9 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
         //   raw_i + Σ_r x_r·(out_rate(r,i) − in_rate(r,i))
         //         + Σ_(node, tier) n_(node,tier)·extractionRate(tier, node.Purity)
         //         + short_i ≥ target_i
+        // Keep references in `supplyConstraints` so we can read dual values
+        // for the sensitivity analysis (#129) after the solve.
+        var supplyConstraints = new Dictionary<ItemId, Constraint>();
         foreach (var i in items)
         {
             var targetI = targets.TryGetValue(i, out var t) ? t : 0.0;
@@ -166,6 +169,7 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
                     }
                 }
             }
+            supplyConstraints[i] = c;
         }
 
         // Objective: minimise total base power (Σ_r x_r · basePower(r)) plus
@@ -261,6 +265,9 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
             }
         }
 
+        var sensitivity = BuildSensitivity(
+            supplyConstraints, xVars, rawVars, shortVars, items, targets, recipes);
+
         return new ProductionPlan(
             Targets: query.Targets,
             Available: query.Available,
@@ -269,7 +276,77 @@ public sealed class OrToolsRecipePlanner : IRecipePlanner
             MissingInputs: InfeasibilityDiagnostics.Build(missingByItem, _catalog, steps),
             ExtractorAllocations: allocations,
             Warnings: PowerVarianceWarning.Build(steps),
-            FluidPipes: FluidPipeRequirements.Build(steps, rawConsumed));
+            FluidPipes: FluidPipeRequirements.Build(steps, rawConsumed),
+            Sensitivity: sensitivity);
+    }
+
+    /// <summary>
+    /// Reads dual values and reduced costs straight off the solved LP and
+    /// packages them as an <see cref="LpSensitivity"/> attached to the
+    /// returned plan (#129).
+    ///
+    /// <para>
+    /// Shadow price = constraint's <see cref="Constraint.DualValue"/>: how
+    /// much the objective improves per +1 unit on the RHS (extra demand).
+    /// Slack is computed by walking the constraint's terms in the same
+    /// shape they were originally added — Σ x_r·net_rate + raw + short −
+    /// target. OR-Tools' .NET bindings don't expose constraint enumeration,
+    /// so we recompute from the inputs the caller already has on hand.
+    /// </para>
+    /// </summary>
+    private static LpSensitivity BuildSensitivity(
+        Dictionary<ItemId, Constraint> supplyConstraints,
+        Dictionary<RecipeId, Variable> xVars,
+        Dictionary<ItemId, Variable> rawVars,
+        Dictionary<ItemId, Variable> shortVars,
+        IEnumerable<ItemId> items,
+        Dictionary<ItemId, double> targets,
+        IReadOnlyList<Recipe> recipes)
+    {
+        var shadowPrices = new List<ItemShadowPrice>();
+        foreach (var i in items)
+        {
+            // Some OR-Tools builds throw on DualValue() / ReducedCost() if
+            // the solve didn't return a basis (e.g. SCIP MIP runs). Surface
+            // as zero rather than crash the planner — the primal answer is
+            // still correct, sensitivity surface just empty.
+            var shadow = TryDualValue(supplyConstraints[i]);
+            var rhs = targets.TryGetValue(i, out var t) ? t : 0.0;
+
+            // Reconstruct LHS at the solution = raw + short + Σ x_r·net_rate
+            var lhs = rawVars[i].SolutionValue() + shortVars[i].SolutionValue();
+            foreach (var r in recipes)
+            {
+                var coeff = NetRatePerMinute(r, i);
+                if (Math.Abs(coeff) > Epsilon)
+                    lhs += coeff * xVars[r.Id].SolutionValue();
+            }
+            var slack = lhs - rhs;
+            if (slack < 0) slack = 0; // numerical noise — constraint can't be violated at OPTIMAL
+
+            shadowPrices.Add(new ItemShadowPrice(i, (decimal)shadow, (decimal)slack));
+        }
+
+        var reducedCosts = new List<RecipeReducedCost>();
+        foreach (var r in recipes)
+        {
+            var rc = TryReducedCost(xVars[r.Id]);
+            reducedCosts.Add(new RecipeReducedCost(r.Id, (decimal)rc));
+        }
+
+        return new LpSensitivity(shadowPrices, reducedCosts);
+    }
+
+    private static double TryDualValue(Constraint c)
+    {
+        try { return c.DualValue(); }
+        catch { return 0; }
+    }
+
+    private static double TryReducedCost(Variable v)
+    {
+        try { return v.ReducedCost(); }
+        catch { return 0; }
     }
 
     private static readonly IReadOnlyList<MinerTier> AllMinerTiers =

--- a/src/Web/PlannerApiClient.cs
+++ b/src/Web/PlannerApiClient.cs
@@ -238,7 +238,8 @@ public sealed record PlanResponse(
     IReadOnlyList<MissingInputView> MissingInputs,
     IReadOnlyList<ExtractorAllocationView> ExtractorAllocations,
     IReadOnlyList<string>? Warnings = null,
-    IReadOnlyList<FluidPipeRequirementView>? FluidPipeRequirements = null)
+    IReadOnlyList<FluidPipeRequirementView>? FluidPipeRequirements = null,
+    LpSensitivityView? Sensitivity = null)
 {
     /// <summary>
     /// Plan-wide advisory strings (e.g. the variable-power-buildings notice
@@ -277,6 +278,23 @@ public sealed record FluidPipeRequirementView(
     string ItemName,
     decimal MaxRatePerMinute,
     string RecommendedTier);
+
+/// <summary>LP sensitivity surface (#129). Null on plans produced by the
+/// recursive engine; populated by the OR-Tools engine.</summary>
+public sealed record LpSensitivityView(
+    IReadOnlyList<ItemShadowPriceView> SupplyConstraints,
+    IReadOnlyList<RecipeReducedCostView> ProductionRecipes);
+
+public sealed record ItemShadowPriceView(
+    string ItemId,
+    string ItemName,
+    decimal ShadowPrice,
+    decimal Slack);
+
+public sealed record RecipeReducedCostView(
+    string RecipeId,
+    string RecipeName,
+    decimal ReducedCost);
 
 /// <summary>Per-item diagnostic for an unsatisfied target (#8).
 /// <c>ItemId</c> + <c>ItemName</c> + <c>ItemsPerMinute</c> match the previous

--- a/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
+++ b/test/ERP/Infrastructure.Tests/OrToolsRecipePlannerTests.cs
@@ -9,6 +9,40 @@ public class OrToolsRecipePlannerTests
     private const decimal Tol = 0.001m;
 
     [Fact]
+    public void Sensitivity_binding_constraint_has_positive_shadow_price()
+    {
+        // Setup deliberately exactly-binding: target 30 ingots, available
+        // 30 ore — the planner runs the recipe at scale 1 and consumes all
+        // available ore. Both the ingot (target) and ore (raw cap) supply
+        // constraints are binding (slack ≈ 0) and should carry positive
+        // shadow prices.
+        var catalog = new FakeCatalog(
+            buildings: [new Building(SmelterId, "Smelter", BasePowerMw: 4)],
+            recipes: [IronIngotRecipe],
+            items: [new Item(IronOre, "Iron Ore"), new Item(IronIngot, "Iron Ingot")]);
+
+        var planner = new OrToolsRecipePlanner(catalog);
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
+
+        Assert.True(plan.IsFeasible);
+        Assert.NotNull(plan.Sensitivity);
+
+        var ingotShadow = plan.Sensitivity!.SupplyConstraints.Single(sp => sp.Item == IronIngot);
+        // Binding: slack ≈ 0, shadow price > 0
+        Assert.InRange(ingotShadow.Slack, 0m - Tol, 0m + Tol);
+        Assert.True(ingotShadow.ShadowPrice > 0m,
+            $"Expected positive shadow price on binding ingot constraint, got {ingotShadow.ShadowPrice}.");
+
+        // Recursive planner should NOT populate Sensitivity (LP-only field).
+        var recursivePlan = new RecursiveRecipePlanner(catalog).Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(IronIngot, 30)],
+            Available: [new ResourceAvailability(IronOre, 30)]));
+        Assert.Null(recursivePlan.Sensitivity);
+    }
+
+    [Fact]
     public void Picks_Cheaper_Alt_Recipe_When_Available()
     {
         // Two recipes for iron ingot:


### PR DESCRIPTION
## Summary

Closes #129. The OR-Tools planner now exposes shadow prices + reduced costs straight off the LP solve, attached to the returned plan as an optional `Sensitivity` field. The recursive planner leaves it `null` (it has no dual to expose).

This is the research-grade companion to the actionable diagnostics from #8 phase 1 (`InfeasibleItem`/`MissingInputs`). Phase 1 told the user *"you're short on iron ore — here's how much, here are the recipes that could produce it, here's what's consuming it"*. Phase 2 layers *"…and ore is your most-leveraged bottleneck right now (shadow price 0.13 MW per ore/min); the Pure Iron alt recipe is 0.04 MW below the cutoff to enter the basis"*.

## What's surfaced

- **Shadow price** per item supply constraint — marginal objective improvement per +1 unit of supply. Positive on binding constraints, zero on non-binding.
- **Slack** per supply constraint — headroom at the optimum. Zero on binding; positive on non-binding. Combined with shadow price, gives the full sensitivity picture.
- **Reduced cost** per recipe — how much an inactive recipe's power coefficient would have to drop for the LP to activate it. Highlights alternates that are *just barely* not worth running.

## Implementation notes

- The .NET OR-Tools binding doesn't expose `Constraint.Coefficients` enumeration, so slack is reconstructed by re-evaluating the constraint's LHS at the solution values the planner already has on hand (raw + short + Σ recipe×net_rate).
- `DualValue()` / `ReducedCost()` are wrapped in try/catch — some OR-Tools backends (e.g. SCIP MIP) throw if no basis is returned. Falling back to zero keeps the primal answer intact.
- All `LpSensitivity` fields are catalog-resolved at DTO time (item names + recipe names baked in) so JSON consumers don't need a second lookup pass.

## Wire format

Additive — `PlanDto.Sensitivity` is a new optional field. JSON readers that ignore unknown keys keep working. `PlanResponse` on the Web client mirrors.

**No UI changes in this PR** — issue body explicitly defers rendering. Wire shape lands first; a follow-up can build a "sensitivity inspector" panel on the planner page when there's appetite for it.

## Test plan

- [x] `dotnet build ERP.Satisfactory.slnx` clean.
- [x] `./build.sh TestNoUi` passes — new binding-constraint test asserts shadow price > 0 + slack ≈ 0 on the exact-fit ingot/ore case, plus the recursive planner returns null Sensitivity.
- [ ] CI: full lane.
- [ ] Optional manual smoke: flip `Planner:Engine=lp` and hit `/plan` with a constrained input; inspect the JSON for `sensitivity.supplyConstraints[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)