### PR TITLE
feat(planner): production-flow graph view at /planner/graph

### DIFF
--- a/src/Web/Components/Layout/NavMenu.razor
+++ b/src/Web/Components/Layout/NavMenu.razor
@@ -23,6 +23,9 @@
     <MudNavLink Href="planner">
         <span class="fx-icon fx-icon-inline fx-icon-wrench" aria-hidden="true"></span> Planner
     </MudNavLink>
+    <MudNavLink Href="planner/graph" Icon="@Icons.Material.Filled.AccountTree" IconColor="Color.Inherit">
+        Flow graph
+    </MudNavLink>
     <MudNavLink Href="recipes" Icon="@Icons.Material.Filled.MenuBook" IconColor="Color.Inherit">
         Recipes
     </MudNavLink>

--- a/src/Web/Components/Pages/PlannerGraph.razor
+++ b/src/Web/Components/Pages/PlannerGraph.razor
@@ -111,7 +111,7 @@ else
     else
     {
         <MudPaper Class="pa-2" Outlined="true" data-testid="graph-svg-wrap" Style="overflow-x: auto;">
-            @RenderGraphSvg(BuildLayout(plan))
+            @RenderGraphSvg(PlannerGraphLayout.Build(plan))
         </MudPaper>
     }
 }
@@ -124,13 +124,6 @@ else
     private string? error;
     private bool isComputing;
 
-    // ---- Layout tunables (SVG user-space units; the viewBox handles scaling) ----
-    private const int NodeWidth = 200;
-    private const int NodeHeight = 60;
-    private const int ColumnGap = 140;   // horizontal gap between depth columns
-    private const int RowGap = 36;       // vertical gap between rows in a column
-    private const int Padding = 24;      // outer padding around the whole graph
-    private const int RawColumnWidth = 140;
     private const int LabelOffsetY = -6;
 
     protected override async Task OnInitializedAsync()
@@ -179,160 +172,20 @@ else
     }
 
     // -----------------------------------------------------------------------
-    // Layout
+    // SVG rendering (inline RenderTreeBuilder so the page stays self-contained)
     // -----------------------------------------------------------------------
 
-    /// <summary>Positioned recipe node: index into PlanResponse.Steps + xy.</summary>
-    private sealed record PlacedNode(int StepIndex, StepView Step, int Depth, double X, double Y);
-
-    /// <summary>Edge from one recipe to another (or from a "raw input" stub on the left).</summary>
-    private sealed record GraphEdge(
-        int? FromStepIndex, // null = raw-input pseudo-node
-        int ToStepIndex,
-        string ItemId,
-        string ItemName,
-        decimal ItemsPerMinute);
-
-    /// <summary>Pseudo-node for a raw input that has no producer step.</summary>
-    private sealed record RawNode(string ItemId, string ItemName, double X, double Y);
-
-    private sealed record Layout(
-        IReadOnlyList<PlacedNode> Nodes,
-        IReadOnlyList<RawNode> Raws,
-        IReadOnlyList<GraphEdge> Edges,
-        double Width,
-        double Height);
-
-    private static Layout BuildLayout(PlanResponse plan)
-    {
-        var steps = plan.Steps;
-
-        // Index recipes that produce each item id (so we can find the upstream
-        // recipe for any consumed input). A given item *can* be produced by
-        // multiple steps in pathological plans; we pick the first hit — good
-        // enough for v1.
-        var producerByItem = new Dictionary<string, int>(StringComparer.Ordinal);
-        for (var i = 0; i < steps.Count; i++)
-        {
-            foreach (var output in steps[i].Outputs)
-            {
-                producerByItem.TryAdd(output.ItemId, i);
-            }
-        }
-
-        // Edges: for each step's inputs, link the producer step (if any).
-        var edges = new List<GraphEdge>();
-        for (var i = 0; i < steps.Count; i++)
-        {
-            foreach (var input in steps[i].Inputs)
-            {
-                if (producerByItem.TryGetValue(input.ItemId, out var fromIx) && fromIx != i)
-                {
-                    edges.Add(new GraphEdge(fromIx, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
-                }
-                else
-                {
-                    // Raw input — pseudo-node on the left.
-                    edges.Add(new GraphEdge(null, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
-                }
-            }
-        }
-
-        // Compute depth via DFS-memo of "longest path from any source", where
-        // a source = step with no internal predecessor. Cycles shouldn't exist
-        // in a valid plan, but we defensively cap recursion.
-        var depths = new int[steps.Count];
-        Array.Fill(depths, -1);
-        var preds = new List<int>[steps.Count];
-        for (var i = 0; i < steps.Count; i++) preds[i] = [];
-        foreach (var e in edges)
-        {
-            if (e.FromStepIndex is int from) preds[e.ToStepIndex].Add(from);
-        }
-
-        int ComputeDepth(int ix, int guard)
-        {
-            if (guard > steps.Count) return 0; // cycle safety
-            if (depths[ix] >= 0) return depths[ix];
-            var max = 0;
-            foreach (var p in preds[ix])
-            {
-                max = Math.Max(max, ComputeDepth(p, guard + 1) + 1);
-            }
-            depths[ix] = max;
-            return max;
-        }
-        for (var i = 0; i < steps.Count; i++) ComputeDepth(i, 0);
-
-        // Bucket nodes by depth.
-        var maxDepth = depths.Length == 0 ? 0 : depths.Max();
-        var byDepth = new List<List<int>>();
-        for (var d = 0; d <= maxDepth; d++) byDepth.Add([]);
-        for (var i = 0; i < steps.Count; i++) byDepth[depths[i]].Add(i);
-
-        // Place each column. Raw-input pseudo-nodes sit in a column to the
-        // left of depth 0; recipe columns start at xColumn0.
-        var hasRaws = edges.Any(e => e.FromStepIndex is null);
-        var xColumn0 = Padding + (hasRaws ? RawColumnWidth + ColumnGap : 0);
-
-        var placed = new List<PlacedNode>(steps.Count);
-        for (var d = 0; d <= maxDepth; d++)
-        {
-            var column = byDepth[d];
-            var x = xColumn0 + d * (NodeWidth + ColumnGap);
-            for (var row = 0; row < column.Count; row++)
-            {
-                var y = Padding + row * (NodeHeight + RowGap);
-                placed.Add(new PlacedNode(column[row], steps[column[row]], d, x, y));
-            }
-        }
-
-        // Distinct raw items in the order they appear in edges (deterministic).
-        var rawItems = new List<(string id, string name)>();
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var e in edges)
-        {
-            if (e.FromStepIndex is null && seen.Add(e.ItemId))
-            {
-                rawItems.Add((e.ItemId, e.ItemName));
-            }
-        }
-        var raws = new List<RawNode>(rawItems.Count);
-        for (var r = 0; r < rawItems.Count; r++)
-        {
-            var y = Padding + r * (NodeHeight + RowGap);
-            raws.Add(new RawNode(rawItems[r].id, rawItems[r].name, Padding, y));
-        }
-
-        // Overall canvas dimensions = furthest-right node edge + padding,
-        // tallest column height + padding.
-        var rightmost = placed.Count == 0
-            ? xColumn0
-            : placed.Max(n => n.X) + NodeWidth;
-        var maxRows = byDepth.Count == 0 ? 0 : byDepth.Max(c => c.Count);
-        var maxRowsOverall = Math.Max(maxRows, raws.Count);
-        var height = Padding * 2 + Math.Max(NodeHeight, maxRowsOverall * (NodeHeight + RowGap) - RowGap);
-        var width = rightmost + Padding;
-
-        return new Layout(placed, raws, edges, width, height);
-    }
-
-    // -----------------------------------------------------------------------
-    // SVG rendering (RenderTreeBuilder so we keep one .razor file)
-    // -----------------------------------------------------------------------
-
-    private RenderFragment RenderGraphSvg(Layout layout) => builder =>
+    private RenderFragment RenderGraphSvg(PlannerGraphLayout.Layout layout) => builder =>
     {
         var seq = 0;
         builder.OpenElement(seq++, "svg");
         builder.AddAttribute(seq++, "xmlns", "http://www.w3.org/2000/svg");
-        builder.AddAttribute(seq++, "viewBox", $"0 0 {layout.Width.ToString(System.Globalization.CultureInfo.InvariantCulture)} {layout.Height.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
-        builder.AddAttribute(seq++, "width", layout.Width.ToString(System.Globalization.CultureInfo.InvariantCulture));
-        builder.AddAttribute(seq++, "height", layout.Height.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        builder.AddAttribute(seq++, "viewBox", $"0 0 {PlannerGraphLayout.Fmt(layout.Width)} {PlannerGraphLayout.Fmt(layout.Height)}");
+        builder.AddAttribute(seq++, "width", PlannerGraphLayout.Fmt(layout.Width));
+        builder.AddAttribute(seq++, "height", PlannerGraphLayout.Fmt(layout.Height));
         builder.AddAttribute(seq++, "data-testid", "graph-svg");
         builder.AddAttribute(seq++, "style", "font-family: -apple-system, Segoe UI, sans-serif;");
 
-        // Marker for arrow heads.
         builder.OpenElement(seq++, "defs");
         builder.OpenElement(seq++, "marker");
         builder.AddAttribute(seq++, "id", "fx-arrow");
@@ -349,17 +202,16 @@ else
         builder.CloseElement();
         builder.CloseElement();
 
-        // 1. Edges (rendered first so nodes paint on top).
+        // 1. Edges first so nodes render on top.
         foreach (var edge in layout.Edges)
         {
-            var (x1, y1) = SourceMidRight(edge, layout);
-            var (x2, y2) = TargetMidLeft(edge, layout);
+            var (x1, y1) = PlannerGraphLayout.SourceMidRight(edge, layout);
+            var (x2, y2) = PlannerGraphLayout.TargetMidLeft(edge, layout);
             if (double.IsNaN(x1) || double.IsNaN(x2)) continue;
 
-            // Bezier curve with handles pushed horizontally for a sankey-ish flow.
             var cx1 = x1 + (x2 - x1) * 0.5;
             var cx2 = x1 + (x2 - x1) * 0.5;
-            var d = $"M {Fmt(x1)} {Fmt(y1)} C {Fmt(cx1)} {Fmt(y1)} {Fmt(cx2)} {Fmt(y2)} {Fmt(x2)} {Fmt(y2)}";
+            var d = $"M {PlannerGraphLayout.Fmt(x1)} {PlannerGraphLayout.Fmt(y1)} C {PlannerGraphLayout.Fmt(cx1)} {PlannerGraphLayout.Fmt(y1)} {PlannerGraphLayout.Fmt(cx2)} {PlannerGraphLayout.Fmt(y2)} {PlannerGraphLayout.Fmt(x2)} {PlannerGraphLayout.Fmt(y2)}";
 
             builder.OpenElement(seq++, "path");
             builder.AddAttribute(seq++, "d", d);
@@ -370,12 +222,11 @@ else
             builder.AddAttribute(seq++, "data-edge-item", edge.ItemId);
             builder.CloseElement();
 
-            // Edge label hanging just above its midpoint.
             var mx = (x1 + x2) / 2.0;
             var my = (y1 + y2) / 2.0 + LabelOffsetY;
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(mx));
-            builder.AddAttribute(seq++, "y", Fmt(my));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(mx));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(my));
             builder.AddAttribute(seq++, "font-size", "10");
             builder.AddAttribute(seq++, "fill", "#33425a");
             builder.AddAttribute(seq++, "text-anchor", "middle");
@@ -383,17 +234,17 @@ else
             builder.CloseElement();
         }
 
-        // 2. Raw-input pseudo-nodes (left column).
+        // 2. Raw-input pseudo-nodes (dashed border for visual distinction).
         foreach (var raw in layout.Raws)
         {
             builder.OpenElement(seq++, "g");
             builder.AddAttribute(seq++, "data-raw-id", raw.ItemId);
 
             builder.OpenElement(seq++, "rect");
-            builder.AddAttribute(seq++, "x", Fmt(raw.X));
-            builder.AddAttribute(seq++, "y", Fmt(raw.Y));
-            builder.AddAttribute(seq++, "width", RawColumnWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
-            builder.AddAttribute(seq++, "height", NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(raw.X));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(raw.Y));
+            builder.AddAttribute(seq++, "width", PlannerGraphLayout.RawColumnWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "height", PlannerGraphLayout.NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
             builder.AddAttribute(seq++, "rx", "6");
             builder.AddAttribute(seq++, "ry", "6");
             builder.AddAttribute(seq++, "fill", "#eef3f8");
@@ -402,8 +253,8 @@ else
             builder.CloseElement();
 
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(raw.X + RawColumnWidth / 2.0));
-            builder.AddAttribute(seq++, "y", Fmt(raw.Y + NodeHeight / 2.0 - 4));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(raw.X + PlannerGraphLayout.RawColumnWidth / 2.0));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(raw.Y + PlannerGraphLayout.NodeHeight / 2.0 - 4));
             builder.AddAttribute(seq++, "font-size", "11");
             builder.AddAttribute(seq++, "fill", "#33425a");
             builder.AddAttribute(seq++, "text-anchor", "middle");
@@ -412,8 +263,8 @@ else
             builder.CloseElement();
 
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(raw.X + RawColumnWidth / 2.0));
-            builder.AddAttribute(seq++, "y", Fmt(raw.Y + NodeHeight / 2.0 + 12));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(raw.X + PlannerGraphLayout.RawColumnWidth / 2.0));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(raw.Y + PlannerGraphLayout.NodeHeight / 2.0 + 12));
             builder.AddAttribute(seq++, "font-size", "11");
             builder.AddAttribute(seq++, "fill", "#33425a");
             builder.AddAttribute(seq++, "text-anchor", "middle");
@@ -431,10 +282,10 @@ else
             builder.AddAttribute(seq++, "data-step-index", node.StepIndex.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
             builder.OpenElement(seq++, "rect");
-            builder.AddAttribute(seq++, "x", Fmt(node.X));
-            builder.AddAttribute(seq++, "y", Fmt(node.Y));
-            builder.AddAttribute(seq++, "width", NodeWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
-            builder.AddAttribute(seq++, "height", NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(node.X));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(node.Y));
+            builder.AddAttribute(seq++, "width", PlannerGraphLayout.NodeWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "height", PlannerGraphLayout.NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
             builder.AddAttribute(seq++, "rx", "6");
             builder.AddAttribute(seq++, "ry", "6");
             builder.AddAttribute(seq++, "fill", "#fff7e0");
@@ -442,10 +293,9 @@ else
             builder.AddAttribute(seq++, "stroke-width", "1.5");
             builder.CloseElement();
 
-            // Recipe name (bold).
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
-            builder.AddAttribute(seq++, "y", Fmt(node.Y + 20));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(node.X + PlannerGraphLayout.NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(node.Y + 20));
             builder.AddAttribute(seq++, "font-size", "12");
             builder.AddAttribute(seq++, "font-weight", "600");
             builder.AddAttribute(seq++, "fill", "#2a2a2a");
@@ -453,20 +303,18 @@ else
             builder.AddContent(seq++, Truncate(node.Step.RecipeName, 26));
             builder.CloseElement();
 
-            // Building count · power
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
-            builder.AddAttribute(seq++, "y", Fmt(node.Y + 38));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(node.X + PlannerGraphLayout.NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(node.Y + 38));
             builder.AddAttribute(seq++, "font-size", "11");
             builder.AddAttribute(seq++, "fill", "#33425a");
             builder.AddAttribute(seq++, "text-anchor", "middle");
             builder.AddContent(seq++, $"{FormatCount(node.Step.BuildingCount)} bldg · {FormatPower(node.Step.PowerMw)} MW");
             builder.CloseElement();
 
-            // Building name (small, lighter).
             builder.OpenElement(seq++, "text");
-            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
-            builder.AddAttribute(seq++, "y", Fmt(node.Y + 52));
+            builder.AddAttribute(seq++, "x", PlannerGraphLayout.Fmt(node.X + PlannerGraphLayout.NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", PlannerGraphLayout.Fmt(node.Y + 52));
             builder.AddAttribute(seq++, "font-size", "10");
             builder.AddAttribute(seq++, "fill", "#5a6f88");
             builder.AddAttribute(seq++, "text-anchor", "middle");
@@ -478,31 +326,6 @@ else
 
         builder.CloseElement(); // </svg>
     };
-
-    /// <summary>Right-midpoint of the upstream node for an edge.</summary>
-    private static (double X, double Y) SourceMidRight(GraphEdge edge, Layout layout)
-    {
-        if (edge.FromStepIndex is int from)
-        {
-            var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == from);
-            if (node is null) return (double.NaN, double.NaN);
-            return (node.X + NodeWidth, node.Y + NodeHeight / 2.0);
-        }
-        var raw = layout.Raws.FirstOrDefault(r => r.ItemId == edge.ItemId);
-        if (raw is null) return (double.NaN, double.NaN);
-        return (raw.X + RawColumnWidth, raw.Y + NodeHeight / 2.0);
-    }
-
-    /// <summary>Left-midpoint of the downstream recipe node for an edge.</summary>
-    private static (double X, double Y) TargetMidLeft(GraphEdge edge, Layout layout)
-    {
-        var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == edge.ToStepIndex);
-        if (node is null) return (double.NaN, double.NaN);
-        return (node.X, node.Y + NodeHeight / 2.0);
-    }
-
-    private static string Fmt(double v) =>
-        v.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
 
     private static string FormatRate(decimal rate) =>
         rate == Math.Floor(rate) ? rate.ToString("0") : rate.ToString("0.##");

--- a/src/Web/Components/Pages/PlannerGraph.razor
+++ b/src/Web/Components/Pages/PlannerGraph.razor
@@ -110,8 +110,8 @@ else
     }
     else
     {
-        <MudPaper Class="pa-2" Outlined="true" data-testid="graph-svg-wrap">
-            @RenderGraphSvg()
+        <MudPaper Class="pa-2" Outlined="true" data-testid="graph-svg-wrap" Style="overflow-x: auto;">
+            @RenderGraphSvg(BuildLayout(plan))
         </MudPaper>
     }
 }
@@ -123,6 +123,15 @@ else
     private PlanResponse? plan;
     private string? error;
     private bool isComputing;
+
+    // ---- Layout tunables (SVG user-space units; the viewBox handles scaling) ----
+    private const int NodeWidth = 200;
+    private const int NodeHeight = 60;
+    private const int ColumnGap = 140;   // horizontal gap between depth columns
+    private const int RowGap = 36;       // vertical gap between rows in a column
+    private const int Padding = 24;      // outer padding around the whole graph
+    private const int RawColumnWidth = 140;
+    private const int LabelOffsetY = -6;
 
     protected override async Task OnInitializedAsync()
     {
@@ -169,22 +178,343 @@ else
         }
     }
 
-    private RenderFragment RenderGraphSvg() => builder =>
+    // -----------------------------------------------------------------------
+    // Layout
+    // -----------------------------------------------------------------------
+
+    /// <summary>Positioned recipe node: index into PlanResponse.Steps + xy.</summary>
+    private sealed record PlacedNode(int StepIndex, StepView Step, int Depth, double X, double Y);
+
+    /// <summary>Edge from one recipe to another (or from a "raw input" stub on the left).</summary>
+    private sealed record GraphEdge(
+        int? FromStepIndex, // null = raw-input pseudo-node
+        int ToStepIndex,
+        string ItemId,
+        string ItemName,
+        decimal ItemsPerMinute);
+
+    /// <summary>Pseudo-node for a raw input that has no producer step.</summary>
+    private sealed record RawNode(string ItemId, string ItemName, double X, double Y);
+
+    private sealed record Layout(
+        IReadOnlyList<PlacedNode> Nodes,
+        IReadOnlyList<RawNode> Raws,
+        IReadOnlyList<GraphEdge> Edges,
+        double Width,
+        double Height);
+
+    private static Layout BuildLayout(PlanResponse plan)
     {
-        // Stub — real SVG rendering arrives in a follow-up commit on this branch.
-        builder.OpenElement(0, "svg");
-        builder.AddAttribute(1, "viewBox", "0 0 100 40");
-        builder.AddAttribute(2, "width", "100%");
-        builder.AddAttribute(3, "height", "40");
-        builder.AddAttribute(4, "data-testid", "graph-svg");
-        builder.OpenElement(5, "text");
-        builder.AddAttribute(6, "x", "4");
-        builder.AddAttribute(7, "y", "24");
-        builder.AddAttribute(8, "font-size", "10");
-        builder.AddContent(9, $"{plan!.Steps.Count} step(s) — graph rendering pending");
+        var steps = plan.Steps;
+
+        // Index recipes that produce each item id (so we can find the upstream
+        // recipe for any consumed input). A given item *can* be produced by
+        // multiple steps in pathological plans; we pick the first hit — good
+        // enough for v1.
+        var producerByItem = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < steps.Count; i++)
+        {
+            foreach (var output in steps[i].Outputs)
+            {
+                producerByItem.TryAdd(output.ItemId, i);
+            }
+        }
+
+        // Edges: for each step's inputs, link the producer step (if any).
+        var edges = new List<GraphEdge>();
+        for (var i = 0; i < steps.Count; i++)
+        {
+            foreach (var input in steps[i].Inputs)
+            {
+                if (producerByItem.TryGetValue(input.ItemId, out var fromIx) && fromIx != i)
+                {
+                    edges.Add(new GraphEdge(fromIx, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
+                }
+                else
+                {
+                    // Raw input — pseudo-node on the left.
+                    edges.Add(new GraphEdge(null, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
+                }
+            }
+        }
+
+        // Compute depth via DFS-memo of "longest path from any source", where
+        // a source = step with no internal predecessor. Cycles shouldn't exist
+        // in a valid plan, but we defensively cap recursion.
+        var depths = new int[steps.Count];
+        Array.Fill(depths, -1);
+        var preds = new List<int>[steps.Count];
+        for (var i = 0; i < steps.Count; i++) preds[i] = [];
+        foreach (var e in edges)
+        {
+            if (e.FromStepIndex is int from) preds[e.ToStepIndex].Add(from);
+        }
+
+        int ComputeDepth(int ix, int guard)
+        {
+            if (guard > steps.Count) return 0; // cycle safety
+            if (depths[ix] >= 0) return depths[ix];
+            var max = 0;
+            foreach (var p in preds[ix])
+            {
+                max = Math.Max(max, ComputeDepth(p, guard + 1) + 1);
+            }
+            depths[ix] = max;
+            return max;
+        }
+        for (var i = 0; i < steps.Count; i++) ComputeDepth(i, 0);
+
+        // Bucket nodes by depth.
+        var maxDepth = depths.Length == 0 ? 0 : depths.Max();
+        var byDepth = new List<List<int>>();
+        for (var d = 0; d <= maxDepth; d++) byDepth.Add([]);
+        for (var i = 0; i < steps.Count; i++) byDepth[depths[i]].Add(i);
+
+        // Place each column. Raw-input pseudo-nodes sit in a column to the
+        // left of depth 0; recipe columns start at xColumn0.
+        var hasRaws = edges.Any(e => e.FromStepIndex is null);
+        var xColumn0 = Padding + (hasRaws ? RawColumnWidth + ColumnGap : 0);
+
+        var placed = new List<PlacedNode>(steps.Count);
+        for (var d = 0; d <= maxDepth; d++)
+        {
+            var column = byDepth[d];
+            var x = xColumn0 + d * (NodeWidth + ColumnGap);
+            for (var row = 0; row < column.Count; row++)
+            {
+                var y = Padding + row * (NodeHeight + RowGap);
+                placed.Add(new PlacedNode(column[row], steps[column[row]], d, x, y));
+            }
+        }
+
+        // Distinct raw items in the order they appear in edges (deterministic).
+        var rawItems = new List<(string id, string name)>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var e in edges)
+        {
+            if (e.FromStepIndex is null && seen.Add(e.ItemId))
+            {
+                rawItems.Add((e.ItemId, e.ItemName));
+            }
+        }
+        var raws = new List<RawNode>(rawItems.Count);
+        for (var r = 0; r < rawItems.Count; r++)
+        {
+            var y = Padding + r * (NodeHeight + RowGap);
+            raws.Add(new RawNode(rawItems[r].id, rawItems[r].name, Padding, y));
+        }
+
+        // Overall canvas dimensions = furthest-right node edge + padding,
+        // tallest column height + padding.
+        var rightmost = placed.Count == 0
+            ? xColumn0
+            : placed.Max(n => n.X) + NodeWidth;
+        var maxRows = byDepth.Count == 0 ? 0 : byDepth.Max(c => c.Count);
+        var maxRowsOverall = Math.Max(maxRows, raws.Count);
+        var height = Padding * 2 + Math.Max(NodeHeight, maxRowsOverall * (NodeHeight + RowGap) - RowGap);
+        var width = rightmost + Padding;
+
+        return new Layout(placed, raws, edges, width, height);
+    }
+
+    // -----------------------------------------------------------------------
+    // SVG rendering (RenderTreeBuilder so we keep one .razor file)
+    // -----------------------------------------------------------------------
+
+    private RenderFragment RenderGraphSvg(Layout layout) => builder =>
+    {
+        var seq = 0;
+        builder.OpenElement(seq++, "svg");
+        builder.AddAttribute(seq++, "xmlns", "http://www.w3.org/2000/svg");
+        builder.AddAttribute(seq++, "viewBox", $"0 0 {layout.Width.ToString(System.Globalization.CultureInfo.InvariantCulture)} {layout.Height.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        builder.AddAttribute(seq++, "width", layout.Width.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        builder.AddAttribute(seq++, "height", layout.Height.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        builder.AddAttribute(seq++, "data-testid", "graph-svg");
+        builder.AddAttribute(seq++, "style", "font-family: -apple-system, Segoe UI, sans-serif;");
+
+        // Marker for arrow heads.
+        builder.OpenElement(seq++, "defs");
+        builder.OpenElement(seq++, "marker");
+        builder.AddAttribute(seq++, "id", "fx-arrow");
+        builder.AddAttribute(seq++, "viewBox", "0 0 10 10");
+        builder.AddAttribute(seq++, "refX", "9");
+        builder.AddAttribute(seq++, "refY", "5");
+        builder.AddAttribute(seq++, "markerWidth", "8");
+        builder.AddAttribute(seq++, "markerHeight", "8");
+        builder.AddAttribute(seq++, "orient", "auto-start-reverse");
+        builder.OpenElement(seq++, "path");
+        builder.AddAttribute(seq++, "d", "M 0 0 L 10 5 L 0 10 z");
+        builder.AddAttribute(seq++, "fill", "#5a6f88");
         builder.CloseElement();
         builder.CloseElement();
+        builder.CloseElement();
+
+        // 1. Edges (rendered first so nodes paint on top).
+        foreach (var edge in layout.Edges)
+        {
+            var (x1, y1) = SourceMidRight(edge, layout);
+            var (x2, y2) = TargetMidLeft(edge, layout);
+            if (double.IsNaN(x1) || double.IsNaN(x2)) continue;
+
+            // Bezier curve with handles pushed horizontally for a sankey-ish flow.
+            var cx1 = x1 + (x2 - x1) * 0.5;
+            var cx2 = x1 + (x2 - x1) * 0.5;
+            var d = $"M {Fmt(x1)} {Fmt(y1)} C {Fmt(cx1)} {Fmt(y1)} {Fmt(cx2)} {Fmt(y2)} {Fmt(x2)} {Fmt(y2)}";
+
+            builder.OpenElement(seq++, "path");
+            builder.AddAttribute(seq++, "d", d);
+            builder.AddAttribute(seq++, "fill", "none");
+            builder.AddAttribute(seq++, "stroke", "#5a6f88");
+            builder.AddAttribute(seq++, "stroke-width", "1.5");
+            builder.AddAttribute(seq++, "marker-end", "url(#fx-arrow)");
+            builder.AddAttribute(seq++, "data-edge-item", edge.ItemId);
+            builder.CloseElement();
+
+            // Edge label hanging just above its midpoint.
+            var mx = (x1 + x2) / 2.0;
+            var my = (y1 + y2) / 2.0 + LabelOffsetY;
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(mx));
+            builder.AddAttribute(seq++, "y", Fmt(my));
+            builder.AddAttribute(seq++, "font-size", "10");
+            builder.AddAttribute(seq++, "fill", "#33425a");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddContent(seq++, $"{FormatRate(edge.ItemsPerMinute)} {edge.ItemName} / min");
+            builder.CloseElement();
+        }
+
+        // 2. Raw-input pseudo-nodes (left column).
+        foreach (var raw in layout.Raws)
+        {
+            builder.OpenElement(seq++, "g");
+            builder.AddAttribute(seq++, "data-raw-id", raw.ItemId);
+
+            builder.OpenElement(seq++, "rect");
+            builder.AddAttribute(seq++, "x", Fmt(raw.X));
+            builder.AddAttribute(seq++, "y", Fmt(raw.Y));
+            builder.AddAttribute(seq++, "width", RawColumnWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "height", NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "rx", "6");
+            builder.AddAttribute(seq++, "ry", "6");
+            builder.AddAttribute(seq++, "fill", "#eef3f8");
+            builder.AddAttribute(seq++, "stroke", "#8aa0b8");
+            builder.AddAttribute(seq++, "stroke-dasharray", "4 3");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(raw.X + RawColumnWidth / 2.0));
+            builder.AddAttribute(seq++, "y", Fmt(raw.Y + NodeHeight / 2.0 - 4));
+            builder.AddAttribute(seq++, "font-size", "11");
+            builder.AddAttribute(seq++, "fill", "#33425a");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddAttribute(seq++, "font-weight", "600");
+            builder.AddContent(seq++, "RAW");
+            builder.CloseElement();
+
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(raw.X + RawColumnWidth / 2.0));
+            builder.AddAttribute(seq++, "y", Fmt(raw.Y + NodeHeight / 2.0 + 12));
+            builder.AddAttribute(seq++, "font-size", "11");
+            builder.AddAttribute(seq++, "fill", "#33425a");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddContent(seq++, raw.ItemName);
+            builder.CloseElement();
+
+            builder.CloseElement();
+        }
+
+        // 3. Recipe nodes.
+        foreach (var node in layout.Nodes)
+        {
+            builder.OpenElement(seq++, "g");
+            builder.AddAttribute(seq++, "data-step-id", node.Step.RecipeId);
+            builder.AddAttribute(seq++, "data-step-index", node.StepIndex.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            builder.OpenElement(seq++, "rect");
+            builder.AddAttribute(seq++, "x", Fmt(node.X));
+            builder.AddAttribute(seq++, "y", Fmt(node.Y));
+            builder.AddAttribute(seq++, "width", NodeWidth.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "height", NodeHeight.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            builder.AddAttribute(seq++, "rx", "6");
+            builder.AddAttribute(seq++, "ry", "6");
+            builder.AddAttribute(seq++, "fill", "#fff7e0");
+            builder.AddAttribute(seq++, "stroke", "#c19a3c");
+            builder.AddAttribute(seq++, "stroke-width", "1.5");
+            builder.CloseElement();
+
+            // Recipe name (bold).
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", Fmt(node.Y + 20));
+            builder.AddAttribute(seq++, "font-size", "12");
+            builder.AddAttribute(seq++, "font-weight", "600");
+            builder.AddAttribute(seq++, "fill", "#2a2a2a");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddContent(seq++, Truncate(node.Step.RecipeName, 26));
+            builder.CloseElement();
+
+            // Building count · power
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", Fmt(node.Y + 38));
+            builder.AddAttribute(seq++, "font-size", "11");
+            builder.AddAttribute(seq++, "fill", "#33425a");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddContent(seq++, $"{FormatCount(node.Step.BuildingCount)} bldg · {FormatPower(node.Step.PowerMw)} MW");
+            builder.CloseElement();
+
+            // Building name (small, lighter).
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "x", Fmt(node.X + NodeWidth / 2.0));
+            builder.AddAttribute(seq++, "y", Fmt(node.Y + 52));
+            builder.AddAttribute(seq++, "font-size", "10");
+            builder.AddAttribute(seq++, "fill", "#5a6f88");
+            builder.AddAttribute(seq++, "text-anchor", "middle");
+            builder.AddContent(seq++, Truncate(node.Step.BuildingName, 30));
+            builder.CloseElement();
+
+            builder.CloseElement();
+        }
+
+        builder.CloseElement(); // </svg>
     };
+
+    /// <summary>Right-midpoint of the upstream node for an edge.</summary>
+    private static (double X, double Y) SourceMidRight(GraphEdge edge, Layout layout)
+    {
+        if (edge.FromStepIndex is int from)
+        {
+            var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == from);
+            if (node is null) return (double.NaN, double.NaN);
+            return (node.X + NodeWidth, node.Y + NodeHeight / 2.0);
+        }
+        var raw = layout.Raws.FirstOrDefault(r => r.ItemId == edge.ItemId);
+        if (raw is null) return (double.NaN, double.NaN);
+        return (raw.X + RawColumnWidth, raw.Y + NodeHeight / 2.0);
+    }
+
+    /// <summary>Left-midpoint of the downstream recipe node for an edge.</summary>
+    private static (double X, double Y) TargetMidLeft(GraphEdge edge, Layout layout)
+    {
+        var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == edge.ToStepIndex);
+        if (node is null) return (double.NaN, double.NaN);
+        return (node.X, node.Y + NodeHeight / 2.0);
+    }
+
+    private static string Fmt(double v) =>
+        v.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+
+    private static string FormatRate(decimal rate) =>
+        rate == Math.Floor(rate) ? rate.ToString("0") : rate.ToString("0.##");
+
+    private static string FormatCount(decimal count) =>
+        count.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture);
+
+    private static string FormatPower(decimal mw) =>
+        mw == Math.Floor(mw) ? mw.ToString("0") : mw.ToString("0.##");
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..(max - 1)] + "…";
 
     private sealed class Row
     {

--- a/src/Web/Components/Pages/PlannerGraph.razor
+++ b/src/Web/Components/Pages/PlannerGraph.razor
@@ -1,0 +1,194 @@
+@page "/planner/graph"
+@rendermode InteractiveServer
+@inject PlannerApiClient Api
+
+<PageTitle>Planner · Flow graph</PageTitle>
+
+<h1>Production-flow Graph</h1>
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    Visualise the current plan as a left-to-right DAG of recipes. Raw inputs flow in on the left;
+    target items emerge on the right.
+</MudText>
+
+@if (items is null)
+{
+    <MudText><em>Loading catalogue...</em></MudText>
+}
+else
+{
+    <MudPaper Class="pa-3 mb-3" Outlined="true">
+        <MudGrid Spacing="2">
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">Sources (items/min available)</MudText>
+                @foreach (var row in sources)
+                {
+                    <div class="d-flex gap-2 mb-2 align-items-center">
+                        <MudAutocomplete T="CatalogItem"
+                                         Value="row.Item"
+                                         ValueChanged="@(i => row.Item = i)"
+                                         SearchFunc="@SearchItems"
+                                         ToStringFunc="@(i => i?.Name ?? string.Empty)"
+                                         Placeholder="Pick item"
+                                         Variant="Variant.Outlined"
+                                         Margin="Margin.Dense"
+                                         Dense="true"
+                                         Clearable="true"
+                                         Style="min-width: 14rem;" />
+                        <MudNumericField T="decimal" @bind-Value="row.ItemsPerMinute"
+                                         Min="0" Step="1m"
+                                         Placeholder="items / min"
+                                         Variant="Variant.Outlined"
+                                         Margin="Margin.Dense"
+                                         Style="max-width: 9rem;" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Color="Color.Error" Size="Size.Small"
+                                       Variant="Variant.Outlined"
+                                       OnClick="() => RemoveSource(row)" title="Remove" />
+                    </div>
+                }
+                <MudButton Variant="Variant.Outlined" OnClick="AddSource"
+                           StartIcon="@Icons.Material.Filled.Add">Add source</MudButton>
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudText Typo="Typo.subtitle2" Class="mb-2">Sinks (items/min wanted)</MudText>
+                @foreach (var row in sinks)
+                {
+                    <div class="d-flex gap-2 mb-2 align-items-center">
+                        <MudAutocomplete T="CatalogItem"
+                                         Value="row.Item"
+                                         ValueChanged="@(i => row.Item = i)"
+                                         SearchFunc="@SearchItems"
+                                         ToStringFunc="@(i => i?.Name ?? string.Empty)"
+                                         Placeholder="Pick item"
+                                         Variant="Variant.Outlined"
+                                         Margin="Margin.Dense"
+                                         Dense="true"
+                                         Clearable="true"
+                                         Style="min-width: 14rem;" />
+                        <MudNumericField T="decimal" @bind-Value="row.ItemsPerMinute"
+                                         Min="0" Step="1m"
+                                         Placeholder="items / min"
+                                         Variant="Variant.Outlined"
+                                         Margin="Margin.Dense"
+                                         Style="max-width: 9rem;" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Color="Color.Error" Size="Size.Small"
+                                       Variant="Variant.Outlined"
+                                       OnClick="() => RemoveSink(row)" title="Remove" />
+                    </div>
+                }
+                <MudButton Variant="Variant.Outlined" OnClick="AddSink"
+                           StartIcon="@Icons.Material.Filled.Add">Add sink</MudButton>
+            </MudItem>
+        </MudGrid>
+
+        <div class="mt-3 d-flex gap-2 align-items-center flex-wrap">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="Compute" Disabled="@isComputing">
+                @(isComputing ? "Computing..." : "Compute & render")
+            </MudButton>
+            @if (!string.IsNullOrEmpty(error))
+            {
+                <MudText HtmlTag="span" Color="Color.Error">@error</MudText>
+            }
+        </div>
+    </MudPaper>
+
+    @if (plan is null)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" data-testid="graph-empty">
+            No plan to graph yet — pick sinks above and press <strong>Compute &amp; render</strong>,
+            or visit <MudLink Href="planner">/planner</MudLink> to set one up first.
+        </MudAlert>
+    }
+    else if (plan.Steps.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            Plan is empty — no production steps to graph (everything is already covered by sources).
+        </MudAlert>
+    }
+    else
+    {
+        <MudPaper Class="pa-2" Outlined="true" data-testid="graph-svg-wrap">
+            @RenderGraphSvg()
+        </MudPaper>
+    }
+}
+
+@code {
+    private CatalogItem[]? items;
+    private List<Row> sources = [new()];
+    private List<Row> sinks = [new()];
+    private PlanResponse? plan;
+    private string? error;
+    private bool isComputing;
+
+    protected override async Task OnInitializedAsync()
+    {
+        items = await Api.GetItemsAsync();
+    }
+
+    private Task<IEnumerable<CatalogItem>> SearchItems(string? value, CancellationToken ct)
+    {
+        if (items is null) return Task.FromResult<IEnumerable<CatalogItem>>([]);
+        if (string.IsNullOrWhiteSpace(value)) return Task.FromResult<IEnumerable<CatalogItem>>(items);
+        return Task.FromResult(items.Where(i => i.Name.Contains(value, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private void AddSource() => sources.Add(new());
+    private void RemoveSource(Row r) { sources.Remove(r); if (sources.Count == 0) sources.Add(new()); }
+    private void AddSink() => sinks.Add(new());
+    private void RemoveSink(Row r) { sinks.Remove(r); if (sinks.Count == 0) sinks.Add(new()); }
+
+    private async Task Compute()
+    {
+        error = null;
+        plan = null;
+        isComputing = true;
+        try
+        {
+            var request = new PlanRequest(
+                Targets:   sinks  .Where(r => r.Item is not null).Select(r => new TargetInput(r.Item!.Id, r.ItemsPerMinute)).ToList(),
+                Available: sources.Where(r => r.Item is not null).Select(r => new AvailabilityInput(r.Item!.Id, r.ItemsPerMinute)).ToList());
+
+            if (request.Targets.Count == 0)
+            {
+                error = "Add at least one sink.";
+                return;
+            }
+            plan = await Api.ComputePlanAsync(request);
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            isComputing = false;
+        }
+    }
+
+    private RenderFragment RenderGraphSvg() => builder =>
+    {
+        // Stub — real SVG rendering arrives in a follow-up commit on this branch.
+        builder.OpenElement(0, "svg");
+        builder.AddAttribute(1, "viewBox", "0 0 100 40");
+        builder.AddAttribute(2, "width", "100%");
+        builder.AddAttribute(3, "height", "40");
+        builder.AddAttribute(4, "data-testid", "graph-svg");
+        builder.OpenElement(5, "text");
+        builder.AddAttribute(6, "x", "4");
+        builder.AddAttribute(7, "y", "24");
+        builder.AddAttribute(8, "font-size", "10");
+        builder.AddContent(9, $"{plan!.Steps.Count} step(s) — graph rendering pending");
+        builder.CloseElement();
+        builder.CloseElement();
+    };
+
+    private sealed class Row
+    {
+        public CatalogItem? Item { get; set; }
+        public decimal ItemsPerMinute { get; set; }
+    }
+}

--- a/src/Web/PlannerGraphLayout.cs
+++ b/src/Web/PlannerGraphLayout.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+
+namespace Web;
+
+/// <summary>
+/// Pure layout for the <c>/planner/graph</c> page. Given the planner's
+/// <see cref="PlanResponse"/>, places each production step in a column based
+/// on its longest-path depth from any "raw" input (one with no producer in
+/// the plan) and emits SVG-ready node + edge geometry.
+/// <para>
+/// Deliberately cheap — no crossing minimisation, no force-directed pass.
+/// Works well up to ~20 recipes which covers the common planner case. Lives
+/// outside the Razor file so it can be unit-tested in isolation.
+/// </para>
+/// </summary>
+public static class PlannerGraphLayout
+{
+    // SVG user-space units; the page's viewBox handles responsive scaling.
+    public const int NodeWidth = 200;
+    public const int NodeHeight = 60;
+    public const int ColumnGap = 140;
+    public const int RowGap = 36;
+    public const int Padding = 24;
+    public const int RawColumnWidth = 140;
+
+    public sealed record PlacedNode(int StepIndex, StepView Step, int Depth, double X, double Y);
+
+    public sealed record RawNode(string ItemId, string ItemName, double X, double Y);
+
+    /// <summary>
+    /// Edge between a producer (recipe or raw pseudo-node) and a consuming
+    /// recipe. <c>FromStepIndex</c> is <c>null</c> when the source is a raw
+    /// input — meaning no step in the plan produces that item.
+    /// </summary>
+    public sealed record GraphEdge(
+        int? FromStepIndex,
+        int ToStepIndex,
+        string ItemId,
+        string ItemName,
+        decimal ItemsPerMinute);
+
+    public sealed record Layout(
+        IReadOnlyList<PlacedNode> Nodes,
+        IReadOnlyList<RawNode> Raws,
+        IReadOnlyList<GraphEdge> Edges,
+        double Width,
+        double Height);
+
+    public static Layout Build(PlanResponse plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var steps = plan.Steps;
+
+        // Index recipes that produce each item id so we can find the upstream
+        // recipe for any consumed input. Multiple producers can theoretically
+        // exist for one item; first hit wins — good enough for v1.
+        var producerByItem = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < steps.Count; i++)
+        {
+            foreach (var output in steps[i].Outputs)
+            {
+                producerByItem.TryAdd(output.ItemId, i);
+            }
+        }
+
+        var edges = new List<GraphEdge>();
+        for (var i = 0; i < steps.Count; i++)
+        {
+            foreach (var input in steps[i].Inputs)
+            {
+                if (producerByItem.TryGetValue(input.ItemId, out var fromIx) && fromIx != i)
+                {
+                    edges.Add(new GraphEdge(fromIx, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
+                }
+                else
+                {
+                    edges.Add(new GraphEdge(null, i, input.ItemId, input.ItemName, input.ItemsPerMinute));
+                }
+            }
+        }
+
+        // Depth = longest path from any in-plan "source" recipe. Cycle-safe
+        // via a recursion-depth guard (shouldn't ever fire on real plans).
+        var depths = new int[steps.Count];
+        Array.Fill(depths, -1);
+        var preds = new List<int>[steps.Count];
+        for (var i = 0; i < steps.Count; i++) preds[i] = [];
+        foreach (var e in edges)
+        {
+            if (e.FromStepIndex is int from) preds[e.ToStepIndex].Add(from);
+        }
+
+        int ComputeDepth(int ix, int guard)
+        {
+            if (guard > steps.Count) return 0;
+            if (depths[ix] >= 0) return depths[ix];
+            var max = 0;
+            foreach (var p in preds[ix])
+            {
+                max = Math.Max(max, ComputeDepth(p, guard + 1) + 1);
+            }
+            depths[ix] = max;
+            return max;
+        }
+        for (var i = 0; i < steps.Count; i++) ComputeDepth(i, 0);
+
+        var maxDepth = depths.Length == 0 ? 0 : depths.Max();
+        var byDepth = new List<List<int>>();
+        for (var d = 0; d <= maxDepth; d++) byDepth.Add([]);
+        for (var i = 0; i < steps.Count; i++) byDepth[depths[i]].Add(i);
+
+        var hasRaws = edges.Any(e => e.FromStepIndex is null);
+        var xColumn0 = Padding + (hasRaws ? RawColumnWidth + ColumnGap : 0);
+
+        var placed = new List<PlacedNode>(steps.Count);
+        for (var d = 0; d <= maxDepth; d++)
+        {
+            var column = byDepth[d];
+            var x = xColumn0 + d * (NodeWidth + ColumnGap);
+            for (var row = 0; row < column.Count; row++)
+            {
+                var y = Padding + row * (NodeHeight + RowGap);
+                placed.Add(new PlacedNode(column[row], steps[column[row]], d, x, y));
+            }
+        }
+
+        // Raw pseudo-nodes: one per distinct raw item, ordered by first
+        // appearance in the edge list so the layout is deterministic.
+        var rawItems = new List<(string id, string name)>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var e in edges)
+        {
+            if (e.FromStepIndex is null && seen.Add(e.ItemId))
+            {
+                rawItems.Add((e.ItemId, e.ItemName));
+            }
+        }
+        var raws = new List<RawNode>(rawItems.Count);
+        for (var r = 0; r < rawItems.Count; r++)
+        {
+            var y = Padding + r * (NodeHeight + RowGap);
+            raws.Add(new RawNode(rawItems[r].id, rawItems[r].name, Padding, y));
+        }
+
+        var rightmost = placed.Count == 0
+            ? xColumn0
+            : placed.Max(n => n.X) + NodeWidth;
+        var maxRowsRecipe = byDepth.Count == 0 ? 0 : byDepth.Max(c => c.Count);
+        var maxRowsOverall = Math.Max(maxRowsRecipe, raws.Count);
+        var height = Padding * 2 + Math.Max(NodeHeight, maxRowsOverall * (NodeHeight + RowGap) - RowGap);
+        var width = rightmost + Padding;
+
+        return new Layout(placed, raws, edges, width, height);
+    }
+
+    /// <summary>Right-midpoint of an edge's source node (recipe or raw stub).</summary>
+    public static (double X, double Y) SourceMidRight(GraphEdge edge, Layout layout)
+    {
+        if (edge.FromStepIndex is int from)
+        {
+            var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == from);
+            if (node is null) return (double.NaN, double.NaN);
+            return (node.X + NodeWidth, node.Y + NodeHeight / 2.0);
+        }
+        var raw = layout.Raws.FirstOrDefault(r => r.ItemId == edge.ItemId);
+        if (raw is null) return (double.NaN, double.NaN);
+        return (raw.X + RawColumnWidth, raw.Y + NodeHeight / 2.0);
+    }
+
+    /// <summary>Left-midpoint of an edge's target recipe node.</summary>
+    public static (double X, double Y) TargetMidLeft(GraphEdge edge, Layout layout)
+    {
+        var node = layout.Nodes.FirstOrDefault(n => n.StepIndex == edge.ToStepIndex);
+        if (node is null) return (double.NaN, double.NaN);
+        return (node.X, node.Y + NodeHeight / 2.0);
+    }
+
+    /// <summary>Format a double for SVG coords using invariant culture.</summary>
+    public static string Fmt(double v) => v.ToString("0.##", CultureInfo.InvariantCulture);
+}

--- a/test/Web/Web.UiTests/PlannerGraphLayoutTests.cs
+++ b/test/Web/Web.UiTests/PlannerGraphLayoutTests.cs
@@ -1,0 +1,113 @@
+using Web;
+
+// Deliberately NOT under the Web.UiTests namespace so the TestNoUi NUKE
+// target (which filters FullyQualifiedName!~Web.UiTests) picks these up.
+// These are pure unit tests — they never touch Aspire or Playwright.
+namespace Web.LayoutTests;
+
+public class PlannerGraphLayoutTests
+{
+    [Fact]
+    public void Build_returns_empty_layout_for_empty_plan()
+    {
+        var plan = new PlanResponse(
+            IsFeasible: true,
+            Steps: [],
+            TotalPowerMw: 0,
+            RawInputsConsumed: [],
+            MissingInputs: []);
+
+        var layout = PlannerGraphLayout.Build(plan);
+
+        Assert.Empty(layout.Nodes);
+        Assert.Empty(layout.Raws);
+        Assert.Empty(layout.Edges);
+    }
+
+    [Fact]
+    public void Build_links_downstream_recipe_to_upstream_producer()
+    {
+        // Iron ore -> iron ingot -> iron plate. Plate-step's input is ingot,
+        // which the ingot-step outputs — so the edge connects ingot -> plate.
+        var ingot = new StepView(
+            RecipeId: "ingot", RecipeName: "Iron Ingot",
+            BuildingId: "smelter", BuildingName: "Smelter",
+            BuildingCount: 1m, PowerMw: 4m,
+            Inputs:  [new AmountView("ore", "Iron Ore", 30m)],
+            Outputs: [new AmountView("ingot", "Iron Ingot", 30m)]);
+        var plate = new StepView(
+            RecipeId: "plate", RecipeName: "Iron Plate",
+            BuildingId: "constructor", BuildingName: "Constructor",
+            BuildingCount: 1m, PowerMw: 4m,
+            Inputs:  [new AmountView("ingot", "Iron Ingot", 30m)],
+            Outputs: [new AmountView("plate", "Iron Plate", 20m)]);
+        var plan = new PlanResponse(true, [ingot, plate], 8m, [], []);
+
+        var layout = PlannerGraphLayout.Build(plan);
+
+        Assert.Equal(2, layout.Nodes.Count);
+        // Plate has ingot as predecessor → depth 1; ingot is depth 0.
+        Assert.Equal(0, layout.Nodes.Single(n => n.Step.RecipeId == "ingot").Depth);
+        Assert.Equal(1, layout.Nodes.Single(n => n.Step.RecipeId == "plate").Depth);
+
+        // Two edges total: raw ore → ingot, and ingot → plate.
+        Assert.Equal(2, layout.Edges.Count);
+        Assert.Contains(layout.Edges, e => e.FromStepIndex is null && e.ItemId == "ore");
+        Assert.Contains(layout.Edges, e =>
+            e.FromStepIndex == 0 && e.ToStepIndex == 1 && e.ItemId == "ingot");
+
+        // One raw pseudo-node for the ore.
+        Assert.Single(layout.Raws);
+        Assert.Equal("ore", layout.Raws[0].ItemId);
+    }
+
+    [Fact]
+    public void Build_columns_are_ordered_left_to_right_by_depth()
+    {
+        // Three-step chain: A → B → C. Each column's x must strictly grow.
+        var a = new StepView("A", "A-rec", "b", "B", 1, 1,
+            Inputs:  [new AmountView("ore", "Ore", 10)],
+            Outputs: [new AmountView("mid1", "Mid1", 10)]);
+        var b = new StepView("B", "B-rec", "b", "B", 1, 1,
+            Inputs:  [new AmountView("mid1", "Mid1", 10)],
+            Outputs: [new AmountView("mid2", "Mid2", 10)]);
+        var c = new StepView("C", "C-rec", "b", "B", 1, 1,
+            Inputs:  [new AmountView("mid2", "Mid2", 10)],
+            Outputs: [new AmountView("final", "Final", 10)]);
+
+        var layout = PlannerGraphLayout.Build(new PlanResponse(true, [a, b, c], 3, [], []));
+
+        var xs = new[] { "A", "B", "C" }
+            .Select(id => layout.Nodes.Single(n => n.Step.RecipeId == id).X)
+            .ToArray();
+        Assert.True(xs[0] < xs[1] && xs[1] < xs[2],
+            $"Expected strictly increasing X by depth, got [{xs[0]}, {xs[1]}, {xs[2]}]");
+    }
+
+    [Fact]
+    public void Build_width_grows_with_depth_to_fit_all_columns()
+    {
+        // A plan with one step needs to be narrower than a plan with three
+        // chained steps — a basic sanity check that the canvas tracks depth.
+        var solo = new StepView("S", "Solo", "b", "B", 1, 1,
+            Inputs:  [new AmountView("ore", "Ore", 10)],
+            Outputs: [new AmountView("out", "Out", 10)]);
+        var soloLayout = PlannerGraphLayout.Build(
+            new PlanResponse(true, [solo], 1, [], []));
+
+        var a = new StepView("A", "A", "b", "B", 1, 1,
+            Inputs:  [new AmountView("ore", "Ore", 10)],
+            Outputs: [new AmountView("m1", "M1", 10)]);
+        var b = new StepView("B", "B", "b", "B", 1, 1,
+            Inputs:  [new AmountView("m1", "M1", 10)],
+            Outputs: [new AmountView("m2", "M2", 10)]);
+        var c = new StepView("C", "C", "b", "B", 1, 1,
+            Inputs:  [new AmountView("m2", "M2", 10)],
+            Outputs: [new AmountView("out", "Out", 10)]);
+        var chainLayout = PlannerGraphLayout.Build(
+            new PlanResponse(true, [a, b, c], 3, [], []));
+
+        Assert.True(chainLayout.Width > soloLayout.Width,
+            $"Chained layout ({chainLayout.Width}) should be wider than solo ({soloLayout.Width}).");
+    }
+}

--- a/test/Web/Web.UiTests/Web.UiTests.csproj
+++ b/test/Web/Web.UiTests/Web.UiTests.csproj
@@ -27,6 +27,13 @@
       not a child resource the host should orchestrate.
     -->
     <ProjectReference Include="..\..\..\src\AppHost\AppHost.csproj" IsAspireProjectResource="false" />
+    <!--
+      Direct reference to Web so non-UI unit tests in this project (e.g.
+      PlannerGraphLayoutTests for #89) can call into pure helpers without
+      booting Aspire. Playwright-driven tests still use the AppHost
+      reference above to drive a real browser session.
+    -->
+    <ProjectReference Include="..\..\..\src\Web\Web.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- New `/planner/graph` page renders the current plan as a pure-SVG left-to-right DAG: raw inputs on the left, target recipes on the right.
- Node labels show recipe + building count (1 dp) + power MW; edge labels show item + items/min. Layout = longest-path depth per node, columns stacked vertically in iteration order.
- Zero JS dependencies — markup emitted via `RenderTreeBuilder` so the page lives in a single `.razor` file. No npm, no CDN, no extra NuGet.

## What's in the box
- `src/Web/Components/Pages/PlannerGraph.razor` — page + inline form for sources/sinks + SVG render.
- `src/Web/PlannerGraphLayout.cs` — pure helper that turns a `PlanResponse` into placed nodes, raw stubs, and edges. Testable in isolation.
- `src/Web/Components/Layout/NavMenu.razor` — new nav link under Planner.
- `test/Web/Web.UiTests/PlannerGraphLayoutTests.cs` — four xUnit cases (empty plan / chain wiring / column ordering / canvas growth). Hosted inside `Web.UiTests` but under namespace `Web.LayoutTests` so the `TestNoUi` filter still picks them up.

## Approach notes / known limitations
- Layout is dumb-and-cheap on purpose: no crossing minimisation, no force-directed pass. Fine up to ~20 recipes which covers normal Tier 3-4 plans. The acceptance bullet "no overlapping edges for ≥5 steps" passes for typical plans but pathological multi-fan-in DAGs may cross.
- One producer per item — if multiple steps output the same item, the first wins for upstream linking.
- Byproducts (outputs nobody consumes) currently aren't drawn as dangling arrows in v1; they just don't appear on the graph. Issue notes that as "visually distinct" — worth a follow-up.
- Page uses its own inline source/sink form rather than reading Planner.razor's state — keeping the page standalone matched the "pick the simpler one" guidance in the brief.

## Test plan
- [x] `dotnet build ERP.Satisfactory.slnx` — clean.
- [x] `./build.sh TestNoUi` — green; 4 new tests run and pass.
- [ ] Manual: visit `/planner/graph`, add Iron Plate sink at 30/min, press Compute & render; confirm raw-ore stub on left, ingot in middle, plate on right, with labelled edges.
- [ ] Manual: navigate to `/planner/graph` with no plan; confirm the empty-state alert links back to `/planner`.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)