### PR TITLE
feat(save): populate Pipeline.Polyline from mSplineData (#138)

### DIFF
--- a/src/ERP/Domain/Pipeline.cs
+++ b/src/ERP/Domain/Pipeline.cs
@@ -6,13 +6,10 @@ namespace ERP.Domain;
 /// the pipe's route when known.
 /// <para>
 /// Polyline coordinates come from the actor's <c>mSplineData</c>
-/// (<c>Array&lt;Struct&lt;FSplinePointData&gt;&gt;</c>). The vendored
-/// SatisfactorySaveNet fork does not yet deserialize that property shape
-/// (its <c>RawProperty</c> typed slots cover <c>Array&lt;ObjectProperty&gt;</c>
-/// but not <c>Array&lt;Struct&gt;</c>), so <c>Polyline</c> is currently
-/// always <c>null</c>. The app-side plumbing here is intentional scaffolding
-/// so that LineString rendering activates the moment the fork catches up —
-/// tracked in issue #65 (this domain field) and the follow-up parser issue.
+/// (<c>Array&lt;Struct&lt;FSplinePointData&gt;&gt;</c>), populated via the
+/// fork's v1.2 <c>RawProperty.ArrayStructValues</c> reader. Pipes that ship
+/// without spline data (or pre-v1.2 saves) leave <c>Polyline</c> null and
+/// fall back to point-only rendering.
 /// </para>
 /// </summary>
 public sealed record Pipeline(

--- a/src/Satisfactory/Save/PropertyExtensions.cs
+++ b/src/Satisfactory/Save/PropertyExtensions.cs
@@ -1,5 +1,6 @@
 using SatisfactorySaveNet.Abstracts.Model;
 using SatisfactorySaveNet.Abstracts.Model.Properties;
+using System.Collections.Generic;
 
 namespace Satisfactory.Save;
 
@@ -29,6 +30,14 @@ public static class PropertyExtensions
     /// <summary>Reads an int property by name.</summary>
     public static int? TryGetInt(this ComponentObject actor, string name)
         => FindRaw(actor, name)?.IntValue;
+
+    /// <summary>
+    /// Reads an ArrayProperty&lt;StructProperty&gt; by name (e.g. <c>mSplineData</c>
+    /// on pipe/belt actors). Returns each element's inner property list, or null
+    /// if absent / not an array-of-struct shape.
+    /// </summary>
+    public static IReadOnlyList<StructElementValue>? TryGetArrayStructValues(this ComponentObject actor, string name)
+        => FindRaw(actor, name)?.ArrayStructValues;
 
     /// <summary>
     /// Returns the trailing class segment of a class path

--- a/src/Satisfactory/Save/Satisfactory.Save.csproj
+++ b/src/Satisfactory/Save/Satisfactory.Save.csproj
@@ -8,8 +8,8 @@
       vendor/SatisfactorySaveNet stays for local fork iteration but is no
       longer on the build path.
     -->
-    <PackageReference Include="SatisfactorySaveNet" Version="4.1.2" />
-    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.1.2" />
+    <PackageReference Include="SatisfactorySaveNet" Version="4.1.3" />
+    <PackageReference Include="SatisfactorySaveNet.Abstracts" Version="4.1.3" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Satisfactory/Save/SaveFileReader.cs
+++ b/src/Satisfactory/Save/SaveFileReader.cs
@@ -2,6 +2,7 @@ using ERP.Domain;
 using SatisfactorySaveNet;
 using SatisfactorySaveNet.Abstracts.Extra;
 using SatisfactorySaveNet.Abstracts.Model;
+using SatisfactorySaveNet.Abstracts.Model.Properties;
 
 namespace Satisfactory.Save;
 
@@ -92,12 +93,8 @@ public sealed class SaveFileReader
             }
             else if (BuildingIdentifiers.PipelineTier(typePath) is { } pipeTier)
             {
-                // Polyline stays null until the vendored fork can parse the
-                // pipe actor's `mSplineData` (Array<Struct<FSplinePointData>>);
-                // see Pipeline.cs xmldoc + issue #65 for the wiring rationale.
-                // Once the fork lands the new property reader, populate here
-                // from the FSplinePointData entries.
-                pipelines.Add(new Pipeline(reference, pipeTier, position, Polyline: null));
+                var polyline = ExtractPipePolyline(actor);
+                pipelines.Add(new Pipeline(reference, pipeTier, position, polyline));
             }
             else if (BuildingIdentifiers.GeneratorKind(typePath) is { } genKind)
             {
@@ -162,6 +159,48 @@ public sealed class SaveFileReader
             }
         }
         return lookup;
+    }
+
+    /// <summary>
+    /// Pulls the polyline geometry from a pipe actor's <c>mSplineData</c>
+    /// (<c>Array&lt;Struct&lt;FSplinePointData&gt;&gt;</c>). Each element exposes a
+    /// <c>Location</c> StructProperty whose value is a 3-doubles vector.
+    /// Returns null when the property is absent (saves predating the fork's
+    /// v1.2 Array&lt;Struct&gt; reader, or pipe actors that legitimately have no
+    /// spline data) — callers fall back to point-only geometry.
+    /// </summary>
+    private static IReadOnlyList<Position>? ExtractPipePolyline(ActorObject actor)
+    {
+        var splineData = actor.TryGetArrayStructValues("mSplineData");
+        if (splineData is null || splineData.Count == 0) return null;
+
+        var points = new List<Position>(splineData.Count);
+        foreach (var element in splineData)
+        {
+            if (TryFindLocationVector(element.Properties) is { } xyz)
+                points.Add(new Position((float)xyz[0], (float)xyz[1], (float)xyz[2]));
+        }
+        return points.Count > 0 ? points : null;
+    }
+
+    /// <summary>
+    /// Finds the <c>Location</c> StructProperty inside one FSplinePointData
+    /// element and returns its (X, Y, Z) doubles. Falls back to null when the
+    /// element omits Location or when its StructValue isn't a 3-element vector.
+    /// </summary>
+    private static double[]? TryFindLocationVector(IReadOnlyList<Property> properties)
+    {
+        foreach (var p in properties)
+        {
+            if (p is RawProperty raw
+                && raw.Name == "Location"
+                && raw.StructValue?.Value is double[] xyz
+                && xyz.Length == 3)
+            {
+                return xyz;
+            }
+        }
+        return null;
     }
 
     private ResourceNode BuildResourceNode(string typePath, string reference, Position position)


### PR DESCRIPTION
## Summary
- Bump SatisfactorySaveNet / .Abstracts PackageReference 4.1.2 → 4.1.3 (fork PR ChrisonSimtian/SatisfactorySaveNet#8 adds v1.2 `ArrayProperty<StructProperty>` deep-parse).
- Wire pipe `mSplineData` through `SaveFileReader.ExtractPipePolyline` so `Pipeline.Polyline` is populated.
- New `TryGetArrayStructValues` helper on `ComponentObject`.

## Why
This is the 0.4.0 milestone feature: pipes now render as LineStrings in the GeoJSON map alongside conveyor belts. Pipes that ship without spline data (legacy saves, isolated pipe actors) keep `Polyline = null` and fall back to point-only rendering.

## Test plan
- [x] `dotnet build ERP.Satisfactory.slnx` clean
- [x] Full ERP test suite passes (Application 24, Catalog 18, Infrastructure 17, Save 33, Persistence 9, Web.UiTests 9)
- [x] Fork-side coverage: `ArrayOfStruct_ParsesElementsAsInnerPropertyLists` + `ArrayOfStruct_EmptyArray_ProducesEmptyValuesList` (137 fork tests pass)
- [ ] End-to-end verification against a real v1.2 save with pipes once available — falls back gracefully if our wire-format assumption needs adjustment

Closes #138.