### PR TITLE
release: bump to 0.4 — pipe polylines milestone

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.3",
+  "version": "0.4",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
## Summary
Bumps `version.json` 0.3 → 0.4 to release the pipe polylines milestone.

## What's in 0.4
- #138 — Pipe `mSplineData` parsed by the fork (4.1.3) and threaded through `SaveFileReader.ExtractPipePolyline` into `Pipeline.Polyline`. Pipes render as LineStrings on the map.
- (#137, #129, #90, #91 also rolled up since 0.3 baseline.)

## SemVer
Minor — additive. Existing pipes without spline data keep `Polyline = null` and fall back to point-only rendering; no caller behaviour breaks.

## Test plan
- [x] CI green on #146 (the feature commit)
- [ ] Release workflow on main creates the GitHub Release once this merges