### PR TITLE
docs: add MIT LICENSE, GitHub Sponsors funding, mermaid diagrams, more badges

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: ChrisonSimtian

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chrison Simtian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 [![CI](https://github.com/ChrisonSimtian/ERP.Satisfactory/actions/workflows/ci.yml/badge.svg)](https://github.com/ChrisonSimtian/ERP.Satisfactory/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/ChrisonSimtian/ERP.Satisfactory?label=release)](https://github.com/ChrisonSimtian/ERP.Satisfactory/releases/latest)
+[![GitHub last commit](https://img.shields.io/github/last-commit/ChrisonSimtian/ERP.Satisfactory)](https://github.com/ChrisonSimtian/ERP.Satisfactory/commits/main)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dot.net)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Wiki](https://img.shields.io/badge/wiki-pages-blue)](https://github.com/ChrisonSimtian/ERP.Satisfactory/wiki)
+[![Open issues](https://img.shields.io/github/issues/ChrisonSimtian/ERP.Satisfactory)](https://github.com/ChrisonSimtian/ERP.Satisfactory/issues)
+[![Open PRs](https://img.shields.io/github/issues-pr/ChrisonSimtian/ERP.Satisfactory)](https://github.com/ChrisonSimtian/ERP.Satisfactory/pulls)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ChrisonSimtian?label=sponsor&logo=githubsponsors&color=EA4AAA)](https://github.com/sponsors/ChrisonSimtian)
 
 A .NET 10 / Blazor / Aspire application that helps you plan factories in the game
 [*Satisfactory*](https://www.satisfactorygame.com/) given the inputs you have and the
@@ -155,6 +160,54 @@ for the lineage and rationale.
   adapters).
 - **Aspire** orchestrates local dev across `ApiService`, `Web`, and
   `ServiceDefaults`.
+
+```mermaid
+flowchart TB
+    subgraph CR["Composition root"]
+        Aspire["AppHost — Aspire"]
+        Api["ApiService — Minimal API"]
+        Web["Web — Blazor + MudBlazor"]
+    end
+    subgraph Infra["ERP.Infrastructure"]
+        ORTools["OrToolsRecipePlanner"]
+        EF["EF Core<br/>SQLite · Postgres"]
+        Ticker["TickerQ jobs"]
+        SaveAdapter["SatisfactorySaveNet adapter"]
+    end
+    subgraph App["ERP.Application"]
+        Ports["IRecipePlanner · IFactoryStateProvider · IPlanRepository"]
+        Wolverine["Wolverine handlers"]
+    end
+    subgraph Dom["ERP.Domain"]
+        Domain["ProductionPlan · ProductionTarget · ..."]
+    end
+    Aspire --> Api & Web
+    Api --> Wolverine
+    Web --> Api
+    Wolverine --> Ports
+    Ports -.->|adapters| ORTools & SaveAdapter & EF
+    Ticker --> Wolverine
+    App --> Dom
+    Infra --> Dom
+```
+
+And here's what happens when you ingest a save and ask for a plan:
+
+```mermaid
+flowchart LR
+    Sav[".sav file"] --> Reader["SaveFileReader"]
+    Reader --> State["IFactoryStateProvider"]
+    Docs["Docs.json"] --> Catalog["Catalog parser"]
+    User["User input<br/>Targets · Available · PowerMW"] --> Query["PlanProductionQuery"]
+    State --> Query
+    Catalog --> Query
+    Query --> Bus["Wolverine bus"]
+    Bus --> LP["OrToolsRecipePlanner<br/>GLOP solver"]
+    LP --> Plan["ProductionPlan"]
+    Plan --> ApiOut["GET /plan"]
+    ApiOut --> UI["Blazor — /planner · /dashboard"]
+    AutoIngest["TickerQ auto-ingest"] -.watches.-> Sav
+```
 
 All architecturally significant decisions live in [`docs/adr/`](docs/adr/README.md).
 Notable ones:


### PR DESCRIPTION
## Summary
Three additions in one pass:

- **`LICENSE`** — declare MIT explicitly (year 2026, holder `Chrison Simtian`). The repo had no license file, so anyone using the code was doing so without an explicit grant. Fixes that.
- **`.github/FUNDING.yml`** — wire up GitHub Sponsors so the repo's built-in "Sponsor" button activates. Closes #117.
- **README refresh** — 5 new shields.io badges (License, Sponsors, last commit, open issues, open PRs) and 2 mermaid diagrams in the Architecture section (onion + bounded contexts overview, plus a `.sav` → plan → render data flow). Both diagrams render natively on GitHub.

## Why this shape
- User wanted "awesome graphs" — mermaid is the highest-leverage option since GitHub renders it natively (no external service, no maintenance).
- Skipped star-history / contrib.rocks for now — 0 stars / 1 contributor would render as flat-line / lonely-avatar; revisit once the project has traction.
- Skipped Codecov — out of scope this round, but `coverlet.collector` is already wired in test projects so it's straightforward later.

## Test plan
- [x] `dotnet build ERP.Satisfactory.slnx` clean
- [ ] After merge: visit the repo page and confirm
  - Mermaid diagrams render as SVG (not raw code blocks)
  - All 9 badges load (no broken-image icons)
  - The "Sponsor" button appears next to Watch / Fork / Star
  - "License: MIT" badge links to `LICENSE`

Closes #117.