### PR TITLE
docs(claude): rebrand CLAUDE.md and .claude/ for multi-game framing (closes #161)

### DIFF
--- a/.claude/agents/ada.md
+++ b/.claude/agents/ada.md
@@ -7,7 +7,8 @@ tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 ---
 
 You are **ADA** — FICSIT's onboard Artificial Directory and Assistant — embedded in
-Chris's ERP.Satisfactory project as his in-game knowledge advisor.
+Chris's ERP for Factory Games project as his in-game knowledge advisor for *Satisfactory*
+(the first supported game).
 
 ## Who you help and what for
 
@@ -75,7 +76,7 @@ Keep responses tight. A ratio question deserves three lines, not a wall of text.
 
 ## Live factory state — `GET /factory/state`
 
-The running ERP.Satisfactory ApiService parses Chris's `.sav` in-process and exposes
+The running ApiService parses Chris's `.sav` in-process and exposes
 the result at `GET /factory/state` (JSON) and `GET /factory/state.geojson` (with
 positions, for the map). That's your source of truth for anything Chris has actually
 built — miner counts by tier, miners bound to which resource node, producers grouped

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -60,6 +60,6 @@ dependencies. Domain logic must not leak into Infrastructure or Web.
 ## Build & run
 
 ```powershell
-dotnet build ERP.Satisfactory.sln
+dotnet build ErpForFactoryGames.slnx
 dotnet run --project src/AppHost
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,13 @@
-# ERP.Satisfactory
+# ERP for Factory Games
 
-ERP-style production planner for the game *Satisfactory*. Primary objective:
+ERP-style production planner for factory games. Primary objective:
 **help the user plan a factory based on the inputs they have and the outputs they need.**
+
+Currently implements **Satisfactory** as the first supported game; the planning core,
+persistence, and UI are game-agnostic and additional games slot in as sibling modules
+alongside `src/Satisfactory/`. See
+[ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md) for the rebrand decision
+and what's deliberately out of scope (UI rebrand, namespace refactor).
 
 ## Where things live
 
@@ -15,7 +21,7 @@ ERP-style production planner for the game *Satisfactory*. Primary objective:
 
 ```powershell
 export GITHUB_TOKEN=$(gh auth token)   # nuget.config reads it for GitHub Packages
-dotnet build ERP.Satisfactory.slnx
+dotnet build ErpForFactoryGames.slnx
 dotnet run --project src/AppHost
 ```
 


### PR DESCRIPTION
Part of the [rebrand milestone](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/15). Updates Claude-facing project docs so future Claude Code sessions don't reintroduce \"ERP.Satisfactory\" framing.

## Changes

- **CLAUDE.md** — title + tagline reframed; build command updated to `ErpForFactoryGames.slnx`; adds a one-line callout linking to [ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md) for the rebrand decision and its out-of-scope notes.
- **.claude/architecture.md** — build command updated (also fixes a stale `.sln` → `.slnx`).
- **.claude/agents/ada.md** — project framing line widened to \"ERP for Factory Games\" with Satisfactory called out as the first supported game. ADA herself stays in character as the in-game Satisfactory assistant.

## Out of scope

- ADA's overall character / tooling — she remains FICSIT-themed and Satisfactory-focused by design ([ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md) §Out of scope).
- `.claude/README.md` — already free of project-name references.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] No remaining \"ERP.Satisfactory\" hits in `CLAUDE.md` or `.claude/` tracked files (verified locally; worktree caches not tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)