### PR TITLE
docs: sweep ADRs + roadmap for rebrand references (closes #162)

### DIFF
--- a/docs/adr/0001-use-dotnet-10.md
+++ b/docs/adr/0001-use-dotnet-10.md
@@ -6,8 +6,10 @@
 
 ## Context
 
-ERP.Satisfactory is a brand-new .NET application. We need to choose a target framework
-that gives us the longest feature/support runway and the best Aspire/Blazor support.
+ERP.Satisfactory (since rebranded to **ERP for Factory Games** — see
+[ADR-0020](0020-rebrand-to-erp-for-factory-games.md)) is a brand-new .NET application.
+We need to choose a target framework that gives us the longest feature/support runway
+and the best Aspire/Blazor support.
 
 ## Decision
 

--- a/docs/adr/0008-use-playwright-for-ui-tests.md
+++ b/docs/adr/0008-use-playwright-for-ui-tests.md
@@ -41,5 +41,5 @@ distributed app through `Aspire.Hosting.Testing` so they exercise the real
 - The Playwright **MCP server** (`@playwright/mcp`) is a separate, optional
   developer tool for ad-hoc browser-driving during a Claude Code session. It is
   **not** part of the test suite or CI and does not replace `Microsoft.Playwright`.
-- Future work: once the Planner UI exists ([milestone 4](https://github.com/ChrisonSimtian/ERP.Satisfactory/milestone/4)),
+- Future work: once the Planner UI exists ([milestone 4](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/4)),
   add scenario tests for the golden planning path (enter target → see plan).

--- a/docs/adr/0010-game-agnostic-catalogue-contract.md
+++ b/docs/adr/0010-game-agnostic-catalogue-contract.md
@@ -50,8 +50,8 @@ Concretely:
 - Naming: rename the existing `IRecipeCatalog` to something broader (e.g.
   `ICatalogProvider` or `IGameCatalogue`) when widening — see the issue under
   milestone #9.
-- The contract grows over time as new epics land: fluids ([Fluids epic](https://github.com/ChrisonSimtian/ERP.Satisfactory/milestone/10)),
-  extractors and resource nodes ([Extractors epic](https://github.com/ChrisonSimtian/ERP.Satisfactory/milestone/11)),
+- The contract grows over time as new epics land: fluids ([Fluids epic](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/10)),
+  extractors and resource nodes ([Extractors epic](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/11)),
   schematics, etc. Each addition is a contract change shared across adapters.
 - Game-specific concepts that don't generalize (e.g. Satisfactory's
   Somersloops, Factorio's modules) live in adapter-side extensions, not the

--- a/docs/adr/0017-mudblazor-as-ui-framework.md
+++ b/docs/adr/0017-mudblazor-as-ui-framework.md
@@ -105,13 +105,13 @@ with MudBlazor's utility classes (`d-flex`, `gap-*`, `mb-*`, `pa-*`,
 ## See also
 
 - [ADR 0002](0002-use-blazor-for-ui.md) — Use Blazor for the UI.
-- PRs [#48](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/48),
-  [#49](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/49),
-  [#51](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/51),
-  [#52](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/52),
-  [#53](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/53),
-  [#54](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/54),
-  [#55](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/55),
-  [#56](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/56),
-  [#57](https://github.com/ChrisonSimtian/ERP.Satisfactory/pull/57) — the
+- PRs [#48](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/48),
+  [#49](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/49),
+  [#51](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/51),
+  [#52](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/52),
+  [#53](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/53),
+  [#54](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/54),
+  [#55](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/55),
+  [#56](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/56),
+  [#57](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/57) — the
   migration phases.

--- a/docs/adr/0018-persistence-stack.md
+++ b/docs/adr/0018-persistence-stack.md
@@ -6,11 +6,12 @@
 
 ## Context
 
-ERP.Satisfactory needs to persist user-created plans (and, later, other
-write-side state — saved overrides, snapshots of catalogues, etc.). The project
-is open-source, single-user by default, occasionally run as a hosted demo, and
-must keep contribution friction low (zero install, `dotnet run` should "just
-work").
+ERP.Satisfactory (since rebranded to **ERP for Factory Games** — see
+[ADR-0020](0020-rebrand-to-erp-for-factory-games.md)) needs to persist user-created
+plans (and, later, other write-side state — saved overrides, snapshots of catalogues,
+etc.). The project is open-source, single-user by default, occasionally run as a
+hosted demo, and must keep contribution friction low (zero install, `dotnet run`
+should "just work").
 
 Storage requirements:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,11 @@
 # Roadmap
 
-This doc captures the long-tail vision for ERP.Satisfactory — features that aren't
-scoped enough yet to be GitHub issues, but that should be visible so design choices
-made today don't accidentally close doors tomorrow.
+This doc captures the long-tail vision for **ERP for Factory Games** — features that
+aren't scoped enough yet to be GitHub issues, but that should be visible so design
+choices made today don't accidentally close doors tomorrow.
 
 Issues that already exist for near-term work live on
-[GitHub](https://github.com/ChrisonSimtian/ERP.Satisfactory/issues) under their
+[GitHub](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues) under their
 milestones. This doc is for what's beyond the current backlog.
 
 The primary objective stays unchanged: **help the user plan a factory based on the
@@ -115,9 +115,11 @@ all of the above.
 
 ## V2 platform direction
 
-Eventually the goal is to graduate from "ERP for Satisfactory" to "ERP for
-factory games" — a generic platform that other games plug into. Two big
-threads tee this up: multi-game support and self-hosted deployment.
+The project-name graduation from "ERP for Satisfactory" to "ERP for Factory Games"
+has landed ([ADR-0020](adr/0020-rebrand-to-erp-for-factory-games.md)) — repo,
+solution, and domain (`erp-for-factory.games`) all reflect the broader scope. What
+the v2 *platform* direction now means is the underlying refactor work that makes
+multi-game real, plus self-hosted deployment. Two big threads tee this up.
 
 ### Multi-game support
 
@@ -149,9 +151,12 @@ What's not yet generic:
   ecosystem, less mature parser tooling.
 
 **Likely refactors:**
-- Rename / re-namespace: `ERP.Satisfactory` → `ERP.Core` + `ERP.Games.Satisfactory`
-  + `ERP.Games.CaptainOfIndustry` + `ERP.Games.DysonSphere`. Repo stays one;
-  per-game projects under `src/Games/`.
+- Re-namespace: today's `ERP.*` + `Satisfactory.*` projects → `ERP.Core` +
+  `ERP.Games.Satisfactory` + `ERP.Games.CaptainOfIndustry` + `ERP.Games.DysonSphere`.
+  Repo stays one; per-game projects under `src/Games/`. The repo/solution
+  rename ([ADR-0020](adr/0020-rebrand-to-erp-for-factory-games.md)) deliberately
+  deferred this — it touches every `.csproj` and `using` directive and is
+  better done when a second game implementation pushes the contracts into shape.
 - New ADR: "Game adapter contract" — what each adapter must implement
   (`ICatalogueLoader`, `ISaveParser`, `IWorldMapRenderer`, optional
   `ILiveStateProvider`).


### PR DESCRIPTION
Part of the [rebrand milestone](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/15). Sweeps remaining project-name and URL references across ADRs and the roadmap to align with the rebrand to \"ERP for Factory Games\" ([ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md)).

## Approach

ADRs are immutable in intent — decisions and historical analysis are preserved. Two distinct treatments:

### ADRs (selective)

- **ADR-0001** and **ADR-0018** — context paragraphs gain a `(since rebranded to **ERP for Factory Games** — see ADR-0020)` inline note. The old name is preserved so the ADR's history reads coherently at its written date; the rebrand is signposted for present-day readers.
- **ADR-0008**, **ADR-0010**, **ADR-0017** — stale GitHub URLs (milestones, PR links) swept to the new repo slug. GitHub redirects from the old slug, but documented URLs should be honest.
- **ADR-0010** \"Separate ERP per game (`ERP.Satisfactory`, `ERP.Factorio`)\" — intentionally **left as-is**. Those were the literal names being considered at the time; rewriting them would distort the alternative analysis.
- `docs/adr/README.md` index header — already updated in PR #168 alongside the new row for 0020.

### Roadmap (full sweep)

`docs/roadmap.md` is a living doc, not immutable:

- Opening framing reads \"ERP for Factory Games\" and points at the new repo URL.
- **V2 platform direction**: the \"graduate from ERP for Satisfactory\" framing is updated — the project-name graduation has now landed via ADR-0020; what remains is the deeper refactor + deployment work.
- **Likely refactors** entry rewritten to clarify that the project-name rename is done; the open work is the deeper re-namespace to `ERP.Core` + `ERP.Games.*` (which ADR-0020 deliberately deferred).

## Test plan

- [ ] Markdown renders cleanly on GitHub; all updated URLs resolve.
- [ ] ADR-0010's historical \"alternative considered\" reads coherently with the rebrand context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)