### PR TITLE
docs: add costs.md transparency doc + sponsorship section (closes #166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ and what's deliberately out of scope (UI rebrand, namespace refactor).
 > [Save File Parsing](https://github.com/ChrisonSimtian/ErpForFactoryGames/wiki/Save-File-Parsing),
 > or [LP Planner](https://github.com/ChrisonSimtian/ErpForFactoryGames/wiki/LP-Planner).
 
+## Sponsorship
+
+This project is OSS and runs on out-of-pocket spend. If you find it useful,
+[sponsor via GitHub Sponsors](https://github.com/sponsors/ChrisonSimtian) — every
+contribution goes back into keeping it running.
+
+See [where the money goes](costs.md) for the running list of project costs.
+
 ## What's new in v0.4 — *Pipe polylines milestone*
 
 - **Pipe polylines** — `mSplineData` is now deep-parsed end-to-end; pipes render

--- a/costs.md
+++ b/costs.md
@@ -1,0 +1,33 @@
+# Project costs
+
+Costs are paid out-of-pocket by [@ChrisonSimtian](https://github.com/ChrisonSimtian).
+Sponsorship via the [GitHub Sponsors button](https://github.com/sponsors/ChrisonSimtian)
+helps offset these — this page is here so anyone considering sponsoring can see exactly
+what their contribution covers.
+
+This is a list of *current, recurring* costs. One-offs (e.g. dev hardware) are not
+tracked here.
+
+| Item | Cost (NZD) | Cost (original currency) | Frequency | Notes |
+|------|-----------:|-------------------------:|-----------|-------|
+| Domain — `erp-for-factory.games` | ~$44 | USD $26.20 | Yearly | Cloudflare registrar, at-cost pricing for `.games` TLD. Registered 2026-05-21 ([ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md)). NZD figure is approximate at ~1.68 NZD/USD; refresh from the next Cloudflare invoice. |
+
+**Total recurring**: ~NZD $44/year (USD $26.20/year)
+
+## Not currently incurred
+
+These are foreseeable but not yet paid:
+
+- **App hosting** — the app isn't deployed anywhere yet. When it lands, expect a
+  homelab option (zero cost; runs on Chris's existing Proxmox cluster) or a
+  small VPS / managed hosting tier.
+- **CI minutes** — GitHub-hosted runners on the free tier suffice for the current
+  workload ([PR #152](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/152)).
+  Listed here so the line item appears the moment we exceed it.
+- **NuGet GitHub Packages bandwidth** — free for public packages.
+
+## Keeping this current
+
+This list is the *current* state. When a new cost arises (or an existing one
+changes), update the table in the same PR as the change. Stale cost lists are
+worse than missing ones.


### PR DESCRIPTION
Part of the [rebrand milestone](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/15). Adds a transparent list of out-of-pocket recurring costs and a Sponsorship section in the README so potential sponsors can see what their contribution covers.

## Changes

- **New file**: `costs.md` at repo root.
  - First entry: `erp-for-factory.games` via Cloudflare — **USD \$26.20/yr** (~**NZD \$44** at ~1.68 NZD/USD; refresh figure from next invoice).
  - \"Not currently incurred\" section captures foreseeable line items (app hosting, CI minutes beyond free tier, NuGet bandwidth) so they're ready to populate the moment any of them becomes real.
- **README.md**: new **Sponsorship** section right after the wiki callout, linking [GitHub Sponsors](https://github.com/sponsors/ChrisonSimtian) and `costs.md`.

## Notes for review

- The NZD figure is approximate — Chris's actual Cloudflare invoice was USD \$26.20. NZD line item should be refreshed against the next card statement / Cloudflare receipt at the prevailing FX rate.
- Cloudflare resells the `.games` TLD at-cost; \$26.20 USD matches the public registrar wholesale.
- If you'd rather track this differently (e.g. just original currency, no NZD; or include one-offs), happy to restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)