### PR TITLE
tools(cloudflare): add DNS + redirect setup script for #156/#164

### DIFF
--- a/tools/cloudflare/README.md
+++ b/tools/cloudflare/README.md
@@ -1,0 +1,65 @@
+# Cloudflare setup scripts
+
+One-time DNS and redirect setup for `erp-for-factory.games`.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| [`Setup-Dns.ps1`](Setup-Dns.ps1) | Configures DNS records, the apex/www → GitHub redirect rule, and TLS zone settings. Idempotent + dry-run by default. |
+
+## One-time setup
+
+1. **Create a scoped API token** at <https://dash.cloudflare.com/profile/api-tokens>.
+   Permissions:
+   - `Zone.Zone:Read`
+   - `Zone.DNS:Edit`
+   - `Zone.Zone Settings:Edit`
+   - `Zone.Rulesets:Edit` (for Single Redirects)
+
+   Restrict the token to the `erp-for-factory.games` zone only.
+
+2. **Dry-run** the setup script to see what would change:
+
+   ```powershell
+   $env:CLOUDFLARE_API_TOKEN = '...'
+   pwsh tools/cloudflare/Setup-Dns.ps1
+   ```
+
+3. **Apply** when satisfied:
+
+   ```powershell
+   pwsh tools/cloudflare/Setup-Dns.ps1 -Apply
+   ```
+
+4. **Verify**:
+
+   ```powershell
+   curl.exe -sI https://erp-for-factory.games        # 301 -> GitHub repo
+   curl.exe -sI https://www.erp-for-factory.games    # 301 -> GitHub repo
+   ```
+
+## What it does
+
+- Creates proxied `A` records on `erp-for-factory.games`, `www.erp-for-factory.games`,
+  and `satisfactory.erp-for-factory.games` pointing at `192.0.2.1` (TEST-NET-1).
+  The redirect fires at the Cloudflare edge, so traffic never reaches the IP.
+- Creates a Single Redirect rule: apex + www → the GitHub repo (until the app
+  has a hosted home).
+- `satisfactory.erp-for-factory.games` is reserved with a proxied placeholder
+  record only — no redirect rule yet. Locks in the host convention from
+  [ADR-0020](../../docs/adr/0020-rebrand-to-erp-for-factory-games.md) without
+  serving anything until the app is deployed.
+- Sets `Always-Use-HTTPS = on` and `Minimum TLS = 1.2` on the zone.
+
+## What it deliberately does NOT do
+
+- **Deploy the app.** Hosting choice (GitHub Pages / Azure SWA / Cloudflare Pages
+  / Fly.io / Proxmox homelab) is out of scope until the rebrand milestone is
+  closed and ADR-0020's "follow-up" issues are picked up.
+- **Configure DNSSEC.** Worth doing once nameservers are stable; add as a
+  follow-up.
+- **Add per-game subdomains beyond `satisfactory.*`.** Done case-by-case as
+  each game lands.
+- **CAA records.** Cloudflare provides certificates via Universal SSL — adding
+  CAA pinned to Cloudflare's issuers is a hardening step for later.

--- a/tools/cloudflare/Setup-Dns.ps1
+++ b/tools/cloudflare/Setup-Dns.ps1
@@ -1,0 +1,256 @@
+<#
+.SYNOPSIS
+    Configure Cloudflare DNS and redirects for erp-for-factory.games.
+
+.DESCRIPTION
+    Idempotent setup script for the project's apex domain on Cloudflare. Sets up:
+
+      1. A "parking" A record on apex + www, proxied through Cloudflare so a
+         redirect rule has DNS to attach to. Points at 192.0.2.1 (TEST-NET-1) —
+         the redirect fires at the Cloudflare edge, traffic never reaches the IP.
+      2. A "placeholder" A record on satisfactory.<apex>, also proxied.
+         Reserves the host convention from ADR-0020 without serving anything yet.
+      3. A Single Redirect rule: apex + www → the GitHub repo (until the app
+         has a hosted home).
+      4. Zone settings: Always-Use-HTTPS = on, Minimum TLS = 1.2.
+
+    Defaults to **dry-run**. Pass -Apply to actually mutate Cloudflare.
+
+.PARAMETER Zone
+    Domain registered on Cloudflare. Default: erp-for-factory.games.
+
+.PARAMETER RedirectTarget
+    URL the apex (and www) redirects to until the app has a hosted home.
+    Default: https://github.com/ChrisonSimtian/ErpForFactoryGames.
+
+.PARAMETER Apply
+    Actually call the Cloudflare API. Without this, the script only prints what
+    *would* be done. Always run once without -Apply first.
+
+.PARAMETER PlaceholderIp
+    IPv4 address used for the proxied parking records. TEST-NET-1 (192.0.2.1)
+    is reserved for documentation and won't route — perfect for "DNS exists so
+    Cloudflare proxies, but nothing's actually hosted there yet".
+
+.NOTES
+    Requires the CLOUDFLARE_API_TOKEN env var with permissions:
+      - Zone.Zone:Read
+      - Zone.DNS:Edit
+      - Zone.Zone Settings:Edit
+      - Zone.Page Rules / Redirect Rules:Edit (Account level: Bulk URL Redirects:Edit)
+
+    Create a scoped token at:
+      https://dash.cloudflare.com/profile/api-tokens
+      → "Create Token" → "Edit zone DNS" template → restrict to this zone.
+
+    Re-running with -Apply is safe: every operation checks existing state first.
+
+.EXAMPLE
+    # 1. Dry run — see what would happen
+    pwsh tools/cloudflare/Setup-Dns.ps1
+
+    # 2. Apply for real
+    $env:CLOUDFLARE_API_TOKEN = '...'
+    pwsh tools/cloudflare/Setup-Dns.ps1 -Apply
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Zone = 'erp-for-factory.games',
+    [string]$RedirectTarget = 'https://github.com/ChrisonSimtian/ErpForFactoryGames',
+    [switch]$Apply,
+    [string]$PlaceholderIp = '192.0.2.1'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Auth + helpers
+# ---------------------------------------------------------------------------
+
+if (-not $env:CLOUDFLARE_API_TOKEN) {
+    throw "CLOUDFLARE_API_TOKEN env var not set. Create a scoped token at https://dash.cloudflare.com/profile/api-tokens"
+}
+
+$headers = @{
+    Authorization  = "Bearer $env:CLOUDFLARE_API_TOKEN"
+    'Content-Type' = 'application/json'
+}
+$base = 'https://api.cloudflare.com/client/v4'
+
+function Invoke-Cf {
+    param(
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][string]$Path,
+        [object]$Body
+    )
+    $args = @{
+        Method  = $Method
+        Uri     = "$base$Path"
+        Headers = $headers
+    }
+    if ($Body) {
+        $args.Body = ($Body | ConvertTo-Json -Depth 10 -Compress)
+    }
+    Invoke-RestMethod @args
+}
+
+function Step {
+    param([string]$Message, [string]$Mode = 'INFO')
+    $colour = switch ($Mode) {
+        'WOULD'   { 'Yellow' }
+        'APPLIED' { 'Green' }
+        'SKIP'    { 'DarkGray' }
+        default   { 'Cyan' }
+    }
+    Write-Host "[$Mode] $Message" -ForegroundColor $colour
+}
+
+# ---------------------------------------------------------------------------
+# 0. Look up zone
+# ---------------------------------------------------------------------------
+
+Step "Looking up zone '$Zone'"
+$zoneResult = Invoke-Cf -Method GET -Path "/zones?name=$Zone"
+$zoneInfo = $zoneResult.result | Select-Object -First 1
+if (-not $zoneInfo) {
+    throw "Zone '$Zone' not found on this Cloudflare account. Is the API token scoped to it?"
+}
+$zoneId = $zoneInfo.id
+Step "Zone ID: $zoneId  (status: $($zoneInfo.status), nameservers: $($zoneInfo.name_servers -join ', '))"
+
+if ($zoneInfo.status -ne 'active') {
+    Write-Warning "Zone is not 'active' yet (status: $($zoneInfo.status)). Nameservers may still be propagating; you can continue but Cloudflare won't serve traffic until status flips to active."
+}
+
+# ---------------------------------------------------------------------------
+# 1. DNS records — apex, www, satisfactory.<apex>
+#    Proxied parking records pointing at TEST-NET-1.
+# ---------------------------------------------------------------------------
+
+$existingRecords = (Invoke-Cf -Method GET -Path "/zones/$zoneId/dns_records?per_page=100").result
+
+$desiredRecords = @(
+    @{ type = 'A'; name = $Zone;                      content = $PlaceholderIp; proxied = $true; comment = 'Apex parking — redirect rule attached' },
+    @{ type = 'A'; name = "www.$Zone";                content = $PlaceholderIp; proxied = $true; comment = 'www → apex via redirect rule' },
+    @{ type = 'A'; name = "satisfactory.$Zone";       content = $PlaceholderIp; proxied = $true; comment = 'Placeholder — host convention per ADR-0020. App not yet deployed.' }
+)
+
+foreach ($desired in $desiredRecords) {
+    $existing = $existingRecords | Where-Object { $_.type -eq $desired.type -and $_.name -eq $desired.name }
+    if ($existing) {
+        if ($existing.content -eq $desired.content -and $existing.proxied -eq $desired.proxied) {
+            Step "$($desired.name) ($($desired.type)) already correct — skip" 'SKIP'
+            continue
+        }
+        if ($Apply) {
+            Invoke-Cf -Method PUT -Path "/zones/$zoneId/dns_records/$($existing.id)" -Body $desired | Out-Null
+            Step "$($desired.name) ($($desired.type)) → updated" 'APPLIED'
+        } else {
+            Step "$($desired.name) ($($desired.type)) → would UPDATE to $($desired.content) (proxied=$($desired.proxied))" 'WOULD'
+        }
+    } else {
+        if ($Apply) {
+            Invoke-Cf -Method POST -Path "/zones/$zoneId/dns_records" -Body $desired | Out-Null
+            Step "$($desired.name) ($($desired.type)) → created" 'APPLIED'
+        } else {
+            Step "$($desired.name) ($($desired.type)) → would CREATE pointing at $($desired.content) (proxied=$($desired.proxied))" 'WOULD'
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 2. Single Redirect rule: apex + www → RedirectTarget
+#    Uses the http_request_dynamic_redirect phase ruleset (Cloudflare's
+#    modern "Single Redirects" feature). Falls back to creating the ruleset
+#    if it doesn't exist yet.
+# ---------------------------------------------------------------------------
+
+$ruleDescription = 'Apex + www → GitHub repo (until app hosted)'
+$ruleExpression  = "(http.host eq `"$Zone`") or (http.host eq `"www.$Zone`")"
+$ruleAction = @{
+    action            = 'redirect'
+    action_parameters = @{
+        from_value = @{
+            status_code           = 301
+            target_url            = @{ value = $RedirectTarget }
+            preserve_query_string = $false
+        }
+    }
+    expression  = $ruleExpression
+    description = $ruleDescription
+    enabled     = $true
+}
+
+# Get the entrypoint ruleset for the redirect phase. 404 means "not created yet".
+try {
+    $entrypoint = Invoke-Cf -Method GET -Path "/zones/$zoneId/rulesets/phases/http_request_dynamic_redirect/entrypoint"
+    $existingRule = $entrypoint.result.rules | Where-Object { $_.description -eq $ruleDescription }
+} catch {
+    if ($_.Exception.Response.StatusCode -eq 404) {
+        $entrypoint = $null
+        $existingRule = $null
+    } else { throw }
+}
+
+if ($existingRule) {
+    Step "Redirect rule already present — skip (rule id $($existingRule.id))" 'SKIP'
+} else {
+    if ($Apply) {
+        if ($entrypoint) {
+            # Update existing ruleset — append our rule.
+            $rules = @($entrypoint.result.rules) + $ruleAction
+            Invoke-Cf -Method PUT -Path "/zones/$zoneId/rulesets/$($entrypoint.result.id)" -Body @{ rules = $rules } | Out-Null
+        } else {
+            # Create entrypoint ruleset with our rule.
+            $body = @{
+                name  = 'default'
+                kind  = 'zone'
+                phase = 'http_request_dynamic_redirect'
+                rules = @($ruleAction)
+            }
+            Invoke-Cf -Method POST -Path "/zones/$zoneId/rulesets" -Body $body | Out-Null
+        }
+        Step "Redirect rule → created (apex + www → $RedirectTarget, 301)" 'APPLIED'
+    } else {
+        Step "Redirect rule → would CREATE: apex + www → $RedirectTarget (301)" 'WOULD'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 3. Zone settings: Always-Use-HTTPS, Minimum TLS 1.2
+# ---------------------------------------------------------------------------
+
+$desiredSettings = @(
+    @{ id = 'always_use_https'; value = 'on';  label = "Always-Use-HTTPS = on" },
+    @{ id = 'min_tls_version';  value = '1.2'; label = "Minimum TLS = 1.2" }
+)
+
+foreach ($s in $desiredSettings) {
+    $current = (Invoke-Cf -Method GET -Path "/zones/$zoneId/settings/$($s.id)").result.value
+    if ($current -eq $s.value) {
+        Step "$($s.label) — already set" 'SKIP'
+        continue
+    }
+    if ($Apply) {
+        Invoke-Cf -Method PATCH -Path "/zones/$zoneId/settings/$($s.id)" -Body @{ value = $s.value } | Out-Null
+        Step "$($s.label) — applied (was: $current)" 'APPLIED'
+    } else {
+        Step "$($s.label) — would SET (currently: $current)" 'WOULD'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+if (-not $Apply) {
+    Write-Host ""
+    Write-Host "Dry run complete. Re-run with -Apply to mutate Cloudflare." -ForegroundColor Yellow
+} else {
+    Write-Host ""
+    Write-Host "Done. Verify with:" -ForegroundColor Green
+    Write-Host "  curl -sI https://$Zone        # expect 301 -> $RedirectTarget"
+    Write-Host "  curl -sI https://www.$Zone    # expect 301 -> $RedirectTarget"
+    Write-Host "  dig +short $Zone              # expect Cloudflare IPs (orange-cloud proxied)"
+}


### PR DESCRIPTION
Prep work for the [rebrand milestone](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/15) — gives Chris a ready-to-run Cloudflare setup script without me actually running it (per his \"prepare scripts but stop short\" direction). Touches issues #156 and #164.

## Contents

- **`tools/cloudflare/Setup-Dns.ps1`** — idempotent PowerShell script. Dry-run by default; pass `-Apply` to mutate Cloudflare. Heavy comments explain every step.
- **`tools/cloudflare/README.md`** — runbook: API token scopes, dry-run/apply sequence, verification commands, and an \"explicitly out of scope\" section.

## What the script does

1. Looks up the zone for `erp-for-factory.games` on the authenticated account.
2. Creates three proxied `A` records (apex, `www`, `satisfactory.<apex>`) pointing at `192.0.2.1` (TEST-NET-1). Cloudflare proxies, the IP never receives traffic, the redirect rule fires at the edge.
3. Adds a Single Redirect rule (modern `http_request_dynamic_redirect` phase): apex + www → the GitHub repo with status 301.
4. Sets `Always-Use-HTTPS = on` and `Minimum TLS = 1.2` on the zone.

`satisfactory.<apex>` is reserved with a placeholder record only — no redirect rule yet. Locks in the [ADR-0020](docs/adr/0020-rebrand-to-erp-for-factory-games.md) host convention without serving anything until the app is deployed.

## Deliberate non-goals

- **App hosting** — out of scope until the rebrand milestone closes.
- **DNSSEC, CAA records, per-game subdomains beyond satisfactory** — listed as follow-ups in the README.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] PowerShell parses cleanly (`pwsh -NoProfile -File tools/cloudflare/Setup-Dns.ps1 -?` should show the help block).
- [ ] No execution against real Cloudflare API as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)