### PR TITLE
docs(readme): refresh repobeats hash post repo rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ or the wiki [Roadmap](https://github.com/ChrisonSimtian/ErpForFactoryGames/wiki/
 
 ## Fancy Charts
 
-![Alt](https://repobeats.axiom.co/api/embed/b5196b0f26128bfafc0dc68fcacd78d12882a641.svg "Repobeats analytics image")
+![Alt](https://repobeats.axiom.co/api/embed/0663f7324cf95e6bb97a97f26a463dc21be47b49.svg "Repobeats analytics image")
 
 ## Run it
 


### PR DESCRIPTION
The Repobeats embed URL is keyed on a per-repo identifier. After the rename from \`ERP.Satisfactory\` → \`ErpForFactoryGames\`, the old hash points at the now-redirected (empty) namespace, so the analytics image stops updating.

New hash supplied from the project's Repobeats dashboard.

## Diff

\`README.md:60\` — one URL hash swap, no other changes.

## Out of scope

- Restoring local main now: I'll switch back and pop the WIP stash (NUKE→Fallout migration) once this PR is opened, so your in-progress work is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)