### PR TITLE
build: migrate from private Nuke.* fork to Fallout.* on nuget.org

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -48,7 +48,7 @@
         "Quiet"
       ]
     },
-    "NukeBuild": {
+    "FalloutBuild": {
       "properties": {
         "Continue": {
           "type": "boolean",
@@ -124,7 +124,7 @@
       }
     },
     {
-      "$ref": "#/definitions/NukeBuild"
+      "$ref": "#/definitions/FalloutBuild"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,16 @@ dotnet build ErpForFactoryGames.slnx
 dotnet run --project src/AppHost
 ```
 
-ERP consumes `SatisfactorySaveNet` *and* the `Nuke.*` build packages via
-`PackageReference` from the `ChrisonSimtian` GitHub Packages feed — see
-`nuget.config` (Nuke is dogfooded from [ChrisonSimtian/nuke](https://github.com/ChrisonSimtian/nuke)).
-GitHub Packages NuGet *always* requires auth (even for public packages),
-so set `GITHUB_TOKEN` before restoring. Your `gh` CLI token needs the
-`read:packages` scope: one-time `gh auth refresh -h github.com -s read:packages`.
-CI does the same thing via `secrets.GITHUB_TOKEN` (the workflow grants
-`packages: read`).
+ERP consumes `SatisfactorySaveNet` from the `ChrisonSimtian` GitHub Packages
+feed — see `nuget.config`. GitHub Packages NuGet *always* requires auth (even
+for public packages), so set `GITHUB_TOKEN` before restoring. Your `gh` CLI
+token needs the `read:packages` scope: one-time
+`gh auth refresh -h github.com -s read:packages`. CI does the same thing via
+`secrets.GITHUB_TOKEN` (the workflow grants `packages: read`).
+
+The build system itself runs on [Fallout](https://github.com/ChrisonSimtian/Fallout)
+(`Fallout.Common`, the hard-fork successor to NUKE) and is pulled from
+nuget.org — no auth needed for that. See [ADR-0021](docs/adr/0021-migrate-from-nuke-fork-to-fallout.md).
 
 The repo has two submodules under `vendor/` (`SatisfactorySaveNet`, `CUE4Parse`),
 both marked `update = none` + `ignore = all` in `.gitmodules`. They are *not*

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,11 +1,11 @@
-using Nuke.Common;
-using Nuke.Common.CI.GitHubActions;
-using Nuke.Common.IO;
-using Nuke.Common.ProjectModel;
-using Nuke.Common.Tooling;
-using Nuke.Common.Tools.DotNet;
+using Fallout.Common;
+using Fallout.Common.CI.GitHubActions;
+using Fallout.Common.IO;
+using Fallout.Common.ProjectModel;
+using Fallout.Common.Tooling;
+using Fallout.Common.Tools.DotNet;
 using Serilog;
-using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using static Fallout.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName
 
@@ -20,7 +20,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 /// CI invokes the same entry points (see .github/workflows/ci.yml). Logic
 /// lives here in C# rather than YAML so it runs identically locally.
 /// </summary>
-class Build : NukeBuild
+class Build : FalloutBuild
 {
     public static int Main() => Execute<Build>(x => x.Compile);
 

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel;
-using Nuke.Common.Tooling;
+using Fallout.Common.Tooling;
 
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Resolved from ChrisonSimtian/nuke via GitHub Packages (see nuget.config + #151). -->
-    <PackageReference Include="Nuke.Common" Version="10.2.1" />
+    <!-- Fallout is the hard-fork successor to NUKE; published to nuget.org (ADR-0021). -->
+    <PackageReference Include="Fallout.Common" Version="10.2.15" />
   </ItemGroup>
 
 </Project>

--- a/docs/adr/0021-migrate-from-nuke-fork-to-fallout.md
+++ b/docs/adr/0021-migrate-from-nuke-fork-to-fallout.md
@@ -1,0 +1,76 @@
+# 0021. Migrate build system from private Nuke.* fork to Fallout.* on nuget.org
+
+- Status: Accepted
+- Date: 2026-05-21
+- Deciders: Chris
+
+## Context
+
+The build pipeline (`build/_build.csproj`, `build/Build.cs`) was running on a
+fork of NUKE that Chris maintained at
+[ChrisonSimtian/nuke](https://github.com/ChrisonSimtian/nuke), with the
+resulting `Nuke.*` packages published to a private GitHub Packages feed on the
+`ChrisonSimtian` org. This was always a temporary arrangement — see #151 — and
+imposed two costs on the repo:
+
+- Every `dotnet restore` (locally and in CI) required `GITHUB_TOKEN` with the
+  `read:packages` scope even though the packages are public, because GitHub
+  Packages NuGet always requires authentication.
+- The fork's identity was a fork: the README still said NUKE, the namespace
+  was still `Nuke.*`, and the relationship to upstream was ambiguous.
+
+The fork has now been rebranded as a hard-fork successor named **Fallout** at
+[ChrisonSimtian/Fallout](https://github.com/ChrisonSimtian/Fallout). The
+rebrand is documented in the project's
+[`docs/rebrand-plan.md`](https://github.com/ChrisonSimtian/Fallout/blob/main/docs/rebrand-plan.md)
+and follows a strict 1:1 namespace mapping (every `Nuke.X.Y.Z` becomes
+`Fallout.X.Y.Z`, `NukeBuild` becomes `FalloutBuild`). The first `Fallout.*`
+release on nuget.org is `Fallout.Common 10.2.15` (published 2026-05-21).
+
+## Decision
+
+Adopt the public `Fallout.*` packages from nuget.org as ERP for Factory Games'
+build dependency, and stop consuming the private `Nuke.*` packages from
+GitHub Packages.
+
+Concretely:
+
+- `build/_build.csproj` references `Fallout.Common 10.2.15`.
+- `build/Build.cs` and `build/Configuration.cs` use `Fallout.*` namespaces and
+  derive from `FalloutBuild`.
+- `nuget.config` drops the `Nuke.*` package-source mapping. The
+  `github-chrisonsimtian` feed stays — it still serves
+  [SatisfactorySaveNet](0014-pure-csharp-save-ingestion-via-fork.md).
+- MSBuild props that the source generator looks for (`NukeRootDirectory`,
+  `NukeScriptDirectory`, `NukeTelemetryVersion`) keep their `Nuke*` names —
+  the rebrand plan does not rename MSBuild props, only namespaces and
+  assemblies. Fallout's own `_build.csproj` continues to use them.
+
+## Alternatives considered
+
+- **Stay on `Nuke.*` shim packages.** Fallout publishes a `Nuke.*` type-forwarding
+  bridge on its GitHub Packages feed so existing consumers can upgrade without
+  touching `using` directives. Rejected: we'd still pay the `GITHUB_TOKEN`
+  cost for what is now publicly available on nuget.org, and the bridge is
+  explicitly transitional (sunset 24 months after `R0`).
+- **Pin to the old fork's last `Nuke.*` release.** Locks us out of every fix
+  going forward — the fork's `main` is now Fallout's.
+
+## Consequences
+
+What got easier:
+
+- `dotnet restore` for the build project no longer requires a token. The
+  remaining `GITHUB_TOKEN` requirement covers only `SatisfactorySaveNet` and
+  can be removed entirely once that fork also publishes to nuget.org.
+- The relationship between our build system and its upstream is now legible:
+  Fallout is a named project on nuget.org, not a fork of a fork.
+
+What follow-up is implied:
+
+- File migration feedback on the Fallout repo so other consumers have a
+  documented path (the migration steps we used are short enough to be useful
+  as a recipe). Issue or discussion — to be decided when filing.
+- When `SatisfactorySaveNet` reaches nuget.org, retire the
+  `github-chrisonsimtian` feed and the entire `GITHUB_TOKEN` plumbing in CI
+  and the local dev README.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0018](0018-persistence-stack.md) | Persistence stack: EF Core with SQLite default, Postgres opt-in | Accepted |
 | [0019](0019-tickerq-background-scheduler.md) | TickerQ as the background-job scheduler | Accepted |
 | [0020](0020-rebrand-to-erp-for-factory-games.md) | Rebrand to ERP for Factory Games | Accepted |
+| [0021](0021-migrate-from-nuke-fork-to-fallout.md) | Migrate build system from private Nuke.* fork to Fallout.* on nuget.org | Accepted |

--- a/nuget.config
+++ b/nuget.config
@@ -10,6 +10,9 @@
       enough.
         CI:   ${{ secrets.GITHUB_TOKEN }} → exposed as GITHUB_TOKEN env (workflow grants packages: read)
         Local: export GITHUB_TOKEN=$(gh auth token)    (one-time per shell, gh PAT must have read:packages)
+
+      Fallout (the hard-fork successor to NUKE) is now on nuget.org, so the
+      Nuke.* mapping was dropped here — see ADR-0021.
     -->
     <add key="github-chrisonsimtian" value="https://nuget.pkg.github.com/ChrisonSimtian/index.json" protocolVersion="3" />
   </packageSources>
@@ -24,17 +27,15 @@
   <!--
     Route the fork-published package families to the GitHub Packages feed:
       • SatisfactorySaveNet (+ Abstracts) — ChrisonSimtian/SatisfactorySaveNet
-      • Nuke.*                            — ChrisonSimtian/nuke (dogfooding the fork, see #151)
-    Everything else to nuget.org. Without explicit mappings, a user-level
-    packageSourceMapping with a `*` fallback to nuget.org silently captures
-    these and NuGet reports "Versions from github-chrisonsimtian were not
-    considered".
+    Everything else to nuget.org (including Fallout.* — ADR-0021). Without
+    explicit mappings, a user-level packageSourceMapping with a `*` fallback
+    to nuget.org silently captures these and NuGet reports "Versions from
+    github-chrisonsimtian were not considered".
   -->
   <packageSourceMapping>
     <packageSource key="github-chrisonsimtian">
       <package pattern="SatisfactorySaveNet" />
       <package pattern="SatisfactorySaveNet.*" />
-      <package pattern="Nuke.*" />
     </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />


### PR DESCRIPTION
## Summary

- Swaps `Nuke.Common 10.2.1` (private GH Packages feed) for `Fallout.Common 10.2.15` (nuget.org). Strict 1:1 namespace rename per Fallout's [rebrand plan](https://github.com/ChrisonSimtian/Fallout/blob/main/docs/rebrand-plan.md): `using Nuke.X.Y.Z` → `using Fallout.X.Y.Z`, `NukeBuild` → `FalloutBuild`.
- Drops the `Nuke.*` mapping from `nuget.config`. The `github-chrisonsimtian` feed stays for SatisfactorySaveNet.
- MSBuild props (`NukeRootDirectory`, `NukeScriptDirectory`, `NukeTelemetryVersion`) keep their `Nuke*` names — the rebrand covers namespaces + assemblies only, and Fallout's own `_build.csproj` still uses them.
- New [ADR-0021](docs/adr/0021-migrate-from-nuke-fork-to-fallout.md) records the decision. CLAUDE.md updated to point at the new setup.

Feedback filed back to the Fallout project as a Show-and-tell discussion: https://github.com/ChrisonSimtian/Fallout/discussions/64

> ⚠️ ADR number conflicts with the in-flight CoI ADR on `adr/0021-captain-of-industry-support`. That branch already includes a commit renumbering CoI 0021 → 0022, so this should land cleanly regardless of merge order.

## Test plan

- [x] `./build.ps1 Compile` (local, Windows) — Restore + Compile green
- [x] `./build.ps1 TestNoUi` (local, Windows) — Restore + Compile + Tests green (3:26)
- [ ] CI lint + build-and-test + migration-drift + postgres-smoke green
- [ ] Verify CI no longer needs `GITHUB_TOKEN` for the build feed (only SatisfactorySaveNet still uses it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)