### PR TITLE
feat: GitHub Pages placeholder + Cloudflare DNS workflow

### DIFF
--- a/.github/workflows/cloudflare-dns.yml
+++ b/.github/workflows/cloudflare-dns.yml
@@ -1,0 +1,53 @@
+name: Cloudflare DNS setup
+
+# Manual-only for now. Run from the Actions tab to dry-run (apply=false) or
+# apply (apply=true) the DNS config in `tools/cloudflare/Setup-Dns.ps1`.
+#
+# Wire `on: push` once the DNS config genuinely changes infrequently and we
+# trust the script to be safe under automation — the reconciliation deletes
+# records under the managed names that don't match desired state, so we want
+# human approval per run for now.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply changes (false = dry-run only)'
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-dns
+  cancel-in-progress: false   # serialise — never cancel an in-flight apply.
+
+jobs:
+  setup:
+    name: Setup-Dns.ps1 (apply=${{ inputs.apply }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify token is present
+        shell: bash
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN secret is not set on this repo."
+            exit 1
+          fi
+
+      - name: Run Setup-Dns.ps1
+        shell: pwsh
+        run: |
+          $scriptArgs = @{}
+          if ('${{ inputs.apply }}' -eq 'true') { $scriptArgs['Apply'] = $true }
+          ./tools/cloudflare/Setup-Dns.ps1 @scriptArgs

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+erp-for-factory.games

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ERP for Factory Games</title>
+    <meta name="description" content="An ERP-style production planner for factory games — starting with Satisfactory.">
+    <meta name="theme-color" content="#0b0d10">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='10' fill='%23f7a40b'/%3E%3Cpath d='M12 18h40v8H22v8h22v8H22v8H12z' fill='%230b0d10'/%3E%3C/svg%3E">
+
+    <meta property="og:title" content="ERP for Factory Games">
+    <meta property="og:description" content="ERP-style production planner for factory games — starting with Satisfactory.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://erp-for-factory.games">
+
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0b0d10;
+            --fg: #e8e6e3;
+            --muted: #8a8682;
+            --accent: #f7a40b;
+            --panel: #15181d;
+            --border: #2a2e35;
+        }
+
+        * { box-sizing: border-box; }
+
+        html, body {
+            margin: 0;
+            padding: 0;
+            background: var(--bg);
+            color: var(--fg);
+            font: 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        }
+
+        main {
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 64px 24px 96px;
+        }
+
+        h1 {
+            font-size: clamp(2rem, 4vw, 2.75rem);
+            line-height: 1.15;
+            margin: 0 0 8px;
+            letter-spacing: -0.01em;
+        }
+
+        h1 .accent { color: var(--accent); }
+
+        .tagline {
+            color: var(--muted);
+            font-size: 1.125rem;
+            margin: 0 0 40px;
+        }
+
+        h2 {
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+            margin: 40px 0 16px;
+        }
+
+        p { margin: 0 0 16px; }
+
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.15s;
+        }
+
+        a:hover { border-bottom-color: var(--accent); }
+
+        .games {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 12px;
+        }
+
+        .games li {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 14px 16px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .games .name { font-weight: 500; }
+
+        .games .status {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 3px 8px;
+            border-radius: 4px;
+            background: var(--border);
+            color: var(--muted);
+        }
+
+        .games .status.live {
+            background: rgba(247, 164, 11, 0.12);
+            color: var(--accent);
+        }
+
+        .links {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px 24px;
+        }
+
+        footer {
+            margin-top: 64px;
+            padding-top: 24px;
+            border-top: 1px solid var(--border);
+            color: var(--muted);
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <h1>ERP <span class="accent">for Factory Games</span></h1>
+        <p class="tagline">
+            An ERP-style production planner for factory games — plan factories
+            from the inputs you have to the outputs you need.
+        </p>
+
+        <p>
+            The app isn't deployed here yet. This page is a placeholder; the
+            project is being built in the open.
+        </p>
+
+        <h2>Supported games</h2>
+        <ul class="games">
+            <li>
+                <span class="name">Satisfactory</span>
+                <span class="status live">In development</span>
+            </li>
+            <li>
+                <span class="name">Captain of Industry</span>
+                <span class="status">Planned</span>
+            </li>
+            <li>
+                <span class="name">Dyson Sphere Program</span>
+                <span class="status">Planned</span>
+            </li>
+        </ul>
+
+        <h2>Links</h2>
+        <ul class="links">
+            <li><a href="https://github.com/ChrisonSimtian/ErpForFactoryGames">GitHub repo</a></li>
+            <li><a href="https://github.com/ChrisonSimtian/ErpForFactoryGames/wiki">Wiki</a></li>
+            <li><a href="https://github.com/sponsors/ChrisonSimtian">Sponsor</a></li>
+            <li><a href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/costs.md">Where the money goes</a></li>
+        </ul>
+
+        <footer>
+            Built by <a href="https://github.com/ChrisonSimtian">Chris Simon</a> · MIT licensed.
+        </footer>
+    </main>
+</body>
+</html>

--- a/tools/cloudflare/README.md
+++ b/tools/cloudflare/README.md
@@ -1,65 +1,83 @@
 # Cloudflare setup scripts
 
-One-time DNS and redirect setup for `erp-for-factory.games`.
+DNS setup for `erp-for-factory.games`. Idempotent + dry-run by default.
 
 ## Scripts
 
 | Script | Purpose |
 |--------|---------|
-| [`Setup-Dns.ps1`](Setup-Dns.ps1) | Configures DNS records, the apex/www → GitHub redirect rule, and TLS zone settings. Idempotent + dry-run by default. |
+| [`Setup-Dns.ps1`](Setup-Dns.ps1) | Configures DNS for the apex + `www` to serve from GitHub Pages, plus zone-level TLS settings. |
 
-## One-time setup
+## How to run
 
-1. **Create a scoped API token** at <https://dash.cloudflare.com/profile/api-tokens>.
-   Permissions:
-   - `Zone.Zone:Read`
-   - `Zone.DNS:Edit`
-   - `Zone.Zone Settings:Edit`
-   - `Zone.Rulesets:Edit` (for Single Redirects)
+Two paths:
 
-   Restrict the token to the `erp-for-factory.games` zone only.
+### Option A — CI (preferred)
 
-2. **Dry-run** the setup script to see what would change:
+Trigger the `Cloudflare DNS setup` workflow manually:
+
+1. GitHub → **Actions** tab → **Cloudflare DNS setup** → **Run workflow**.
+2. Leave `apply` = `false` (default) → review the diff in the run log.
+3. Re-run with `apply` = `true` once the dry-run looks right.
+
+Token is read from the `CLOUDFLARE_API_TOKEN` repo secret. No local setup needed.
+
+### Option B — Local
+
+1. Create a Cloudflare API token (see "Token scopes" below), set it as
+   `CLOUDFLARE_API_TOKEN`:
 
    ```powershell
    $env:CLOUDFLARE_API_TOKEN = '...'
+   ```
+
+2. Dry-run:
+
+   ```powershell
    pwsh tools/cloudflare/Setup-Dns.ps1
    ```
 
-3. **Apply** when satisfied:
+3. Apply when satisfied:
 
    ```powershell
    pwsh tools/cloudflare/Setup-Dns.ps1 -Apply
    ```
 
-4. **Verify**:
+## Token scopes
 
-   ```powershell
-   curl.exe -sI https://erp-for-factory.games        # 301 -> GitHub repo
-   curl.exe -sI https://www.erp-for-factory.games    # 301 -> GitHub repo
-   ```
+When creating the token at <https://dash.cloudflare.com/profile/api-tokens>:
 
-## What it does
+- `Zone.Zone:Read`
+- `Zone.DNS:Edit`
+- `Zone.Zone Settings:Edit`
 
-- Creates proxied `A` records on `erp-for-factory.games`, `www.erp-for-factory.games`,
-  and `satisfactory.erp-for-factory.games` pointing at `192.0.2.1` (TEST-NET-1).
-  The redirect fires at the Cloudflare edge, so traffic never reaches the IP.
-- Creates a Single Redirect rule: apex + www → the GitHub repo (until the app
-  has a hosted home).
-- `satisfactory.erp-for-factory.games` is reserved with a proxied placeholder
-  record only — no redirect rule yet. Locks in the host convention from
-  [ADR-0020](../../docs/adr/0020-rebrand-to-erp-for-factory-games.md) without
-  serving anything until the app is deployed.
-- Sets `Always-Use-HTTPS = on` and `Minimum TLS = 1.2` on the zone.
+Zone resource: restrict to `erp-for-factory.games` only.
 
-## What it deliberately does NOT do
+## What the script does
 
-- **Deploy the app.** Hosting choice (GitHub Pages / Azure SWA / Cloudflare Pages
-  / Fly.io / Proxmox homelab) is out of scope until the rebrand milestone is
-  closed and ADR-0020's "follow-up" issues are picked up.
-- **Configure DNSSEC.** Worth doing once nameservers are stable; add as a
-  follow-up.
-- **Add per-game subdomains beyond `satisfactory.*`.** Done case-by-case as
-  each game lands.
-- **CAA records.** Cloudflare provides certificates via Universal SSL — adding
-  CAA pinned to Cloudflare's issuers is a hardening step for later.
+After it applies, `erp-for-factory.games` serves the GitHub Pages site sourced
+from this repo's [`docs/`](../../docs/) folder.
+
+- **Apex** (`erp-for-factory.games`) — four A records pointing at GitHub Pages'
+  published IPs (`185.199.108.153`, `.109.153`, `.110.153`, `.111.153`).
+  Grey-cloud (proxy off) so GitHub Pages can issue/renew its Let's Encrypt
+  certificate without the Cloudflare proxy interfering with the HTTP-01
+  challenge.
+- **www** — `CNAME` → `chrisonsimtian.github.io`. Same grey-cloud reasoning.
+- **Records on apex/www that don't match the desired state get deleted** —
+  the script reconciles, not just appends.
+- **Zone-level**: `Always-Use-HTTPS = on`, `Minimum TLS = 1.2`.
+
+## What the script deliberately does NOT do
+
+- **Create the GitHub Pages site itself.** Repo Settings → Pages → set source
+  to `main` branch `/docs` folder + custom domain `erp-for-factory.games`.
+  One-time, two clicks.
+- **Add per-game subdomains** (e.g. `satisfactory.erp-for-factory.games`).
+  Those get added when the corresponding app ships, per the host convention in
+  [ADR-0020](../../docs/adr/0020-rebrand-to-erp-for-factory-games.md).
+- **DNSSEC.** Worth doing once nameservers are stable; add as a follow-up.
+- **CAA records** pinning Let's Encrypt as the issuer. Hardening step for later.
+- **Turn the Cloudflare proxy back on.** Once GH Pages has a stable cert,
+  flipping to orange-cloud gives CDN + WAF — known dance, do it manually when
+  ready.

--- a/tools/cloudflare/Setup-Dns.ps1
+++ b/tools/cloudflare/Setup-Dns.ps1
@@ -1,75 +1,87 @@
 <#
 .SYNOPSIS
-    Configure Cloudflare DNS and redirects for erp-for-factory.games.
+    Configure Cloudflare DNS for erp-for-factory.games to serve from GitHub Pages.
 
 .DESCRIPTION
-    Idempotent setup script for the project's apex domain on Cloudflare. Sets up:
+    Idempotent setup script for the project's apex domain on Cloudflare. After
+    this runs, https://erp-for-factory.games and https://www.erp-for-factory.games
+    serve the GitHub Pages site sourced from this repo's `/docs/` folder.
 
-      1. A "parking" A record on apex + www, proxied through Cloudflare so a
-         redirect rule has DNS to attach to. Points at 192.0.2.1 (TEST-NET-1) —
-         the redirect fires at the Cloudflare edge, traffic never reaches the IP.
-      2. A "placeholder" A record on satisfactory.<apex>, also proxied.
-         Reserves the host convention from ADR-0020 without serving anything yet.
-      3. A Single Redirect rule: apex + www → the GitHub repo (until the app
-         has a hosted home).
-      4. Zone settings: Always-Use-HTTPS = on, Minimum TLS = 1.2.
+    DNS topology:
+      - Apex (erp-for-factory.games) — four A records pointing at GitHub Pages'
+        published IPs. Grey-cloud (proxy off) so GitHub Pages handles TLS via
+        Let's Encrypt directly. Re-enable orange-cloud later if you want
+        Cloudflare's CDN/WAF in front.
+      - www — CNAME to <user>.github.io (same grey-cloud reasoning).
+      - Per-game subdomains (e.g. satisfactory.erp-for-factory.games) are NOT
+        created here — they go in when their app is actually deployed. The host
+        convention is documented in ADR-0020.
+
+    Zone settings:
+      - Always-Use-HTTPS = on
+      - Minimum TLS = 1.2
 
     Defaults to **dry-run**. Pass -Apply to actually mutate Cloudflare.
 
 .PARAMETER Zone
     Domain registered on Cloudflare. Default: erp-for-factory.games.
 
-.PARAMETER RedirectTarget
-    URL the apex (and www) redirects to until the app has a hosted home.
-    Default: https://github.com/ChrisonSimtian/ErpForFactoryGames.
+.PARAMETER GhPagesHost
+    Hostname for the www CNAME — your GitHub Pages canonical host
+    (`<user>.github.io`). Default: chrisonsimtian.github.io.
 
 .PARAMETER Apply
     Actually call the Cloudflare API. Without this, the script only prints what
     *would* be done. Always run once without -Apply first.
-
-.PARAMETER PlaceholderIp
-    IPv4 address used for the proxied parking records. TEST-NET-1 (192.0.2.1)
-    is reserved for documentation and won't route — perfect for "DNS exists so
-    Cloudflare proxies, but nothing's actually hosted there yet".
 
 .NOTES
     Requires the CLOUDFLARE_API_TOKEN env var with permissions:
       - Zone.Zone:Read
       - Zone.DNS:Edit
       - Zone.Zone Settings:Edit
-      - Zone.Page Rules / Redirect Rules:Edit (Account level: Bulk URL Redirects:Edit)
 
-    Create a scoped token at:
-      https://dash.cloudflare.com/profile/api-tokens
-      → "Create Token" → "Edit zone DNS" template → restrict to this zone.
+    In CI this comes from the repo secret of the same name (see
+    .github/workflows/cloudflare-dns.yml).
 
-    Re-running with -Apply is safe: every operation checks existing state first.
+    Re-running with -Apply is safe: every operation checks existing state first
+    and only creates/updates/deletes what's needed to converge on the desired
+    state. Records on apex / www that don't match the desired set are removed.
 
 .EXAMPLE
-    # 1. Dry run — see what would happen
+    # 1. Dry run locally — see what would happen
+    $env:CLOUDFLARE_API_TOKEN = '...'
     pwsh tools/cloudflare/Setup-Dns.ps1
 
-    # 2. Apply for real
-    $env:CLOUDFLARE_API_TOKEN = '...'
+    # 2. Apply
     pwsh tools/cloudflare/Setup-Dns.ps1 -Apply
+
+    # 3. CI: trigger the cloudflare-dns workflow manually with apply=true.
 #>
 
 [CmdletBinding()]
 param(
     [string]$Zone = 'erp-for-factory.games',
-    [string]$RedirectTarget = 'https://github.com/ChrisonSimtian/ErpForFactoryGames',
-    [switch]$Apply,
-    [string]$PlaceholderIp = '192.0.2.1'
+    [string]$GhPagesHost = 'chrisonsimtian.github.io',
+    [switch]$Apply
 )
 
 $ErrorActionPreference = 'Stop'
+
+# GitHub Pages' published IPv4s for apex domains.
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
+$GhPagesIps = @(
+    '185.199.108.153',
+    '185.199.109.153',
+    '185.199.110.153',
+    '185.199.111.153'
+)
 
 # ---------------------------------------------------------------------------
 # Auth + helpers
 # ---------------------------------------------------------------------------
 
 if (-not $env:CLOUDFLARE_API_TOKEN) {
-    throw "CLOUDFLARE_API_TOKEN env var not set. Create a scoped token at https://dash.cloudflare.com/profile/api-tokens"
+    throw "CLOUDFLARE_API_TOKEN env var not set. In CI this comes from secrets.CLOUDFLARE_API_TOKEN; locally create a scoped token at https://dash.cloudflare.com/profile/api-tokens"
 }
 
 $headers = @{
@@ -84,15 +96,15 @@ function Invoke-Cf {
         [Parameter(Mandatory)][string]$Path,
         [object]$Body
     )
-    $args = @{
+    $invokeArgs = @{
         Method  = $Method
         Uri     = "$base$Path"
         Headers = $headers
     }
     if ($Body) {
-        $args.Body = ($Body | ConvertTo-Json -Depth 10 -Compress)
+        $invokeArgs.Body = ($Body | ConvertTo-Json -Depth 10 -Compress)
     }
-    Invoke-RestMethod @args
+    Invoke-RestMethod @invokeArgs
 }
 
 function Step {
@@ -101,6 +113,7 @@ function Step {
         'WOULD'   { 'Yellow' }
         'APPLIED' { 'Green' }
         'SKIP'    { 'DarkGray' }
+        'DELETE'  { 'Magenta' }
         default   { 'Cyan' }
     }
     Write-Host "[$Mode] $Message" -ForegroundColor $colour
@@ -117,103 +130,76 @@ if (-not $zoneInfo) {
     throw "Zone '$Zone' not found on this Cloudflare account. Is the API token scoped to it?"
 }
 $zoneId = $zoneInfo.id
-Step "Zone ID: $zoneId  (status: $($zoneInfo.status), nameservers: $($zoneInfo.name_servers -join ', '))"
+Step "Zone ID: $zoneId  (status: $($zoneInfo.status))"
 
 if ($zoneInfo.status -ne 'active') {
     Write-Warning "Zone is not 'active' yet (status: $($zoneInfo.status)). Nameservers may still be propagating; you can continue but Cloudflare won't serve traffic until status flips to active."
 }
 
 # ---------------------------------------------------------------------------
-# 1. DNS records — apex, www, satisfactory.<apex>
-#    Proxied parking records pointing at TEST-NET-1.
+# 1. Build desired DNS state
+#
+#    Apex: 4× A records pointing at GitHub Pages, grey-cloud (proxied=$false).
+#          Grey-cloud lets GH Pages issue/renew its own Let's Encrypt cert
+#          without the Cloudflare proxy interfering with the HTTP-01 challenge.
+#    www:  CNAME → <user>.github.io, also grey-cloud.
+#
+#    No satisfactory.<apex> record — that's added when the Satisfactory app
+#    actually ships (per ADR-0020's host convention).
+# ---------------------------------------------------------------------------
+
+$desired = @()
+foreach ($ip in $GhPagesIps) {
+    $desired += @{ type = 'A'; name = $Zone; content = $ip; proxied = $false; comment = 'GitHub Pages — apex' }
+}
+$desired += @{ type = 'CNAME'; name = "www.$Zone"; content = $GhPagesHost; proxied = $false; comment = 'GitHub Pages — www' }
+
+# Names we manage. Records under these names that don't match `$desired` get
+# removed (idempotency). Records under OTHER names are left alone.
+$managedNames = @($Zone, "www.$Zone")
+
+# ---------------------------------------------------------------------------
+# 2. Reconcile DNS records
 # ---------------------------------------------------------------------------
 
 $existingRecords = (Invoke-Cf -Method GET -Path "/zones/$zoneId/dns_records?per_page=100").result
 
-$desiredRecords = @(
-    @{ type = 'A'; name = $Zone;                      content = $PlaceholderIp; proxied = $true; comment = 'Apex parking — redirect rule attached' },
-    @{ type = 'A'; name = "www.$Zone";                content = $PlaceholderIp; proxied = $true; comment = 'www → apex via redirect rule' },
-    @{ type = 'A'; name = "satisfactory.$Zone";       content = $PlaceholderIp; proxied = $true; comment = 'Placeholder — host convention per ADR-0020. App not yet deployed.' }
-)
-
-foreach ($desired in $desiredRecords) {
-    $existing = $existingRecords | Where-Object { $_.type -eq $desired.type -and $_.name -eq $desired.name }
-    if ($existing) {
-        if ($existing.content -eq $desired.content -and $existing.proxied -eq $desired.proxied) {
-            Step "$($desired.name) ($($desired.type)) already correct — skip" 'SKIP'
-            continue
-        }
-        if ($Apply) {
-            Invoke-Cf -Method PUT -Path "/zones/$zoneId/dns_records/$($existing.id)" -Body $desired | Out-Null
-            Step "$($desired.name) ($($desired.type)) → updated" 'APPLIED'
-        } else {
-            Step "$($desired.name) ($($desired.type)) → would UPDATE to $($desired.content) (proxied=$($desired.proxied))" 'WOULD'
-        }
-    } else {
-        if ($Apply) {
-            Invoke-Cf -Method POST -Path "/zones/$zoneId/dns_records" -Body $desired | Out-Null
-            Step "$($desired.name) ($($desired.type)) → created" 'APPLIED'
-        } else {
-            Step "$($desired.name) ($($desired.type)) → would CREATE pointing at $($desired.content) (proxied=$($desired.proxied))" 'WOULD'
-        }
-    }
+function Test-RecordMatch {
+    param($Existing, $Desired)
+    return ($Existing.type -eq $Desired.type) `
+        -and ($Existing.name -eq $Desired.name) `
+        -and ($Existing.content -eq $Desired.content) `
+        -and ($Existing.proxied -eq $Desired.proxied)
 }
 
-# ---------------------------------------------------------------------------
-# 2. Single Redirect rule: apex + www → RedirectTarget
-#    Uses the http_request_dynamic_redirect phase ruleset (Cloudflare's
-#    modern "Single Redirects" feature). Falls back to creating the ruleset
-#    if it doesn't exist yet.
-# ---------------------------------------------------------------------------
+# 2a. Remove records under managed names that aren't in $desired.
+foreach ($existing in $existingRecords) {
+    if ($existing.name -notin $managedNames) { continue }
+    $stillWanted = $desired | Where-Object { Test-RecordMatch -Existing $existing -Desired $_ }
+    if ($stillWanted) { continue }
 
-$ruleDescription = 'Apex + www → GitHub repo (until app hosted)'
-$ruleExpression  = "(http.host eq `"$Zone`") or (http.host eq `"www.$Zone`")"
-$ruleAction = @{
-    action            = 'redirect'
-    action_parameters = @{
-        from_value = @{
-            status_code           = 301
-            target_url            = @{ value = $RedirectTarget }
-            preserve_query_string = $false
-        }
-    }
-    expression  = $ruleExpression
-    description = $ruleDescription
-    enabled     = $true
-}
-
-# Get the entrypoint ruleset for the redirect phase. 404 means "not created yet".
-try {
-    $entrypoint = Invoke-Cf -Method GET -Path "/zones/$zoneId/rulesets/phases/http_request_dynamic_redirect/entrypoint"
-    $existingRule = $entrypoint.result.rules | Where-Object { $_.description -eq $ruleDescription }
-} catch {
-    if ($_.Exception.Response.StatusCode -eq 404) {
-        $entrypoint = $null
-        $existingRule = $null
-    } else { throw }
-}
-
-if ($existingRule) {
-    Step "Redirect rule already present — skip (rule id $($existingRule.id))" 'SKIP'
-} else {
     if ($Apply) {
-        if ($entrypoint) {
-            # Update existing ruleset — append our rule.
-            $rules = @($entrypoint.result.rules) + $ruleAction
-            Invoke-Cf -Method PUT -Path "/zones/$zoneId/rulesets/$($entrypoint.result.id)" -Body @{ rules = $rules } | Out-Null
-        } else {
-            # Create entrypoint ruleset with our rule.
-            $body = @{
-                name  = 'default'
-                kind  = 'zone'
-                phase = 'http_request_dynamic_redirect'
-                rules = @($ruleAction)
-            }
-            Invoke-Cf -Method POST -Path "/zones/$zoneId/rulesets" -Body $body | Out-Null
-        }
-        Step "Redirect rule → created (apex + www → $RedirectTarget, 301)" 'APPLIED'
+        Invoke-Cf -Method DELETE -Path "/zones/$zoneId/dns_records/$($existing.id)" | Out-Null
+        Step "$($existing.name) ($($existing.type) → $($existing.content)) — deleted" 'DELETE'
     } else {
-        Step "Redirect rule → would CREATE: apex + www → $RedirectTarget (301)" 'WOULD'
+        Step "$($existing.name) ($($existing.type) → $($existing.content)) — would DELETE (proxied=$($existing.proxied))" 'WOULD'
+    }
+}
+
+# 2b. Create records in $desired that aren't already present.
+$existingRecords = (Invoke-Cf -Method GET -Path "/zones/$zoneId/dns_records?per_page=100").result
+foreach ($d in $desired) {
+    $alreadyThere = $existingRecords | Where-Object { Test-RecordMatch -Existing $_ -Desired $d }
+    if ($alreadyThere) {
+        Step "$($d.name) ($($d.type) → $($d.content)) — already correct" 'SKIP'
+        continue
+    }
+
+    if ($Apply) {
+        Invoke-Cf -Method POST -Path "/zones/$zoneId/dns_records" -Body $d | Out-Null
+        Step "$($d.name) ($($d.type) → $($d.content)) — created (proxied=$($d.proxied))" 'APPLIED'
+    } else {
+        Step "$($d.name) ($($d.type) → $($d.content)) — would CREATE (proxied=$($d.proxied))" 'WOULD'
     }
 }
 
@@ -249,8 +235,13 @@ if (-not $Apply) {
     Write-Host "Dry run complete. Re-run with -Apply to mutate Cloudflare." -ForegroundColor Yellow
 } else {
     Write-Host ""
-    Write-Host "Done. Verify with:" -ForegroundColor Green
-    Write-Host "  curl -sI https://$Zone        # expect 301 -> $RedirectTarget"
-    Write-Host "  curl -sI https://www.$Zone    # expect 301 -> $RedirectTarget"
-    Write-Host "  dig +short $Zone              # expect Cloudflare IPs (orange-cloud proxied)"
+    Write-Host "Done. Next steps:" -ForegroundColor Green
+    Write-Host "  1. In the GitHub repo: Settings → Pages → set Custom domain to '$Zone' (if not already)."
+    Write-Host "  2. Wait for the GH Pages 'DNS check' to go green (can take a few minutes)."
+    Write-Host "  3. Enable 'Enforce HTTPS' in the Pages settings once the cert is issued."
+    Write-Host ""
+    Write-Host "Verify:" -ForegroundColor Green
+    Write-Host "  dig +short $Zone        # expect: 185.199.108.153 (and three siblings)"
+    Write-Host "  dig +short www.$Zone    # expect: $GhPagesHost  → GH Pages IPs"
+    Write-Host "  curl -sI https://$Zone  # expect: 200 from GitHub Pages"
 }


### PR DESCRIPTION
Stands the apex domain up properly so https://erp-for-factory.games serves an actual page (not a redirect to the repo).

## Three pieces

### 1. Placeholder page (`docs/`)

- `docs/index.html` — landing page, no JS, ~140 lines of HTML/CSS. Title, tagline, supported-games list (Satisfactory **In development**, CoI + DSP **Planned**), links to repo / wiki / sponsor / costs.
- `docs/CNAME` — `erp-for-factory.games`. Required by GH Pages when a custom domain is set.
- `docs/.nojekyll` — disables Jekyll so the existing `docs/adr/*.md` and `docs/roadmap.md` aren't re-processed when `/docs` becomes the Pages source.

### 2. Rewritten `tools/cloudflare/Setup-Dns.ps1`

Switches the topology from \"apex redirect to GitHub repo\" → \"apex serves GitHub Pages\":

- **Apex** — 4× A records → GH Pages IPs (`185.199.108.153`/`.109.153`/`.110.153`/`.111.153`), **grey-cloud** so GH Pages owns TLS via Let's Encrypt (Cloudflare proxy interferes with the HTTP-01 challenge).
- **www** — `CNAME` → `chrisonsimtian.github.io`, also grey-cloud.
- **Reconciliation**: records under apex/www that don't match the desired set get **deleted**, not just left behind.
- Dropped the apex/www redirect rule (never applied to Cloudflare; only existed as the previous script's intent).
- Dropped the `satisfactory.<apex>` placeholder — added when that app deploys, per ADR-0020 host convention.
- Kept \`Always-Use-HTTPS = on\` and \`Minimum TLS = 1.2\`.

### 3. `.github/workflows/cloudflare-dns.yml`

- \`workflow_dispatch\` only — manual trigger from the Actions tab.
- \`apply\` boolean input, **default \`false\`** → dry-run.
- Reads \`CLOUDFLARE_API_TOKEN\` from repo secrets.
- Serialised via \`concurrency\` group (never cancel an in-flight apply).

## After merging — one-time manual step

GitHub repo → **Settings → Pages**:
1. Source: \`Deploy from a branch\` → \`main\` / \`/docs\`.
2. Custom domain: \`erp-for-factory.games\` (commits a CNAME — already in repo, so it'll match).
3. \"Enforce HTTPS\" — wait until GH issues the cert (a few minutes after DNS propagates), then enable.

Then in **Actions → Cloudflare DNS setup**:
1. Run with \`apply=false\` → review log.
2. Re-run with \`apply=true\`.

## Out of scope

- Per-game subdomains beyond what's in ADR-0020's convention. Added when each app ships.
- DNSSEC, CAA records, Cloudflare orange-cloud (proxy on). All easy follow-ups; deliberate non-goals for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)