### PR TITLE
feat(coi): scaffold CaptainOfIndustry.Catalog module

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -30,6 +30,10 @@
   <Folder Name="/src/Satisfactory/Save/">
     <Project Path="src/Satisfactory/Save/Satisfactory.Save.csproj" />
   </Folder>
+  <Folder Name="/src/CaptainOfIndustry/" />
+  <Folder Name="/src/CaptainOfIndustry/Catalog/">
+    <Project Path="src/CaptainOfIndustry/Catalog/CaptainOfIndustry.Catalog.csproj" />
+  </Folder>
   <Folder Name="/test/" />
   <Folder Name="/test/ApiService.Tests/" />
   <Folder Name="/test/ERP/" />
@@ -51,6 +55,10 @@
   </Folder>
   <Folder Name="/test/Satisfactory/Save.Tests/">
     <Project Path="test/Satisfactory/Save.Tests/Satisfactory.Save.Tests.csproj" />
+  </Folder>
+  <Folder Name="/test/CaptainOfIndustry/" />
+  <Folder Name="/test/CaptainOfIndustry/Catalog.Tests/">
+    <Project Path="test/CaptainOfIndustry/Catalog.Tests/CaptainOfIndustry.Catalog.Tests.csproj" />
   </Folder>
   <Folder Name="/test/Web/" />
   <Folder Name="/test/Web/Web.UiTests/">

--- a/src/CaptainOfIndustry/Catalog/CaptainOfIndustry.Catalog.csproj
+++ b/src/CaptainOfIndustry/Catalog/CaptainOfIndustry.Catalog.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ERP\Domain\ERP.Domain.csproj" />
+    <ProjectReference Include="..\..\ERP\Application\ERP.Application.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CaptainOfIndustry/Catalog/EmptyCoiCatalogProvider.cs
+++ b/src/CaptainOfIndustry/Catalog/EmptyCoiCatalogProvider.cs
@@ -1,0 +1,37 @@
+using ERP.Application;
+using ERP.Domain;
+
+namespace CaptainOfIndustry.Catalog;
+
+/// <summary>
+/// Placeholder Captain of Industry catalogue adapter. Returns an empty catalogue
+/// until the extractor pipeline lands (see issue #177, ADR-0022). Exists so the
+/// CoI module can be wired into a host without a real data source.
+/// </summary>
+public sealed class EmptyCoiCatalogProvider : ICatalogProvider
+{
+    public bool IsLoaded => false;
+    public string? Source => null;
+
+    public IReadOnlyList<Item> Items { get; } = Array.Empty<Item>();
+    public IReadOnlyList<Building> Buildings { get; } = Array.Empty<Building>();
+    public IReadOnlyList<Recipe> Recipes { get; } = Array.Empty<Recipe>();
+
+    public Item? FindItem(ItemId id) => null;
+    public Building? FindBuilding(BuildingId id) => null;
+    public Recipe? FindRecipe(RecipeId id) => null;
+
+    public Recipe? FindDefaultProducerOf(ItemId item) => null;
+    public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) => Array.Empty<Recipe>();
+
+    public CatalogueStatus GetStatus() => new(
+        IsLoaded: false,
+        Source: null,
+        ItemCount: 0,
+        BuildingCount: 0,
+        RecipeCount: 0,
+        AlternateRecipeCount: 0,
+        Warnings: new[] { "Captain of Industry catalogue not yet implemented. Tracked under milestone #16." });
+
+    public CatalogueStatus LoadFromPath(string docsJsonPath) => GetStatus();
+}

--- a/test/CaptainOfIndustry/Catalog.Tests/CaptainOfIndustry.Catalog.Tests.csproj
+++ b/test/CaptainOfIndustry/Catalog.Tests/CaptainOfIndustry.Catalog.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>CaptainOfIndustry.Catalog.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\CaptainOfIndustry\Catalog\CaptainOfIndustry.Catalog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/CaptainOfIndustry/Catalog.Tests/EmptyCoiCatalogProviderTests.cs
+++ b/test/CaptainOfIndustry/Catalog.Tests/EmptyCoiCatalogProviderTests.cs
@@ -1,0 +1,30 @@
+using ERP.Application;
+
+namespace CaptainOfIndustry.Catalog.Tests;
+
+public class EmptyCoiCatalogProviderTests
+{
+    [Fact]
+    public void Provider_Starts_Unloaded()
+    {
+        ICatalogProvider provider = new EmptyCoiCatalogProvider();
+
+        Assert.False(provider.IsLoaded);
+        Assert.Null(provider.Source);
+        Assert.Empty(provider.Items);
+        Assert.Empty(provider.Buildings);
+        Assert.Empty(provider.Recipes);
+    }
+
+    [Fact]
+    public void Lookups_Return_Null_Or_Empty()
+    {
+        var provider = new EmptyCoiCatalogProvider();
+
+        Assert.Null(provider.FindItem(new("iron")));
+        Assert.Null(provider.FindBuilding(new("smelter")));
+        Assert.Null(provider.FindRecipe(new("iron-smelting")));
+        Assert.Null(provider.FindDefaultProducerOf(new("iron")));
+        Assert.Empty(provider.FindAllProducersOf(new("iron")));
+    }
+}


### PR DESCRIPTION
Closes #176.

## Summary

- New `src/CaptainOfIndustry/Catalog/CaptainOfIndustry.Catalog.csproj` mirroring `src/Satisfactory/Catalog/`.
- `EmptyCoiCatalogProvider` — placeholder `ICatalogProvider` that returns an empty catalogue + a warning. Lives inside the game module rather than in `ERP.Infrastructure` (a small departure from the Satisfactory layout); will be revisited when the real adapter ships post-extractor and we decide whether ADR-0010's contract needs widening.
- `test/CaptainOfIndustry/Catalog.Tests/` with two smoke tests proving the stub satisfies the interface.
- `ErpForFactoryGames.slnx` updated.

## Out of scope (per ADR-0022)

- No DI registration in any host. Satisfactory and CoI presentation apps stay isolated; the CoI Web app (#179) will register its own provider.
- No real catalogue parsing. That's #177a (extractor) + #177b (JSON ingestion), informed by the #175 spike.
- No `Directory.Packages.props` / `nuget.config` changes. No new packages introduced.

## Test plan

- [x] `dotnet build ErpForFactoryGames.slnx` → 0 errors (only pre-existing warnings).
- [x] `dotnet test test/CaptainOfIndustry/Catalog.Tests/` → 2 passed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)