### PR TITLE
feat(coi): catalogue config + path resolution

### DIFF
--- a/src/CaptainOfIndustry/Catalog/CoiCatalogueOptions.cs
+++ b/src/CaptainOfIndustry/Catalog/CoiCatalogueOptions.cs
@@ -1,0 +1,20 @@
+namespace CaptainOfIndustry.Catalog;
+
+/// <summary>
+/// Bound from the <c>Catalogue:CaptainOfIndustry</c> configuration section.
+/// </summary>
+/// <remarks>
+/// Captain of Industry has no equivalent of Satisfactory's <c>Docs.json</c> — its
+/// catalogue is encoded in C# assemblies. The user runs the extractor tool
+/// (<c>tools/CaptainOfIndustryExtractor</c>, see #177) once per game patch to
+/// produce a JSON catalogue; the runtime app then points at that file.
+/// </remarks>
+public sealed class CoiCatalogueOptions
+{
+    /// <summary>
+    /// Absolute path to the extracted CoI catalogue JSON. May be <c>null</c> if
+    /// the user hasn't configured one — in which case the resolver falls back
+    /// to <see cref="CoiCataloguePathResolver.DefaultPath"/>.
+    /// </summary>
+    public string? CataloguePath { get; set; }
+}

--- a/src/CaptainOfIndustry/Catalog/CoiCataloguePathResolver.cs
+++ b/src/CaptainOfIndustry/Catalog/CoiCataloguePathResolver.cs
@@ -1,0 +1,64 @@
+namespace CaptainOfIndustry.Catalog;
+
+/// <summary>
+/// Resolves where the extracted Captain of Industry catalogue JSON lives,
+/// following the same priority order ADR-0011 established for Satisfactory:
+/// environment variable → configured path → default location under
+/// <c>%LocalAppData%\ErpForFactoryGames\</c>.
+/// </summary>
+/// <remarks>
+/// Returns the *expected* path (whether or not the file exists) so callers can
+/// surface "configured but missing" distinctly from "not configured" in the UI.
+/// Use <see cref="ResolveExisting"/> when you only care about a readable file.
+/// </remarks>
+public static class CoiCataloguePathResolver
+{
+    /// <summary>
+    /// Environment variable consulted first. Per-game key chosen over a generic
+    /// <c>ERP_CATALOGUE_PATH</c> so a dev box configuring both games stays
+    /// unambiguous (see ADR-0011 'Consequences').
+    /// </summary>
+    public const string EnvironmentVariable = "ERP_CAPTAIN_OF_INDUSTRY_CATALOGUE_PATH";
+
+    private const string DefaultFileName = "coi-catalogue.json";
+    private const string AppFolderName = "ErpForFactoryGames";
+
+    /// <summary>
+    /// Default JSON location used when neither the env var nor configuration
+    /// provides an explicit path. Lives next to other per-user app data so the
+    /// extractor and the runtime app converge by convention.
+    /// </summary>
+    public static string DefaultPath { get; } =
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            AppFolderName,
+            DefaultFileName);
+
+    /// <summary>
+    /// Resolves the *expected* path without checking whether the file exists.
+    /// </summary>
+    public static string Resolve(CoiCatalogueOptions options) =>
+        Resolve(options.CataloguePath);
+
+    /// <summary>
+    /// Resolves the *expected* path without checking whether the file exists.
+    /// </summary>
+    public static string Resolve(string? configuredPath)
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(EnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(fromEnv)) return fromEnv;
+
+        if (!string.IsNullOrWhiteSpace(configuredPath)) return configuredPath;
+
+        return DefaultPath;
+    }
+
+    /// <summary>
+    /// Returns the resolved path if the file exists on disk, else <c>null</c>.
+    /// </summary>
+    public static string? ResolveExisting(CoiCatalogueOptions options)
+    {
+        var path = Resolve(options);
+        return File.Exists(path) ? path : null;
+    }
+}

--- a/src/CaptainOfIndustry/Catalog/EmptyCoiCatalogProvider.cs
+++ b/src/CaptainOfIndustry/Catalog/EmptyCoiCatalogProvider.cs
@@ -10,8 +10,17 @@ namespace CaptainOfIndustry.Catalog;
 /// </summary>
 public sealed class EmptyCoiCatalogProvider : ICatalogProvider
 {
+    private readonly CoiCatalogueOptions _options;
+
+    public EmptyCoiCatalogProvider() : this(new CoiCatalogueOptions()) { }
+
+    public EmptyCoiCatalogProvider(CoiCatalogueOptions options)
+    {
+        _options = options;
+    }
+
     public bool IsLoaded => false;
-    public string? Source => null;
+    public string? Source => CoiCataloguePathResolver.ResolveExisting(_options);
 
     public IReadOnlyList<Item> Items { get; } = Array.Empty<Item>();
     public IReadOnlyList<Building> Buildings { get; } = Array.Empty<Building>();
@@ -24,14 +33,30 @@ public sealed class EmptyCoiCatalogProvider : ICatalogProvider
     public Recipe? FindDefaultProducerOf(ItemId item) => null;
     public IReadOnlyList<Recipe> FindAllProducersOf(ItemId item) => Array.Empty<Recipe>();
 
-    public CatalogueStatus GetStatus() => new(
-        IsLoaded: false,
-        Source: null,
-        ItemCount: 0,
-        BuildingCount: 0,
-        RecipeCount: 0,
-        AlternateRecipeCount: 0,
-        Warnings: new[] { "Captain of Industry catalogue not yet implemented. Tracked under milestone #16." });
+    public CatalogueStatus GetStatus()
+    {
+        var existing = CoiCataloguePathResolver.ResolveExisting(_options);
+        var expected = CoiCataloguePathResolver.Resolve(_options);
+        var warnings = new List<string>
+        {
+            "Captain of Industry catalogue ingestion not yet implemented. Tracked under milestone #16.",
+        };
+        if (existing is null)
+            warnings.Add($"No catalogue JSON at '{expected}'. Run the extractor (tools/CaptainOfIndustryExtractor, #177) to generate one.");
 
-    public CatalogueStatus LoadFromPath(string docsJsonPath) => GetStatus();
+        return new CatalogueStatus(
+            IsLoaded: false,
+            Source: existing,
+            ItemCount: 0,
+            BuildingCount: 0,
+            RecipeCount: 0,
+            AlternateRecipeCount: 0,
+            Warnings: warnings);
+    }
+
+    public CatalogueStatus LoadFromPath(string docsJsonPath)
+    {
+        _options.CataloguePath = docsJsonPath;
+        return GetStatus();
+    }
 }

--- a/test/CaptainOfIndustry/Catalog.Tests/CoiCataloguePathResolverTests.cs
+++ b/test/CaptainOfIndustry/Catalog.Tests/CoiCataloguePathResolverTests.cs
@@ -1,0 +1,88 @@
+namespace CaptainOfIndustry.Catalog.Tests;
+
+public class CoiCataloguePathResolverTests : IDisposable
+{
+    private readonly string? _originalEnv;
+
+    public CoiCataloguePathResolverTests()
+    {
+        _originalEnv = Environment.GetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable);
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, _originalEnv);
+    }
+
+    [Fact]
+    public void Env_Var_Wins_Over_Configured_Path()
+    {
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, @"C:\from-env.json");
+
+        var resolved = CoiCataloguePathResolver.Resolve(new CoiCatalogueOptions { CataloguePath = @"C:\from-config.json" });
+
+        Assert.Equal(@"C:\from-env.json", resolved);
+    }
+
+    [Fact]
+    public void Configured_Path_Wins_Over_Default()
+    {
+        var resolved = CoiCataloguePathResolver.Resolve(new CoiCatalogueOptions { CataloguePath = @"C:\from-config.json" });
+
+        Assert.Equal(@"C:\from-config.json", resolved);
+    }
+
+    [Fact]
+    public void Falls_Back_To_Default_Path_When_Nothing_Configured()
+    {
+        var resolved = CoiCataloguePathResolver.Resolve(new CoiCatalogueOptions());
+
+        Assert.Equal(CoiCataloguePathResolver.DefaultPath, resolved);
+    }
+
+    [Fact]
+    public void Default_Path_Lives_Under_LocalAppData()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        Assert.StartsWith(localAppData, CoiCataloguePathResolver.DefaultPath, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith("coi-catalogue.json", CoiCataloguePathResolver.DefaultPath);
+    }
+
+    [Fact]
+    public void Whitespace_Configured_Path_Is_Ignored()
+    {
+        var resolved = CoiCataloguePathResolver.Resolve(new CoiCatalogueOptions { CataloguePath = "   " });
+
+        Assert.Equal(CoiCataloguePathResolver.DefaultPath, resolved);
+    }
+
+    [Fact]
+    public void ResolveExisting_Returns_Null_When_File_Missing()
+    {
+        var result = CoiCataloguePathResolver.ResolveExisting(new CoiCatalogueOptions
+        {
+            CataloguePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json"),
+        });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveExisting_Returns_Path_When_File_Exists()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(tempFile, "{}");
+        try
+        {
+            var result = CoiCataloguePathResolver.ResolveExisting(new CoiCatalogueOptions { CataloguePath = tempFile });
+
+            Assert.Equal(tempFile, result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}

--- a/test/CaptainOfIndustry/Catalog.Tests/EmptyCoiCatalogProviderTests.cs
+++ b/test/CaptainOfIndustry/Catalog.Tests/EmptyCoiCatalogProviderTests.cs
@@ -2,12 +2,30 @@ using ERP.Application;
 
 namespace CaptainOfIndustry.Catalog.Tests;
 
-public class EmptyCoiCatalogProviderTests
+public class EmptyCoiCatalogProviderTests : IDisposable
 {
-    [Fact]
-    public void Provider_Starts_Unloaded()
+    private readonly string? _originalEnv;
+    private readonly CoiCatalogueOptions _missingFileOptions;
+
+    public EmptyCoiCatalogProviderTests()
     {
-        ICatalogProvider provider = new EmptyCoiCatalogProvider();
+        _originalEnv = Environment.GetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable);
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, null);
+        _missingFileOptions = new CoiCatalogueOptions
+        {
+            CataloguePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json"),
+        };
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, _originalEnv);
+    }
+
+    [Fact]
+    public void Provider_Starts_Unloaded_With_No_Source()
+    {
+        ICatalogProvider provider = new EmptyCoiCatalogProvider(_missingFileOptions);
 
         Assert.False(provider.IsLoaded);
         Assert.Null(provider.Source);
@@ -19,12 +37,46 @@ public class EmptyCoiCatalogProviderTests
     [Fact]
     public void Lookups_Return_Null_Or_Empty()
     {
-        var provider = new EmptyCoiCatalogProvider();
+        var provider = new EmptyCoiCatalogProvider(_missingFileOptions);
 
         Assert.Null(provider.FindItem(new("iron")));
         Assert.Null(provider.FindBuilding(new("smelter")));
         Assert.Null(provider.FindRecipe(new("iron-smelting")));
         Assert.Null(provider.FindDefaultProducerOf(new("iron")));
         Assert.Empty(provider.FindAllProducersOf(new("iron")));
+    }
+
+    [Fact]
+    public void Status_Surfaces_Missing_File_Warning()
+    {
+        var provider = new EmptyCoiCatalogProvider(_missingFileOptions);
+
+        var status = provider.GetStatus();
+
+        Assert.False(status.IsLoaded);
+        Assert.Equal(2, status.Warnings.Count);
+        Assert.Contains(status.Warnings, w => w.Contains("not yet implemented"));
+        Assert.Contains(status.Warnings, w => w.Contains(_missingFileOptions.CataloguePath!));
+    }
+
+    [Fact]
+    public void Status_Drops_Missing_File_Warning_When_File_Exists()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(tempFile, "{}");
+        try
+        {
+            var provider = new EmptyCoiCatalogProvider(new CoiCatalogueOptions { CataloguePath = tempFile });
+
+            var status = provider.GetStatus();
+
+            Assert.Equal(tempFile, status.Source);
+            Assert.Single(status.Warnings);
+            Assert.Contains("not yet implemented", status.Warnings[0]);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 }


### PR DESCRIPTION
Closes #178.

## Summary

- `CoiCatalogueOptions` binds from `Catalogue:CaptainOfIndustry` (`CataloguePath` property).
- `CoiCataloguePathResolver` follows ADR-0011's priority order: env var (`ERP_CAPTAIN_OF_INDUSTRY_CATALOGUE_PATH`) → configured path → default `%LocalAppData%\ErpForFactoryGames\coi-catalogue.json`. Two flavours: `Resolve()` returns the expected path (whether or not it exists), `ResolveExisting()` returns null if the file is missing — so callers can distinguish 'not configured' from 'configured but missing'.
- `EmptyCoiCatalogProvider` now uses the resolver and surfaces a separate warning when the JSON is missing, so a future Settings UX can react.

## Design calls worth flagging

- **Per-game env var, not a generic `ERP_CATALOGUE_PATH`** — ADR-0011 'Consequences' flagged this as undecided; chose per-game so a dev machine configured for both games stays unambiguous.
- **Config points at the extracted JSON, not the game install dir** — per the spike pivot on #175. The CoI catalogue doesn't live in the install (it's compiled into Mafi.Base.dll); the extractor (#177) writes JSON that the runtime app then reads.
- **No Steam library auto-detect here** — the install directory is only useful to the extractor tool, not the runtime app. Moved to #177a. Issue body called for parity with Satisfactory but the post-spike framing makes that scope mismatch.

## Test plan

- [x] 11 tests in `CaptainOfIndustry.Catalog.Tests` — all pass. Env-var leakage handled per test.
- [x] `dotnet build ErpForFactoryGames.slnx` → 0 errors.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)