### PR TITLE
feat(coi): Blazor presentation app

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -34,6 +34,9 @@
   <Folder Name="/src/CaptainOfIndustry/Catalog/">
     <Project Path="src/CaptainOfIndustry/Catalog/CaptainOfIndustry.Catalog.csproj" />
   </Folder>
+  <Folder Name="/src/CaptainOfIndustry/Web/">
+    <Project Path="src/CaptainOfIndustry/Web/CaptainOfIndustry.Web.csproj" />
+  </Folder>
   <Folder Name="/test/" />
   <Folder Name="/test/ApiService.Tests/" />
   <Folder Name="/test/ERP/" />

--- a/src/AppHost/AppHost.cs
+++ b/src/AppHost/AppHost.cs
@@ -16,4 +16,11 @@ builder.AddProject<Projects.Web>("webfrontend")
     .WithReference(apiService)
     .WaitFor(apiService);
 
+// Captain of Industry presentation app — runs independently of the Satisfactory
+// frontend per ADR-0022 (isolated apps, one per supported game). Reads its
+// catalogue in-process from the extractor's JSON; no ApiService dependency in v1.
+builder.AddProject<Projects.CaptainOfIndustry_Web>("coi-webfrontend")
+    .WithExternalHttpEndpoints()
+    .WithHttpHealthCheck("/health");
+
 builder.Build().Run();

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ApiService\ApiService.csproj" />
     <ProjectReference Include="..\Web\Web.csproj" />
+    <ProjectReference Include="..\CaptainOfIndustry\Web\CaptainOfIndustry.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CaptainOfIndustry/Web/CaptainOfIndustry.Web.csproj
+++ b/src/CaptainOfIndustry/Web/CaptainOfIndustry.Web.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>CaptainOfIndustry.Web</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ServiceDefaults\ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\ERP\Application\ERP.Application.csproj" />
+    <ProjectReference Include="..\Catalog\CaptainOfIndustry.Catalog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/CaptainOfIndustry/Web/Components/App.razor
+++ b/src/CaptainOfIndustry/Web/Components/App.razor
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <ImportMap />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+</body>
+
+</html>

--- a/src/CaptainOfIndustry/Web/Components/Layout/MainLayout.razor
+++ b/src/CaptainOfIndustry/Web/Components/Layout/MainLayout.razor
@@ -1,0 +1,24 @@
+@inherits LayoutComponentBase
+
+<MudThemeProvider Theme="_theme" IsDarkMode="true" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudText Typo="Typo.h6">ERP for Factory Games — Captain of Industry</MudText>
+        <MudSpacer />
+        <MudLink Href="/" Color="Color.Inherit" Class="mx-2">Home</MudLink>
+        <MudLink Href="catalogue" Color="Color.Inherit" Class="mx-2">Catalogue</MudLink>
+    </MudAppBar>
+    <MudMainContent>
+        <MudContainer MaxWidth="MaxWidth.Large" Class="mt-6">
+            @Body
+        </MudContainer>
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private readonly MudTheme _theme = new();
+}

--- a/src/CaptainOfIndustry/Web/Components/Pages/Catalogue.razor
+++ b/src/CaptainOfIndustry/Web/Components/Pages/Catalogue.razor
@@ -1,0 +1,72 @@
+@page "/catalogue"
+@using ERP.Application
+@using ERP.Domain
+@inject ICatalogProvider Catalog
+
+<PageTitle>Catalogue — CoI</PageTitle>
+
+<h1>Catalogue</h1>
+
+@if (!Catalog.IsLoaded)
+{
+    <MudAlert Severity="Severity.Warning">No catalogue loaded — see the home page.</MudAlert>
+    return;
+}
+
+<MudTabs Elevation="0" Outlined="false" Class="mt-3">
+    <MudTabPanel Text="@($"Items ({Catalog.Items.Count})")">
+        <MudTable Items="Catalog.Items" Dense="true" Hover="true" Striped="true" Bordered="false" Class="mt-2">
+            <HeaderContent>
+                <MudTh>Id</MudTh>
+                <MudTh>Name</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.Id.Value</MudTd>
+                <MudTd>@context.Name</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+
+    <MudTabPanel Text="@($"Recipes ({Catalog.Recipes.Count})")">
+        <MudTable Items="Catalog.Recipes" Dense="true" Hover="true" Striped="true" Bordered="false" Class="mt-2">
+            <HeaderContent>
+                <MudTh>Id</MudTh>
+                <MudTh>Name</MudTh>
+                <MudTh>Building</MudTh>
+                <MudTh>Duration</MudTh>
+                <MudTh>Inputs → Outputs</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.Id.Value</MudTd>
+                <MudTd>@context.Name</MudTd>
+                <MudTd>@context.Building.Value</MudTd>
+                <MudTd>@context.Duration.TotalSeconds.ToString("0.##")s</MudTd>
+                <MudTd>@FormatRecipe(context)</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+
+    <MudTabPanel Text="@($"Buildings ({Catalog.Buildings.Count})")">
+        <MudTable Items="Catalog.Buildings" Dense="true" Hover="true" Striped="true" Bordered="false" Class="mt-2">
+            <HeaderContent>
+                <MudTh>Id</MudTh>
+                <MudTh>Name</MudTh>
+                <MudTh>Power (MW)</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.Id.Value</MudTd>
+                <MudTd>@context.Name</MudTd>
+                <MudTd>@context.BasePowerMw.ToString("0.##")</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+</MudTabs>
+
+@code {
+    private static string FormatRecipe(Recipe r)
+    {
+        var inputs = string.Join(" + ", r.Inputs.Select(i => $"{i.Quantity}× {i.Item.Value}"));
+        var outputs = string.Join(" + ", r.Outputs.Select(o => $"{o.Quantity}× {o.Item.Value}"));
+        return string.IsNullOrEmpty(inputs) ? $"→ {outputs}" : $"{inputs} → {outputs}";
+    }
+}

--- a/src/CaptainOfIndustry/Web/Components/Pages/Error.razor
+++ b/src/CaptainOfIndustry/Web/Components/Pages/Error.razor
@@ -1,0 +1,25 @@
+@page "/Error"
+@using System.Diagnostics
+
+<PageTitle>Error</PageTitle>
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@RequestId</code>
+    </p>
+}
+
+@code{
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/CaptainOfIndustry/Web/Components/Pages/Home.razor
+++ b/src/CaptainOfIndustry/Web/Components/Pages/Home.razor
@@ -1,0 +1,37 @@
+@page "/"
+@using ERP.Application
+@inject ICatalogProvider Catalog
+
+<PageTitle>ERP — Captain of Industry</PageTitle>
+
+<h1>Captain of Industry</h1>
+
+<MudText Class="mb-3">
+    Production planning for <em>Captain of Industry</em>. Sibling app to the Satisfactory planner
+    (<MudLink Href="https://satisfactory.erp-for-factory.games">satisfactory.erp-for-factory.games</MudLink>),
+    sharing the planning core but with its own isolated UI per
+    <MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/docs/adr/0022-captain-of-industry-support.md">ADR-0022</MudLink>.
+</MudText>
+
+@if (Catalog.IsLoaded)
+{
+    <MudAlert Severity="Severity.Success" Class="mb-3">
+        Catalogue loaded from <code>@Catalog.Source</code> —
+        @Catalog.Items.Count items, @Catalog.Recipes.Count recipes, @Catalog.Buildings.Count buildings.
+    </MudAlert>
+}
+else
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-3">
+        No catalogue loaded. Run <code>dotnet run --project tools/CaptainOfIndustryExtractor -- --install &lt;CoI dir&gt;</code>
+        to generate one.
+    </MudAlert>
+    @foreach (var w in Catalog.GetStatus().Warnings)
+    {
+        <MudText Typo="Typo.body2" Class="mb-1"><em>@w</em></MudText>
+    }
+}
+
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Href="catalogue" Class="mt-3">
+    Browse catalogue
+</MudButton>

--- a/src/CaptainOfIndustry/Web/Components/Routes.razor
+++ b/src/CaptainOfIndustry/Web/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/CaptainOfIndustry/Web/Components/_Imports.razor
+++ b/src/CaptainOfIndustry/Web/Components/_Imports.razor
@@ -1,0 +1,11 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using MudBlazor
+@using CaptainOfIndustry.Web
+@using CaptainOfIndustry.Web.Components

--- a/src/CaptainOfIndustry/Web/Program.cs
+++ b/src/CaptainOfIndustry/Web/Program.cs
@@ -1,0 +1,42 @@
+using CaptainOfIndustry.Web.Components;
+using CaptainOfIndustry.Catalog;
+using ERP.Application;
+using Microsoft.Extensions.Options;
+using MudBlazor.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddMudServices();
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+// CoI catalogue runs in-process: the Blazor app reads the extractor's JSON
+// directly via JsonCoiCatalogProvider. No ApiService hop in v1 — per ADR-0022
+// the CoI app is isolated from the Satisfactory app and doesn't share the
+// planner-over-HTTP plumbing yet.
+builder.Services.Configure<CoiCatalogueOptions>(
+    builder.Configuration.GetSection("Catalogue:CaptainOfIndustry"));
+builder.Services.AddSingleton<ICatalogProvider>(sp =>
+    new JsonCoiCatalogProvider(sp.GetRequiredService<IOptions<CoiCatalogueOptions>>().Value));
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseAntiforgery();
+app.MapStaticAssets();
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.MapDefaultEndpoints();
+
+app.Run();

--- a/src/CaptainOfIndustry/Web/Properties/launchSettings.json
+++ b/src/CaptainOfIndustry/Web/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5247",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7237;http://localhost:5247",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/CaptainOfIndustry/Web/appsettings.Development.json
+++ b/src/CaptainOfIndustry/Web/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/CaptainOfIndustry/Web/appsettings.json
+++ b/src/CaptainOfIndustry/Web/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Catalogue": {
+    "CaptainOfIndustry": {
+      "CataloguePath": null
+    }
+  }
+}

--- a/src/CaptainOfIndustry/Web/wwwroot/app.css
+++ b/src/CaptainOfIndustry/Web/wwwroot/app.css
@@ -1,0 +1,13 @@
+html, body {
+    height: 100%;
+    margin: 0;
+}
+
+h1 {
+    font-weight: 300;
+}
+
+code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.9em;
+}


### PR DESCRIPTION
Closes #179.

## Summary

- New `src/CaptainOfIndustry/Web/` — isolated Blazor Server app per ADR-0022.
- **Naming**: picked `src/CaptainOfIndustry/Web/` over `src/Web.CaptainOfIndustry/`. Issue body called both out; this keeps all CoI code under one folder and matches the `src/Satisfactory/Catalog/` precedent.
- **In-process catalogue**: registers `JsonCoiCatalogProvider` directly via `IOptions<CoiCatalogueOptions>`. No ApiService dependency in v1 — the planner-over-HTTP plumbing isn't shared yet, and there's no shared-component need until #181's lazy extraction policy kicks in.
- **Pages**:
  - `Home` — catalogue status banner (loaded source + counts, or extractor instructions if not configured).
  - `Catalogue` — tabbed `MudTable` over items / recipes / buildings, proving end-to-end load.
- **AppHost** wired with a second project resource (`coi-webfrontend`); runs alongside Satisfactory on its own ports (5247 http / 7237 https).

## Local smoke test

Started standalone with `dotnet run --project src/CaptainOfIndustry/Web`, drove with Playwright:

| Page | Result |
|---|---|
| `/` | Status banner: "Catalogue loaded from `%LocalAppData%\ErpForFactoryGames\coi-catalogue.json` — 227 items, 494 recipes, 84 buildings." |
| `/catalogue` (Items tab) | 227 rows render with id + name (Product_Acid → Acid, etc.) |
| `/catalogue` (Recipes tab) | 494 rows with id, name, building, duration, inputs→outputs (e.g. WheatMilling → FoodMill, 7.5s) |
| `/catalogue` (Buildings tab) | 84 rows with id, name, power in MW |

## Out of scope

- **No real planner page yet.** The placeholder `Catalogue` page is enough to unblock #182 (e2e planner smoke); a real CoI planner UI lands later — CoI's planning needs may diverge from Satisfactory's enough to want bespoke pages rather than shared components.
- **No shared frontend extraction.** Per ADR-0022 + #181, we wait for a real second consumer of a component before extracting. The CoI app's MainLayout / Home / Catalogue are deliberately written from scratch and minimal.
- **No theming, no icons, no auth.** Default MudBlazor dark theme. Icons are a follow-up (the CoI wiki ships them, similar to how Satisfactory icons came from the wiki).

## Test plan

- [x] `dotnet build ErpForFactoryGames.slnx` → 0 errors.
- [x] `dotnet format --verify-no-changes` → clean.
- [x] Standalone run + Playwright drive: home + catalogue pages render with real CoI 0.8.4 data.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)