### PR TITLE
feat(coi): item icons from wiki.coigame.com

### DIFF
--- a/src/CaptainOfIndustry/Web/Components/Pages/Catalogue.razor
+++ b/src/CaptainOfIndustry/Web/Components/Pages/Catalogue.razor
@@ -17,10 +17,20 @@
     <MudTabPanel Text="@($"Items ({Catalog.Items.Count})")">
         <MudTable Items="Catalog.Items" Dense="true" Hover="true" Striped="true" Bordered="false" Class="mt-2">
             <HeaderContent>
+                <MudTh Style="width: 48px;"></MudTh>
                 <MudTh>Id</MudTh>
                 <MudTh>Name</MudTh>
             </HeaderContent>
             <RowTemplate>
+                <MudTd>
+                    @* onerror hides broken images so we silently fall back to text-only
+                       for items the wiki doesn't have an icon for (e.g. Aluminum_Scrap_Pressed).
+                       Icons come from .assets/coi/icons/items/ — see tools/Download-CoiIcons.ps1. *@
+                    <img src="@($"/assets/coi/icons/items/{context.Id.Value}.png")"
+                         alt=""
+                         width="32" height="32"
+                         onerror="this.style.visibility='hidden'" />
+                </MudTd>
                 <MudTd>@context.Id.Value</MudTd>
                 <MudTd>@context.Name</MudTd>
             </RowTemplate>

--- a/src/CaptainOfIndustry/Web/Program.cs
+++ b/src/CaptainOfIndustry/Web/Program.cs
@@ -1,6 +1,7 @@
 using CaptainOfIndustry.Web.Components;
 using CaptainOfIndustry.Catalog;
 using ERP.Application;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using MudBlazor.Services;
 
@@ -33,6 +34,35 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAntiforgery();
 app.MapStaticAssets();
+
+// .assets/coi/ is the dev's gitignored drop folder for CoI-derived art
+// (item icons fetched from wiki.coigame.com by tools/Download-CoiIcons.ps1,
+// per ADR-0015 / ADR-0016). Map at /assets/* so Razor templates can reference
+// <img src="/assets/coi/icons/items/{id}.png" /> without bundling MB of
+// external art into the repo. Silently no-ops when the folder doesn't exist.
+var assetsPath = app.Configuration["Assets:LocalPath"];
+if (string.IsNullOrWhiteSpace(assetsPath))
+{
+    var probe = app.Environment.ContentRootPath;
+    while (!string.IsNullOrEmpty(probe) && !Directory.Exists(Path.Combine(probe, ".assets")))
+    {
+        probe = Path.GetDirectoryName(probe);
+    }
+    if (!string.IsNullOrEmpty(probe)) assetsPath = Path.Combine(probe, ".assets");
+}
+if (!string.IsNullOrEmpty(assetsPath) && Directory.Exists(assetsPath))
+{
+    app.UseStaticFiles(new StaticFileOptions
+    {
+        FileProvider = new PhysicalFileProvider(Path.GetFullPath(assetsPath)),
+        RequestPath = "/assets",
+    });
+    app.Logger.LogInformation("Serving .assets/ from {Path} at /assets/*", assetsPath);
+}
+else
+{
+    app.Logger.LogInformation(".assets/ folder not found — item icons will be missing (run tools/Download-CoiIcons.ps1).");
+}
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/tools/Download-CoiIcons.ps1
+++ b/tools/Download-CoiIcons.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    Populates .assets/coi/ with product icons from wiki.coigame.com.
+
+.DESCRIPTION
+    Per ADR-0016, .assets/ is the gitignored drop zone for external game-derived
+    assets that the Web project serves at runtime via the /assets/* static-files
+    mapping. This script is the reproducible way to populate the Captain of
+    Industry slice on a fresh checkout or after a game patch.
+
+    Source: wiki.coigame.com (Mafi's official wiki, MediaWiki). Item icons are
+    fetched via Special:FilePath/<Name>.png — a stable MediaWiki redirect that
+    resolves to the actual storage hash, so we don't need to scrape pages.
+
+    The input catalogue JSON comes from tools/CaptainOfIndustryExtractor — run
+    that once first, then point this script at the resulting file (default:
+    %LocalAppData%/ErpForFactoryGames/coi-catalogue.json).
+
+    Naming: wiki uses Title_Case_With_Underscores (e.g. 'Animal_Feed.png'),
+    but our catalogue stores names as 'Animal feed'. The mapper title-cases
+    each word and joins with underscores. Items that don't have a wiki page
+    (e.g. Bauxite_Powder, Aluminum_Scrap_Pressed) silently 404 and the
+    Catalogue page falls back to text-only for those.
+
+    Rate-limited at 1 req/s with a User-Agent identifying the project. One-shot
+    10s back-off on HTTP 429.
+
+.PARAMETER CataloguePath
+    Path to the extractor's JSON output. Defaults to the same per-user app-data
+    location the runtime app reads from.
+
+.PARAMETER Force
+    Re-download files that already exist locally. Default: skip existing files.
+
+.EXAMPLE
+    pwsh tools/Download-CoiIcons.ps1
+    # Reads %LocalAppData%/ErpForFactoryGames/coi-catalogue.json. Skips existing files.
+
+.EXAMPLE
+    pwsh tools/Download-CoiIcons.ps1 -Force
+    # Re-downloads everything (e.g. after a CoI patch changed icon art).
+#>
+
+[CmdletBinding()]
+param(
+    [string] $CataloguePath = (Join-Path $env:LOCALAPPDATA 'ErpForFactoryGames/coi-catalogue.json'),
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot  = Resolve-Path (Join-Path $PSScriptRoot '..')
+$iconsDir  = Join-Path $repoRoot '.assets/coi/icons/items'
+$userAgent = 'ErpForFactoryGames-OSS-FactoryPlanner/0.1 (+https://github.com/ChrisonSimtian/ErpForFactoryGames)'
+$delayMs   = 1000
+
+if (-not (Test-Path $CataloguePath)) {
+    Write-Host "Catalogue JSON not found at $CataloguePath." -ForegroundColor Red
+    Write-Host "Run the extractor first:" -ForegroundColor Red
+    Write-Host "  dotnet run --project tools/CaptainOfIndustryExtractor -- --install <CoI install dir>" -ForegroundColor Red
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $iconsDir | Out-Null
+
+function Get-WikiImage {
+    param(
+        [Parameter(Mandatory)] [string] $WikiFileName,
+        [Parameter(Mandatory)] [string] $OutputPath
+    )
+
+    if ((-not $Force) -and (Test-Path $OutputPath) -and ((Get-Item $OutputPath).Length -gt 0)) {
+        return 'skipped'
+    }
+
+    # Special:FilePath is the canonical MediaWiki redirect — resolves the
+    # storage-hash path for us and is stable across image re-uploads.
+    $url = "https://wiki.coigame.com/Special:FilePath/$WikiFileName"
+    $tmp = "$OutputPath.tmp"
+
+    foreach ($attempt in 1..2) {
+        try {
+            # -AllowInsecureRedirect: Special:FilePath bounces through http://
+            # mid-chain before settling on the https://images/... target.
+            # PowerShell 7 blocks downgrades by default since 7.4; we opt in
+            # because the final response is https and the wiki has no https-only
+            # storage host alternative.
+            Invoke-WebRequest -Uri $url -OutFile $tmp -UserAgent $userAgent -MaximumRedirection 5 -AllowInsecureRedirect -ErrorAction Stop | Out-Null
+            Move-Item -Force $tmp $OutputPath
+            return 'ok'
+        }
+        catch [System.Net.WebException], [Microsoft.PowerShell.Commands.HttpResponseException] {
+            $status = $_.Exception.Response.StatusCode.value__
+            Remove-Item -Force -ErrorAction SilentlyContinue $tmp
+            if ($status -eq 429 -and $attempt -eq 1) {
+                Write-Host "  429 on $WikiFileName, backing off 10s" -ForegroundColor Yellow
+                Start-Sleep -Seconds 10
+                continue
+            }
+            return "fail($status)"
+        }
+    }
+    return 'fail'
+}
+
+function ConvertTo-WikiName {
+    param([Parameter(Mandatory)] [string] $Name)
+    # Title-case each whitespace-separated word and join with underscores.
+    # Matches the wiki's filename convention (Animal_Feed.png, Carbon_Dioxide.png).
+    ($Name -split '\s+' | Where-Object { $_ } | ForEach-Object {
+        $_.Substring(0, 1).ToUpper() + $_.Substring(1)
+    }) -join '_'
+}
+
+Write-Host "Loading catalogue from $CataloguePath" -ForegroundColor Cyan
+$catalogue = Get-Content -Raw -LiteralPath $CataloguePath | ConvertFrom-Json
+Write-Host "  $($catalogue.items.Count) items, extractor v$($catalogue.extractorVersion), CoI v$($catalogue.coiVersion)"
+
+$ok = 0; $skip = 0; $fail = @()
+Write-Host "Item icons -> $iconsDir" -ForegroundColor Cyan
+foreach ($item in $catalogue.items) {
+    $wikiName = ConvertTo-WikiName -Name $item.name
+    $result   = Get-WikiImage -WikiFileName "$wikiName.png" -OutputPath (Join-Path $iconsDir "$($item.id).png")
+
+    switch ($result) {
+        'ok'      { $ok++ }
+        'skipped' { $skip++ }
+        default   { $fail += "$($item.id) ($($item.name)) -> $result [tried $wikiName.png]" }
+    }
+    Start-Sleep -Milliseconds $delayMs
+}
+
+Write-Host ""
+Write-Host "--- summary ---" -ForegroundColor Cyan
+Write-Host "  downloaded: $ok"
+Write-Host "  skipped (already present): $skip"
+Write-Host "  missing: $($fail.Count)"
+if ($fail.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Items without a wiki icon (Catalogue page falls back to text-only):" -ForegroundColor Yellow
+    $fail | ForEach-Object { Write-Host "  $_" -ForegroundColor Yellow }
+}


### PR DESCRIPTION
Closes #192.

## Summary

- `tools/Download-CoiIcons.ps1` fetches product icons from `wiki.coigame.com` (Mafi's official wiki) via `Special:FilePath` — the canonical MediaWiki redirect that resolves storage-hash paths for us. Mirrors `tools/Update-Assets.ps1`'s shape: 1 req/s pacing, 429 backoff, identifying User-Agent. Output: `.assets/coi/icons/items/<id>.png` (gitignored per ADR-0016).
- `src/CaptainOfIndustry/Web/Program.cs` mounts `.assets/` at `/assets/*`, parity with `src/Web/Program.cs`. Silently no-ops when the folder doesn't exist.
- `Components/Pages/Catalogue.razor` renders 32×32 icons in the Items tab with `onerror="this.style.visibility='hidden'"` so items without a wiki icon gracefully fall back to text only.

## Smoke against vanilla CoI 0.8.4

```
Loading catalogue from %LocalAppData%\ErpForFactoryGames\coi-catalogue.json
  227 items, extractor v0.4.0.0, CoI v0.8.4.0
Item icons -> .assets\coi\icons\items
--- summary ---
  downloaded: 174
  skipped (already present): 0
  missing: 53
```

**174 of 227 items (77%) get icons.** The 53 misses are wiki-doesn't-have-it cases — most fall into:
- Variants sharing one wiki icon (Steam `(high)` / `(low)` / `(super)` — wiki has one Steam image)
- Crushed / pressed / waste forms (Aluminum_Scrap_Pressed, Recyclables_Pressed)
- Virtual products (Product_Virtual_SpaceCrew, Product_Virtual_Upoints)
- Parenthetical IDs the wiki doesn't include in filenames (Enriched_Uranium_(4%))

Playwright drove the catalogue page after running the script — icons render correctly, missing entries silently fall back to text. Console "errors" are just the expected 404s from `onerror`-hidden imgs, not app errors.

## Design calls

- **Filename convention**: TitleCase each word + underscore-joined. Verified by probing the wiki (`Animal_Feed.png` ✓, `Animal_feed.png` ✗, `Carbon_Dioxide.png` ✓).
- **`-AllowInsecureRedirect`**: `Special:FilePath` bounces through an http URL mid-chain before settling on https://images/... PS7.4 blocks this by default; opted in with a comment explaining why.
- **No name-override table yet**. The 53 misses are well-understood; can add overrides incrementally if any prove worth chasing. The Satisfactory script has 3 overrides total — they grow only when a known item is unfindable on the wiki by simple slug rules.

## License posture

Mirrors ADR-0015 / ADR-0016. CoI's case is actually stronger than Satisfactory's: `wiki.coigame.com` is the devs' own wiki, so the fair-use rationale doesn't need to lean on third-party-tolerance.

## Test plan

- [x] `dotnet build src/CaptainOfIndustry/Web/` → 0 warnings, 0 errors.
- [x] `dotnet format --verify-no-changes` → clean.
- [x] `pwsh tools/Download-CoiIcons.ps1` → 174 downloads, 53 documented misses.
- [x] Playwright drive of `/catalogue` Items tab → icons render, missing items fall back gracefully.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)