### PR TITLE
feat(coi): e2e planner smoke + interactive planner page

### DIFF
--- a/src/CaptainOfIndustry/Web/Components/Layout/MainLayout.razor
+++ b/src/CaptainOfIndustry/Web/Components/Layout/MainLayout.razor
@@ -10,6 +10,7 @@
         <MudText Typo="Typo.h6">ERP for Factory Games — Captain of Industry</MudText>
         <MudSpacer />
         <MudLink Href="/" Color="Color.Inherit" Class="mx-2">Home</MudLink>
+        <MudLink Href="planner" Color="Color.Inherit" Class="mx-2">Planner</MudLink>
         <MudLink Href="catalogue" Color="Color.Inherit" Class="mx-2">Catalogue</MudLink>
     </MudAppBar>
     <MudMainContent>

--- a/src/CaptainOfIndustry/Web/Components/Pages/Planner.razor
+++ b/src/CaptainOfIndustry/Web/Components/Pages/Planner.razor
@@ -1,0 +1,119 @@
+@page "/planner"
+@using ERP.Application
+@using ERP.Application.Queries.PlanProduction
+@using ERP.Domain
+@inject ICatalogProvider Catalog
+@inject IRecipePlanner RecipePlanner
+
+<PageTitle>Planner — CoI</PageTitle>
+
+<h1>Planner</h1>
+
+@if (!Catalog.IsLoaded)
+{
+    <MudAlert Severity="Severity.Warning">No catalogue loaded — see the home page.</MudAlert>
+    return;
+}
+
+<MudGrid Spacing="2" Class="mb-4">
+    <MudItem xs="12" md="6">
+        <MudAutocomplete T="Item"
+                         @bind-Value="_target"
+                         Label="What do you want to produce?"
+                         SearchFunc="SearchItems"
+                         ToStringFunc="@(i => i is null ? "" : $"{i.Name} ({i.Id.Value})")"
+                         Variant="Variant.Outlined"
+                         Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="6" md="3">
+        <MudNumericField T="decimal"
+                         @bind-Value="_ratePerMinute"
+                         Label="Items / min"
+                         Min="0.01m" Step="1m"
+                         Variant="Variant.Outlined"
+                         Margin="Margin.Dense" />
+    </MudItem>
+    <MudItem xs="6" md="3" Class="d-flex align-end">
+        <MudButton OnClick="RunPlan" Disabled="@(_target is null)"
+                   Variant="Variant.Filled" Color="Color.Primary" FullWidth="true">
+            Plan
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@if (_plan is not null)
+{
+    <MudText Typo="Typo.h6" Class="mb-2">
+        @(_plan.IsFeasible ? "Plan" : "Plan (incomplete — see missing inputs)")
+    </MudText>
+
+    @if (_plan.Steps.Count == 0)
+    {
+        <MudAlert Severity="Severity.Warning">No recipes found that produce this item.</MudAlert>
+    }
+    else
+    {
+        <MudTable Items="_plan.Steps" Dense="true" Hover="true" Bordered="false">
+            <HeaderContent>
+                <MudTh>Recipe</MudTh>
+                <MudTh>Building</MudTh>
+                <MudTh Style="text-align: right;">Count</MudTh>
+                <MudTh Style="text-align: right;">Power (MW)</MudTh>
+                <MudTh>Inputs / min</MudTh>
+                <MudTh>Outputs / min</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>@context.Recipe.Name</MudTd>
+                <MudTd>@context.Recipe.Building.Value</MudTd>
+                <MudTd Style="text-align: right;">@context.BuildingCount.ToString("0.##")</MudTd>
+                <MudTd Style="text-align: right;">@context.PowerMw.ToString("0.##")</MudTd>
+                <MudTd>@FormatAmounts(context.InputsPerMinute)</MudTd>
+                <MudTd>@FormatAmounts(context.OutputsPerMinute)</MudTd>
+            </RowTemplate>
+        </MudTable>
+
+        <MudText Typo="Typo.body2" Class="mt-3">
+            <strong>Total power:</strong> @_plan.Steps.Sum(s => s.PowerMw).ToString("0.##") MW
+            &nbsp;•&nbsp;
+            <strong>Raw inputs:</strong> @FormatAmounts(_plan.RawInputsConsumed)
+        </MudText>
+    }
+
+    @if (!_plan.IsFeasible)
+    {
+        <MudAlert Severity="Severity.Error" Class="mt-3">
+            <strong>Missing inputs:</strong>
+            @foreach (var m in _plan.MissingInputs)
+            {
+                <div>@m.Item.Value: @m.QuantityShort.ToString("0.##") / min — @m.Reason</div>
+            }
+        </MudAlert>
+    }
+}
+
+@code {
+    private Item? _target;
+    private decimal _ratePerMinute = 16;
+    private ProductionPlan? _plan;
+
+    private Task<IEnumerable<Item>> SearchItems(string query, CancellationToken _) =>
+        Task.FromResult(Catalog.Items
+            .Where(i => string.IsNullOrWhiteSpace(query)
+                     || i.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+                     || i.Id.Value.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(50));
+
+    private void RunPlan()
+    {
+        if (_target is null) return;
+        // No availability supplied — the planner reports anything it can't
+        // source as a missing input, which is exactly what we want to show.
+        _plan = RecipePlanner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(_target.Id, _ratePerMinute)],
+            Available: []));
+    }
+
+    private static string FormatAmounts(IEnumerable<ItemAmount> amounts) =>
+        string.Join(", ", amounts.Select(a => $"{a.Quantity.ToString("0.##")}× {a.Item.Value}"));
+}

--- a/src/CaptainOfIndustry/Web/Program.cs
+++ b/src/CaptainOfIndustry/Web/Program.cs
@@ -1,6 +1,7 @@
 using CaptainOfIndustry.Web.Components;
 using CaptainOfIndustry.Catalog;
 using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using MudBlazor.Services;
@@ -22,6 +23,11 @@ builder.Services.Configure<CoiCatalogueOptions>(
     builder.Configuration.GetSection("Catalogue:CaptainOfIndustry"));
 builder.Services.AddSingleton<ICatalogProvider>(sp =>
     new JsonCoiCatalogProvider(sp.GetRequiredService<IOptions<CoiCatalogueOptions>>().Value));
+
+// Planner: in-process. RecursiveRecipePlanner is the cheap default that
+// matches the Satisfactory app's v1 surface; the LP planner (#88) requires
+// OR-Tools and is wired through ERP.Infrastructure which we don't pull in.
+builder.Services.AddSingleton<IRecipePlanner, RecursiveRecipePlanner>();
 
 var app = builder.Build();
 

--- a/test/CaptainOfIndustry/Catalog.Tests/PlannerSmokeTests.cs
+++ b/test/CaptainOfIndustry/Catalog.Tests/PlannerSmokeTests.cs
@@ -1,0 +1,168 @@
+using ERP.Application;
+using ERP.Application.Queries.PlanProduction;
+using ERP.Domain;
+
+namespace CaptainOfIndustry.Catalog.Tests;
+
+/// <summary>
+/// The e2e proof for the milestone (#182): wire the JsonCoiCatalogProvider
+/// (CoI module) into the planner core (ERP.Application) and confirm a real
+/// production target resolves to a sensible recipe graph. If this test ever
+/// flips red, the "planner is genuinely game-agnostic" claim from ADR-0022
+/// has regressed — investigate the catalogue mapping, not the planner.
+/// </summary>
+public class PlannerSmokeTests : IDisposable
+{
+    private readonly string? _originalEnv;
+    private readonly string _tempDir;
+
+    public PlannerSmokeTests()
+    {
+        _originalEnv = Environment.GetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable);
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, null);
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(CoiCataloguePathResolver.EnvironmentVariable, _originalEnv);
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    // CoI internal-unit reminder: quantity 50 = 1 visual item / 1 belt slot in
+    // game. The planner doesn't care about absolute units — it works in
+    // "items/min" purely as ratios — so the smoke uses CoI's raw quantities
+    // verbatim. Production UI is the layer that picks user-friendly units.
+    private const string MillingChain = """
+        {
+          "extractorVersion": "0.4.0.0",
+          "coiVersion": "0.8.4.0",
+          "extractedAt": "2026-05-21T00:00:00+00:00",
+          "items": [
+            { "id": "Product_Wheat", "name": "Wheat", "kind": "Loose", "isStorable": true, "isWaste": false, "radioactivity": 0 },
+            { "id": "Product_Flour", "name": "Flour", "kind": "Loose", "isStorable": true, "isWaste": false, "radioactivity": 0 },
+            { "id": "Product_Bread", "name": "Bread", "kind": "Countable", "isStorable": true, "isWaste": false, "radioactivity": 0 },
+            { "id": "Product_AnimalFeed", "name": "Animal feed", "kind": "Loose", "isStorable": true, "isWaste": false, "radioactivity": 0 }
+          ],
+          "buildings": [
+            { "id": "FoodMill", "name": "Food mill", "electricityKw": 200, "recipes": ["WheatMilling"] },
+            { "id": "Bakery",   "name": "Bakery",    "electricityKw": 100, "recipes": ["BreadProduction"] }
+          ],
+          "recipes": [
+            {
+              "id": "WheatMilling",
+              "name": "Wheat milling",
+              "building": "FoodMill",
+              "durationTicks": 300,
+              "inputs":  [{ "productId": "Product_Wheat", "quantity": 8 }],
+              "outputs": [
+                { "productId": "Product_Flour",      "quantity": 8 },
+                { "productId": "Product_AnimalFeed", "quantity": 1 }
+              ]
+            },
+            {
+              "id": "BreadProduction",
+              "name": "Bread making",
+              "building": "Bakery",
+              "durationTicks": 300,
+              "inputs":  [{ "productId": "Product_Flour", "quantity": 4 }],
+              "outputs": [{ "productId": "Product_Bread", "quantity": 2 }]
+            }
+          ],
+          "warnings": []
+        }
+        """;
+
+    private (JsonCoiCatalogProvider catalog, RecursiveRecipePlanner planner) BuildPlanner(string json)
+    {
+        var path = Path.Combine(_tempDir, "cat.json");
+        File.WriteAllText(path, json);
+        var catalog = new JsonCoiCatalogProvider(new CoiCatalogueOptions { CataloguePath = path });
+        var planner = new RecursiveRecipePlanner(catalog);
+        return (catalog, planner);
+    }
+
+    [Fact]
+    public void Plans_Bread_Production_With_Both_Steps()
+    {
+        var (_, planner) = BuildPlanner(MillingChain);
+
+        // Each cycle: 300 ticks @ 40/s = 7.5s -> 8 cycles/min -> 16 bread/min.
+        // Target 16 bread/min should call for exactly 1 Bakery + 1 FoodMill.
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(new ItemId("Product_Bread"), 16)],
+            Available: [new ResourceAvailability(new ItemId("Product_Wheat"), 9999)]));
+
+        Assert.True(plan.IsFeasible);
+        Assert.Equal(2, plan.Steps.Count);
+
+        var bread = plan.Steps.Single(s => s.Recipe.Id == new RecipeId("BreadProduction"));
+        Assert.Equal(new BuildingId("Bakery"), bread.Recipe.Building);
+        Assert.Equal(1m, bread.BuildingCount);
+        Assert.Equal(0.1m, bread.PowerMw); // 100 kW -> 0.1 MW
+
+        var milling = plan.Steps.Single(s => s.Recipe.Id == new RecipeId("WheatMilling"));
+        Assert.Equal(new BuildingId("FoodMill"), milling.Recipe.Building);
+        Assert.Equal(0.5m, milling.BuildingCount); // 32 flour/min produced @ full speed; we need 16, so half a mill.
+        Assert.Equal(0.1m, milling.PowerMw); // 200 kW * 0.5 = 0.1 MW
+    }
+
+    [Fact]
+    public void Surfaces_Missing_Raw_Inputs()
+    {
+        var (_, planner) = BuildPlanner(MillingChain);
+
+        // No wheat available — should flag Product_Wheat as missing.
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(new ItemId("Product_Bread"), 16)],
+            Available: []));
+
+        Assert.False(plan.IsFeasible);
+        Assert.Contains(plan.MissingInputs, m => m.Item == new ItemId("Product_Wheat"));
+    }
+
+    [Fact]
+    public void Multi_Output_Recipe_Powers_Both_Sinks()
+    {
+        var (_, planner) = BuildPlanner(MillingChain);
+
+        // Wheat milling produces flour AND animal feed. Asking for Animal feed
+        // should land on the same recipe — proving multi-output linkage works.
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(new ItemId("Product_AnimalFeed"), 8)],
+            Available: [new ResourceAvailability(new ItemId("Product_Wheat"), 9999)]));
+
+        Assert.True(plan.IsFeasible);
+        var milling = Assert.Single(plan.Steps);
+        Assert.Equal(new RecipeId("WheatMilling"), milling.Recipe.Id);
+        // WheatMilling: 7.5s/cycle = 8 cycles/min; 1 animal feed/cycle = 8/min/mill.
+        // Asking for 8 feed/min lands on exactly 1.0 mill (flour byproduct is excess).
+        Assert.Equal(1m, milling.BuildingCount);
+    }
+
+    [Fact]
+    public void Smoke_Against_Real_Extracted_Catalogue_If_Present()
+    {
+        var defaultPath = CoiCataloguePathResolver.DefaultPath;
+        if (!File.Exists(defaultPath))
+        {
+            // No real catalogue on this machine — silent no-op. Mirrors
+            // RealCatalogueSmokeTests' pattern: local-only safety net, not a CI gate.
+            return;
+        }
+
+        var catalog = new JsonCoiCatalogProvider(new CoiCatalogueOptions { CataloguePath = defaultPath });
+        var planner = new RecursiveRecipePlanner(catalog);
+
+        // WheatMilling is a stable vanilla CoI recipe with a well-known output
+        // (Flour). If this ever flips red, either the extractor's mapping
+        // changed or Mafi renamed it — investigate before mutating the test.
+        var plan = planner.Plan(new PlanProductionQuery(
+            Targets: [new ProductionTarget(new ItemId("Product_Flour"), 100)],
+            Available: [new ResourceAvailability(new ItemId("Product_Wheat"), 99999)]));
+
+        Assert.NotEmpty(plan.Steps);
+        Assert.Contains(plan.Steps, s => s.Recipe.Id == new RecipeId("WheatMilling"));
+    }
+}


### PR DESCRIPTION
Closes #182.

The headline proof of ADR-0022: ERP.Application's `RecursiveRecipePlanner` runs against the CoI `JsonCoiCatalogProvider` with zero Satisfactory-specific code, produces a sensible plan, and surfaces missing inputs correctly.

## Summary

- **`PlannerSmokeTests.cs`** — 4 xUnit tests in the CoI catalog test project:
  1. 2-step chain (Wheat → WheatMilling → Flour → BreadProduction → Bread) — asserts both steps register, building counts are correct (16 bread/min → 1 bakery + 0.5 mill), kW→MW power conversion at the ingestion seam.
  2. Missing raw input → planner reports `InfeasibleItem`, doesn't throw.
  3. Multi-output recipe (Wheat milling produces flour + animal feed) — both outputs resolvable, asking for either lands on the same recipe.
  4. Real-data smoke against the locally-extracted catalogue if present, no-ops on CI.

- **`Planner.razor`** — interactive page in the CoI Web app. `MudAutocomplete` picks an item from the loaded catalogue, numeric field sets target items/min, button runs `IRecipePlanner.Plan` and renders the steps table + missing-inputs diagnostic. Wired into the nav.

- **`Program.cs`** — `IRecipePlanner` registered as `RecursiveRecipePlanner` (the LP planner #88 requires OR-Tools via `ERP.Infrastructure` which the CoI app deliberately doesn't pull in — keeps the dep graph small and the apps isolated per ADR-0022).

## Smoke against real CoI 0.8.4 (227 items / 494 recipes)

Drove the Planner page with Playwright. Asked: **16 Flour/min**.

Got: `0.25× FoodMill running Wheat milling, 0.03 MW, consuming 16× Product_Wheat, producing 16× Product_Flour + 2× Product_AnimalFeed`. Marked incomplete with the diagnostic *"No recipe produces Wheat. Short 16/min — raise the AvailableInputs cap or substitute downstream."* — which is exactly right: Wheat comes from farms in-game, and farms aren't `MachineProto` so they fall outside the recipe graph as expected.

## No contract changes needed

ADR-0022 left open the question of whether `ICatalogProvider` needed widening for CoI (multi-output recipes, unlock prereqs, etc.). Answer from this work: **no**. The existing contract handled multi-output recipes, varied building power, 494 recipes, all without modification. Closing the question for v1 — if the LP planner uncovers a real mismatch later, that's the place an ADR amendment can land.

## Test plan

- [x] 20 tests passing in `CaptainOfIndustry.Catalog.Tests` (16 pre-existing + 4 new).
- [x] `dotnet build ErpForFactoryGames.slnx` → 0 errors.
- [x] `dotnet format --verify-no-changes` → clean.
- [x] Playwright drive of `/planner` against real catalogue → renders correctly with sensible plan.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)