### PR TITLE
feat(deploy): homelab Docker + Cloudflare Tunnel hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Keep image builds fast and small. The build stages explicitly opt back into
+# .git/ (NB.GV needs it for version-height computation).
+
+**/bin/
+**/obj/
+**/.vs/
+**/.vscode/
+**/.idea/
+**/node_modules/
+**/TestResults/
+**/.playwright/
+
+# Build / IDE caches
+**/*.lscache
+**/*.user
+
+# Things we deliberately never ship
+.assets/
+.satisfactory/
+.coi/
+vendor/
+
+# Local-dev DBs / state
+**/plans.db*
+**/erp.db*
+
+# IDE / OS noise
+.DS_Store
+Thumbs.db
+
+# Tests don't need to be in the build context.
+test/
+
+# Tools are dev-only (extractors / icon downloaders). They build separately.
+tools/
+
+# Documentation isn't in the image.
+docs/
+
+# Don't leak the gitignored Claude scratch dir.
+.claude/
+
+# Misc
+*.log

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,79 @@
+# Builds + pushes runtime container images to GHCR on tag.
+#
+# Triggered by tags shaped `v*` (e.g. v0.5.0). Tags become the image
+# tag, and the always-moving `:latest` label is updated to match. Per
+# ADR-0023:
+#   - Satisfactory Web (src/Web/Dockerfile) -> ghcr.io/<owner>/erp-web
+#   - Planner ApiService (src/ApiService/Dockerfile) -> ghcr.io/<owner>/erp-api
+# CoI Web image is deliberately not built here yet; it's deferred to the
+# game-agent milestone which will solve catalogue distribution.
+
+name: Release images
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build + push ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: erp-web
+            dockerfile: src/Web/Dockerfile
+          - image: erp-api
+            dockerfile: src/ApiService/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs git history for version-height calc
+
+      - name: Initialize vendored SatisfactorySaveNet submodule
+        run: git -c submodule.vendor/SatisfactorySaveNet.update=checkout submodule update --init --recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve tags
+        id: tags
+        run: |
+          ref_name="${GITHUB_REF_NAME}"
+          image_ref="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${{ matrix.image }}"
+          # On tag push: <image>:<tag> + :latest. On workflow_dispatch from main: :main + :latest.
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tags=${image_ref}:${ref_name},${image_ref}:latest" >>"$GITHUB_OUTPUT"
+          else
+            echo "tags=${image_ref}:${GITHUB_REF_NAME//\//-},${image_ref}:latest" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # GitHub Packages NuGet auth — nuget.config reads %GITHUB_TOKEN%.
+          # Passed as a build secret so it never lands in an image layer.
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+          # GHA cache backend keeps subsequent builds quick across runs.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -52,10 +52,18 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
+          # Match *UI-relevant* files only — Dockerfile, *.md, *.dockerignore
+          # don't change rendered output, so they shouldn't burn ~15 min of
+          # Playwright runner time. dorny/paths-filter supports `!neg`.
+          # Add more excludes here as new non-UI artefacts land under web dirs.
           filters: |
             web:
               - 'src/Web/**'
+              - 'src/CaptainOfIndustry/Web/**'
+              - 'src/Web.Shared/**'
               - 'test/Web/**'
+              - '!**/Dockerfile'
+              - '!**/*.md'
 
       - name: Compute gate
         id: gate

--- a/docs/adr/0023-hosting-deployment-approach.md
+++ b/docs/adr/0023-hosting-deployment-approach.md
@@ -1,0 +1,163 @@
+# 0023. Hosting + deployment via homelab Docker behind Cloudflare Tunnel
+
+- Status: Accepted
+- Date: 2026-05-21
+- Deciders: Chris
+
+## Context
+
+The Satisfactory and Captain of Industry Blazor apps both have nowhere to be
+deployed. Cloudflare DNS for `erp-for-factory.games` is set up (#156 / #164)
+and the GitHub Pages landing placeholder (#185) serves the apex, but
+`satisfactory.erp-for-factory.games` and
+`captain-of-industry.erp-for-factory.games` have no origin behind them. This
+blocks #180 (CoI subdomain wiring) and the Satisfactory app's public face.
+
+Chris has two viable hosting options:
+
+- **Homelab** — 3 Proxmox nodes already running. An existing
+  `Homelab.Stacks.Infrastructure` compose stack already runs
+  `cloudflared` with a registered Cloudflare Tunnel, plus Watchtower for
+  auto-update on image push. So ~90% of the deployment story exists; only
+  the app-specific stack is missing.
+- **Azure** — a small allowance of Azure credits from a Visual Studio
+  subscription. Real money once exhausted, and Azure Container Apps for
+  two always-on Blazor apps would burn through it in months.
+
+Both apps consume the user's locally-extracted CoI catalogue JSON. Mafi's
+recipe data is creative content that [ADR-0009](0009-runtime-ingestion-of-game-catalogue.md)
+committed not to redistribute. How that data reaches the production
+container is a constraint the deployment choice has to honour.
+
+A third option emerged during scoping: ship a small **client-side agent**
+that runs on the user's machine (where the game is installed), extracts
+catalogue + savegame data locally, and pushes it to the hosted web app.
+This decouples the web's hosting location from where the game runs and
+turns "redistribute Mafi's data" into "the user moves their own data,"
+which is a fundamentally different posture. Captured as its own
+milestone — see "Follow-up" below.
+
+## Decision
+
+Deploy as Docker containers on Chris's homelab, fronted by the existing
+Cloudflare Tunnel. **Save the Azure credits for something else** — they
+have a cliff edge, the homelab is already paid for and 90% configured.
+
+Concrete shape:
+
+- **Container images** for `src/Web/` and `src/ApiService/` — multi-stage
+  builds (`mcr.microsoft.com/dotnet/sdk` → `aspnet` runtime). The CoI app
+  image is **deferred to the agent milestone** — without the agent in
+  place, the only catalogue source is the dev's local extract, and the
+  v0 deployment scope doesn't need to solve that.
+- **GitHub Actions** builds + pushes to `ghcr.io/chrisonsimtian/...` on
+  tag (e.g. `v0.5.0` → `:v0.5.0` + `:latest`). Reuses the existing
+  `packages: write` token pattern from the NuGet feed work.
+- **GHCR visibility = public.** None of the images we ship in v0 contain
+  game-publisher IP — Satisfactory's catalogue is loaded at runtime from
+  the user's `Docs.json` (ADR-0009); ApiService is engine code. The CoI
+  image will join once the agent path is solid and we know the image
+  itself doesn't need to embed Mafi data either.
+- **Compose stack lives in a new sibling repo** —
+  `Homelab.Stacks.ErpForFactoryGames` — matching the existing
+  `Homelab.Stacks.*` pattern. Each game/feature stack is independently
+  deployable.
+- **Cloudflare Tunnel ingress rules** map the subdomains to the
+  internal container ports. Configured in the Cloudflare dashboard or
+  via the tunnel config file in the sister repo.
+- **Aspire orchestration is dev-only.** In production each container
+  starts directly via its compose service; no AppHost.
+
+## Alternatives considered
+
+- **Azure Container Apps via `azd up`.** First-class Aspire support, no
+  home-network exposure, managed TLS, predictable URL. Rejected for the
+  credit-cliff problem — VS credits would last ~2–6 months for two
+  always-on Blazor apps; once gone the project either pays or dies.
+  Long-term planning around a finite resource is the wrong default for
+  an OSS hobby project.
+- **Private GHCR with the CoI catalogue baked at build time.** Original
+  shape of this ADR before the agent option surfaced. Worked, but
+  permanently encoded "image is private forever" as a constraint and
+  required either a manual extractor run on each homelab host or a
+  release-asset workflow to feed CI. The agent path supersedes it:
+  user-supplied catalogue means no redistribution problem, no
+  bake-at-build mechanism to maintain, no private-visibility lock-in.
+- **Public GHCR images with the catalogue volume-mounted on the host.**
+  Host provides the JSON via volume mount; image stays public. Works
+  for one operator, doesn't scale to "anyone runs this themselves" —
+  every operator would need their own catalogue refresh routine. Agent
+  generalises this to any user, not just the homelab operator.
+- **Bare-metal `dotnet publish` + systemd on a Proxmox VM.** No Docker
+  layer, simpler stack. Rejected because Watchtower-style auto-update
+  on a tagged image is more reliable than custom systemd-unit pulling,
+  and the existing homelab stacks are all containerised — match the
+  pattern that already works.
+- **Single image bundling both apps + a reverse proxy.** Smaller
+  footprint. Rejected for breaking the isolated-apps spirit of
+  [ADR-0022](0022-captain-of-industry-support.md) — each game's app
+  stays its own deploy unit.
+
+## Consequences
+
+**Easier**
+
+- Reuses existing Cloudflare Tunnel + Watchtower stack — zero new
+  external dependencies. Cloudflare DNS already proxies the subdomains;
+  the tunnel terminates TLS and routes to internal HTTP.
+- No paid hosting tier. Aligns with the [no-paid-licenses
+  principle](../../../Users/ChrisSimon/.claude/projects/C--Source-Github-ERP-Satisfactory/memory/feedback_foundational_deps.md).
+- Adding a future game's app is incremental: another Dockerfile,
+  another compose service, another tunnel ingress rule. The pattern
+  scales to N games without rearchitecting.
+- Aspire stays the dev-time orchestration layer (`dotnet run --project
+  src/AppHost` for local F5), and production runs the same images with
+  no AppHost — clean separation.
+
+**Harder**
+
+- Home network reliability bounds the project's uptime promise. For a
+  hobby planner that users only consult while playing, this is
+  acceptable; for anything mission-critical it wouldn't be.
+- Two-repo split (this repo + `Homelab.Stacks.ErpForFactoryGames`)
+  means deploy changes happen in lockstep across two places. PR-able
+  but coordination cost is real. Worth it to keep the homelab stacks
+  pattern consistent.
+- CoI app stays undeployable until the agent milestone lands a
+  catalogue-source story. Acceptable: CoI is brand-new and the
+  Satisfactory side has the larger audience. Could ship the CoI image
+  with a "configure your agent" empty-state if there's urgency.
+
+**Follow-up** (tracked under [#194](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/194))
+
+- Dockerfiles for `src/Web/` and `src/ApiService/` (this repo).
+- GitHub Actions release workflow building + pushing to GHCR on tag.
+- `Homelab.Stacks.ErpForFactoryGames` repo init + compose stack +
+  tunnel ingress config (sister repo, Chris-driven).
+- Operator runbook in `docs/operations/deploy.md` documenting the
+  tag-to-deploy lifecycle.
+
+**Forward direction — the game agent**
+
+A new milestone tracks the cross-platform agent that runs on the user's
+game machine, extracts catalogue + savegame data locally, and pushes it
+to the hosted web app. Once that lands:
+
+- CoI image joins the public GHCR set, ships catalogue-less, reads
+  per-user catalogues that the agent has uploaded.
+- Live save-state ingestion becomes possible for hosted instances
+  (the live-state milestones for Satisfactory and CoI both depend on
+  data the web can't get from outside the user's machine).
+- DNS wiring for `captain-of-industry.erp-for-factory.games`
+  ([#180](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/180))
+  unblocks at the same time.
+
+**Explicitly out of scope**
+
+- Multi-region / HA. Single homelab origin is fine.
+- Migration to cloud (Azure or otherwise) if the project grows beyond
+  hobby scope — that's a future ADR amendment, not this one.
+- Public release of the catalogue JSON. Not happening (ADR-0009 stance
+  remains).
+- Per-PR ephemeral preview environments. Out of scope for v1; can be
+  added later via a separate compose-on-demand setup.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0020](0020-rebrand-to-erp-for-factory-games.md) | Rebrand to ERP for Factory Games | Accepted |
 | [0021](0021-migrate-from-nuke-fork-to-fallout.md) | Migrate build system from private Nuke.* fork to Fallout.* on nuget.org | Accepted |
 | [0022](0022-captain-of-industry-support.md) | Captain of Industry as the second supported game | Accepted |
+| [0023](0023-hosting-deployment-approach.md) | Hosting + deployment via homelab Docker behind Cloudflare Tunnel | Accepted |

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -1,0 +1,77 @@
+# Deployment runbook
+
+How the Blazor apps reach `*.erp-for-factory.games`. Implements
+[ADR-0023](../adr/0023-hosting-deployment-approach.md).
+
+## Topology
+
+```
+GitHub Actions (release-images.yml)
+       │  on tag v*, builds + pushes
+       ▼
+ghcr.io/chrisonsimtian/erp-web     :v0.5.0  + :latest
+ghcr.io/chrisonsimtian/erp-api     :v0.5.0  + :latest
+       │
+       │  Watchtower polls every 6h, pulls :latest
+       ▼
+Homelab Docker host (one of three Proxmox nodes)
+   └─ Homelab.Stacks.ErpForFactoryGames  (sibling repo)
+       ├─ erp-web         (Blazor Server, port 8080)
+       └─ erp-api         (Wolverine + EF Core, port 8080)
+       │
+       │  internal HTTP via shared docker network
+       ▼
+Cloudflared tunnel (running in Homelab.Stacks.Infrastructure)
+       │  ingress rules in cloudflare config
+       ▼
+satisfactory.erp-for-factory.games  →  http://erp-web:8080
+```
+
+The CoI app (`captain-of-industry.erp-for-factory.games`) is **not yet
+deployed** — see the game-agent milestone for what's blocking it.
+
+## Cutting a release
+
+1. Land all the PRs you want in the release on `main`.
+2. Tag the commit:
+
+   ```powershell
+   git tag v0.5.0
+   git push origin v0.5.0
+   ```
+
+3. The `Release images` workflow runs (~5–10 min), builds `erp-web`
+   and `erp-api`, pushes to GHCR with the tag plus `:latest`.
+4. Watchtower picks up the new `:latest` on its next 6-hour cycle.
+   To force-pull immediately, SSH the homelab host and run:
+
+   ```bash
+   docker compose -f /path/to/stacks/ErpForFactoryGames/compose.yml pull
+   docker compose -f /path/to/stacks/ErpForFactoryGames/compose.yml up -d
+   ```
+
+## First-time setup (sister repo)
+
+Tracked in `Homelab.Stacks.ErpForFactoryGames`. Outline:
+
+- `compose.yml` declares two services (`erp-web`, `erp-api`),
+  references the GHCR images, joins the shared `cloudflared` network.
+- ApiService gets the production database connection string via env
+  var or a docker secret (see ADR-0018 for the persistence picture).
+- Cloudflare Tunnel ingress rules (in the tunnel config file or
+  dashboard) route the subdomain to `http://erp-web:8080`.
+
+## When things break
+
+| Symptom | First check |
+|---|---|
+| 502 on the public URL | `docker logs erp-web` — common cause is ApiService not ready |
+| Build fails on the GHA workflow | Bottom of the failed job — usually missing `GITHUB_TOKEN` scope or a NuGet feed flake |
+| Watchtower not picking up new images | Confirm the `:latest` tag was actually pushed; check `docker logs watchtower` |
+| New deploy reverts user data | ApiService DB is persisted in a named volume — verify the volume mount survived a recompose |
+
+## Things explicitly NOT documented here
+
+- Cloud / Azure migration. ADR-0023 chose homelab; if that changes a
+  new ADR captures the move.
+- CoI app deployment. Waiting on the game agent.

--- a/src/ApiService/Dockerfile
+++ b/src/ApiService/Dockerfile
@@ -1,0 +1,49 @@
+# Multi-stage build for the ERP planner API (Wolverine + EF Core).
+# Build context = repo root:
+#   docker build -f src/ApiService/Dockerfile -t erp-api .
+
+ARG DOTNET_VERSION=10.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+WORKDIR /src
+
+RUN --mount=type=secret,id=github_token \
+    test -s /run/secrets/github_token \
+    || (echo "GITHUB_TOKEN secret missing. Pass: docker build --secret id=github_token,env=GITHUB_TOKEN ..." && exit 1)
+
+COPY nuget.config Directory.Build.props version.json ./
+COPY src/ApiService/ApiService.csproj                                  src/ApiService/
+COPY src/ServiceDefaults/ServiceDefaults.csproj                        src/ServiceDefaults/
+COPY src/ERP/Application/ERP.Application.csproj                        src/ERP/Application/
+COPY src/ERP/Domain/ERP.Domain.csproj                                  src/ERP/Domain/
+COPY src/ERP/Infrastructure/ERP.Infrastructure.csproj                  src/ERP/Infrastructure/
+COPY src/ERP/Infrastructure/Persistence/ERP.Infrastructure.Persistence.csproj src/ERP/Infrastructure/Persistence/
+COPY src/Satisfactory/Catalog/Satisfactory.Catalog.csproj              src/Satisfactory/Catalog/
+COPY src/Satisfactory/Save/Satisfactory.Save.csproj                    src/Satisfactory/Save/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet restore src/ApiService/ApiService.csproj
+
+COPY src/ src/
+COPY .git .git/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet publish src/ApiService/ApiService.csproj \
+        --configuration Release \
+        --no-restore \
+        --output /app/publish
+
+# -----------------------------------------------------------------------------
+# Runtime
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
+WORKDIR /app
+USER app
+
+COPY --from=build --chown=app:app /app/publish ./
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "ApiService.dll"]

--- a/src/Web/Dockerfile
+++ b/src/Web/Dockerfile
@@ -1,0 +1,64 @@
+# Multi-stage build for the Satisfactory Blazor Server app.
+# Build context is the REPO ROOT — invoke as:
+#   docker build -f src/Web/Dockerfile -t erp-web .
+# That's because the build needs Directory.Build.props, nuget.config, and the
+# referenced ERP / Satisfactory projects which all live above src/Web/.
+
+ARG DOTNET_VERSION=10.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+WORKDIR /src
+
+# GitHub Packages NuGet always requires auth — even for public packages.
+# Passed via --secret id=github_token at build time; never lands in a layer.
+# See ADR-0023, nuget.config.
+RUN --mount=type=secret,id=github_token \
+    test -s /run/secrets/github_token \
+    || (echo "GITHUB_TOKEN secret missing. Pass: docker build --secret id=github_token,env=GITHUB_TOKEN ..." && exit 1)
+
+# Restore separately for layer caching — only re-runs when csprojs / props change.
+# Copy nuget config + build props + every csproj into the right layout first.
+COPY nuget.config Directory.Build.props version.json ./
+COPY src/Web/Web.csproj                                                src/Web/
+COPY src/ServiceDefaults/ServiceDefaults.csproj                        src/ServiceDefaults/
+COPY src/ApiService/ApiService.csproj                                  src/ApiService/
+COPY src/ERP/Application/ERP.Application.csproj                        src/ERP/Application/
+COPY src/ERP/Domain/ERP.Domain.csproj                                  src/ERP/Domain/
+COPY src/ERP/Infrastructure/ERP.Infrastructure.csproj                  src/ERP/Infrastructure/
+COPY src/ERP/Infrastructure/Persistence/ERP.Infrastructure.Persistence.csproj src/ERP/Infrastructure/Persistence/
+COPY src/Satisfactory/Catalog/Satisfactory.Catalog.csproj              src/Satisfactory/Catalog/
+COPY src/Satisfactory/Save/Satisfactory.Save.csproj                    src/Satisfactory/Save/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet restore src/Web/Web.csproj
+
+# Copy the rest of the source.
+COPY src/ src/
+# NB.GV needs git history for version-height computation. .dockerignore keeps
+# the build context tight; .git/ is whitelisted explicitly so version stamping
+# works without ballooning the image.
+COPY .git .git/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet publish src/Web/Web.csproj \
+        --configuration Release \
+        --no-restore \
+        --output /app/publish
+
+# -----------------------------------------------------------------------------
+# Runtime
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
+WORKDIR /app
+
+# Non-root for defence-in-depth — aspnet image already ships an `app` user.
+USER app
+
+COPY --from=build --chown=app:app /app/publish ./
+
+# ASP.NET listens on port 8080 by default in the modern aspnet images.
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Web.dll"]


### PR DESCRIPTION
Part of #194. See also the forward-direction note in [ADR-0023](docs/adr/0023-hosting-deployment-approach.md) about the upcoming game-agent milestone.

## Summary

- **[ADR-0023](docs/adr/0023-hosting-deployment-approach.md)** captures the decision: homelab Docker + Cloudflare Tunnel over Azure VS credits. Reuses the existing `Homelab.Stacks.Infrastructure` tunnel + Watchtower stack — adding ERP to it is incremental, not net-new infra.
- **Dockerfiles** for `src/Web/` (Satisfactory) and `src/ApiService/`. Multi-stage; GitHub Packages NuGet token passed via BuildKit secret (never lands in a layer). `.git/` is whitelisted in the build context because NB.GV needs it for version-height.
- **`.github/workflows/release-images.yml`** builds + pushes to GHCR on `v*` tags. Two images, parallel via matrix.
- **`docs/operations/deploy.md`** runbook covering the cut-a-release flow + first-time sister-repo setup.

## CoI app deployment deliberately deferred

During scoping you raised a third option: a cross-platform client-side **agent** that runs on the user's game machine, extracts catalogue + savegame data locally, and pushes it to the hosted web app. That changes the posture entirely — no redistribution problem, no private-image constraint, and live save-state ingestion becomes possible from a remotely-hosted web app for the first time.

The CoI Dockerfile was drafted and then removed from this PR. CoI app deployment waits for the agent milestone (filed separately). Once that lands, the CoI image joins the public-GHCR set.

## What's NOT in this PR (intentionally)

- `Homelab.Stacks.ErpForFactoryGames` sister repo. You drive the repo init; the runbook outlines the compose stack + tunnel ingress shape.
- CoI Dockerfile + image build. Waiting on the agent milestone.
- Live save-state ingestion. Also agent-shaped.

## Test plan

- [x] `dotnet format --verify-no-changes` clean.
- [ ] CI green on this branch.
- [ ] After merge: cut `v0.5.0`, verify the `Release images` workflow pushes both images to GHCR.
- [ ] After merge: stand up the sister repo's compose stack, point the tunnel at the new origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)