### PR TITLE
docs(adr): add 0024 game agent v1 PoC shape

### DIFF
--- a/docs/adr/0024-agent-v1-shape.md
+++ b/docs/adr/0024-agent-v1-shape.md
@@ -1,0 +1,293 @@
+# 0024. Game agent v1 PoC — shape, wire protocol, distribution
+
+- Status: Accepted
+- Date: 2026-05-21
+- Deciders: Chris
+
+## Context
+
+[ADR-0023](0023-hosting-deployment-approach.md) chose homelab deployment
+and flagged a client-side **agent** as the strategic answer to the
+"redistribute publisher IP" and "live save data from a remotely-hosted
+web" problems. The agent milestone
+([#17](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/17))
+is the critical path for the 1.0 release
+([#154](https://github.com/ChrisonSimtian/ErpForFactoryGames/pull/154)),
+so we want the v1 PoC small and shippable, not a feature-complete
+distribution engineering project.
+
+This ADR pins the few decisions every issue under #17 depends on, so
+they can land in parallel without re-litigating the basics.
+
+In scope for v1: a headless agent that watches the Satisfactory save
+folder, uploads new/changed `.sav` files to the hosted API, and exposes
+its status through the existing Web UI. No catalogue uploads, no CoI,
+no real auth — just the slimmest thing that closes the loop between the
+user's local game and a remotely-hosted planner.
+
+## Decision
+
+### 1. Hosting model — generic host + `BackgroundService` + per-OS shims
+
+The agent is a single .NET 10 executable built from
+`Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder()`. One
+`BackgroundService` (`SaveFolderWatcher`) does the work; everything
+else is DI plumbing.
+
+Per-OS service registration uses the standard hosting shims:
+
+- `UseWindowsService()` — when the binary is launched by the Windows
+  service control manager, the host integrates with the SCM lifecycle
+  (start, stop, event-log writes). No-op when launched from a console.
+- `UseSystemd()` — same shape for systemd `Type=notify` units. No-op
+  outside systemd.
+
+Both calls are unconditional. The same binary runs as a console app
+during development, as a Windows service in production, and as a
+systemd unit on Linux — without environment-specific builds.
+
+macOS: the binary still runs (it's .NET 10, cross-platform), but no
+launchd integration in v1. Documented as deferred.
+
+### 2. Logging — `ILogger` with Serilog file sink
+
+Default `ILogger` providers (Console + Debug) cover stdout. For the
+file sink we pull in **Serilog** specifically `Serilog.Extensions.Hosting`
++ `Serilog.Sinks.File`. Bootstrap is one line in `Program.cs`:
+
+```csharp
+builder.Services.AddSerilog((sp, lc) => lc
+    .ReadFrom.Configuration(sp.GetRequiredService<IConfiguration>())
+    .WriteTo.Console()
+    .WriteTo.File(<per-os-path>, rollingInterval: RollingInterval.Day));
+```
+
+Application code only ever sees `ILogger<T>` — Serilog stays at the
+boundary, so swapping it later costs one Program.cs edit.
+
+Log paths (XDG / Microsoft conventions):
+
+- Windows: `%LocalAppData%/ErpForFactoryGames/agent-logs/agent-{Date}.log`
+- Linux: `${XDG_STATE_HOME:-$HOME/.local/state}/ErpForFactoryGames/agent-logs/agent-{Date}.log`
+
+### 3. Save-folder discovery — auto-detect with config override
+
+`SaveFolderResolver` returns the first directory found in this order:
+
+1. `Agent:SaveFolderPath` from configuration (env var
+   `ERP_AGENT_SAVE_FOLDER_PATH` wins via the standard ASP.NET binding).
+2. Windows: `%LocalAppData%/FactoryGame/Saved/SaveGames/` (Steam +
+   Epic on Windows both use this path).
+3. Linux: the Proton path
+   `~/.steam/steam/steamapps/compatdata/526870/pfx/drive_c/users/steamuser/AppData/Local/FactoryGame/Saved/SaveGames/`.
+
+If none resolve to a readable directory, the agent boots in a
+degraded state — watcher disabled, status surfaces "save folder not
+detected", user sets the override and restarts.
+
+### 4. Wire protocol — raw bytes, server-side parse
+
+Upload is `POST {ApiBaseUrl}/agent/savegames/satisfactory`:
+
+- **Body**: raw `.sav` bytes, `Content-Type: application/octet-stream`.
+- **Headers**:
+  - `X-Agent-Token: <opaque-string>` — placeholder auth seam (§5).
+  - `X-Agent-FileName: <name>.sav` — original file name, displayed in
+    the status card. URL-encoded.
+  - `X-Agent-Version: <semver>` — agent version, surfaced in server
+    logs so a future "minimum supported agent" gate can drop in.
+- **Response 200**: `application/json`
+  `{ saveVersion, buildVersion, parsedAt }` (camelCase).
+- **Response 415**: body wasn't a recognisable `.sav` (server-side
+  magic-byte check before invoking `SatisfactorySaveNet`).
+- **Response 422**: parser failed; response body carries the exception
+  type + first line of message.
+
+**Agent does not parse the `.sav`.** It just shuttles bytes. This
+keeps the agent dependency-light (no `SatisfactorySaveNet`, no vendored
+fork to track) and means a save-format change on a new Satisfactory
+patch only needs a server-side update. If we ever need pre-flight
+validation client-side, we can add a thin magic-byte check; full
+parsing stays server-side.
+
+Status query is `GET {ApiBaseUrl}/agent/status` (no body, same
+response shape as the upload's 200 plus an `agentSeen` timestamp and
+an `isStale` flag).
+
+### 5. Auth seam — `X-Agent-Token` header, accepted but unvalidated
+
+Every upload + status request carries `X-Agent-Token`. The v1 server
+accepts any non-empty value (treating it as opaque user identity for
+multi-tenant storage layouts later) and rejects empty/missing values
+with 401. **No validation, no token issuance, no rotation in v1.**
+
+The contract this fixes:
+
+- Token is per-machine (one user, one agent install). Anonymous-per-install
+  is a likely later implementation; this ADR doesn't pick a final scheme.
+- Header name + position are committed: anything other than
+  `X-Agent-Token` would be a breaking protocol change.
+- 401 (not 400 or 403) for missing token, so when real auth lands the
+  status code semantics already match.
+- The agent stores the token in its config file
+  (`agent.json` next to the binary, or
+  `${XDG_CONFIG_HOME}/ErpForFactoryGames/agent.json` on Linux). A
+  follow-up ADR defines how the token gets *into* that file (manual
+  paste, OAuth callback, signup flow…).
+
+### 6. Web UI tech — Razor class library at `src/Web.Shared/`
+
+Decided in the [#200 redirect](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/200):
+the agent doesn't self-host a UI. Status lives in the existing Web app
+as a Razor component (`AgentStatusCard`) in a new
+`src/Web.Shared/` library, consumed by `src/Web/` immediately and
+`src/CaptainOfIndustry/Web/` once a CoI agent path exists.
+
+`Web.Shared` references only `Microsoft.AspNetCore.Components.Web`
+plus the project's domain libraries. **No MudBlazor in the shared
+library's public surface** — components take a styling slot via
+`CssClass` parameters and let each host app re-style with its theme.
+That keeps the option open to swap MudBlazor in either app without
+touching shared code (per
+[ADR-0017](0017-mudblazor-as-ui-framework.md)'s reservation that
+foundational UI deps may shift).
+
+### 7. Distribution — single-file self-contained, GitHub Release zips
+
+`dotnet publish -r {RID} --self-contained -p:PublishSingleFile=true
+-p:IncludeNativeLibrariesForSelfExtract=true`. RIDs shipped in v1:
+
+- `win-x64` — packaged as `erp-agent-win-x64.zip` (binary + install
+  README + `agent.json.example`).
+- `linux-x64` — packaged as `erp-agent-linux-x64.tar.gz` (binary +
+  systemd unit template + install README).
+
+CI builds these on tag (`v*`) and attaches them to the GitHub Release
+alongside the container images from
+[ADR-0023](0023-hosting-deployment-approach.md). Same workflow,
+new matrix rows.
+
+`--install` / `--uninstall` CLI flags handled by the agent itself
+register/deregister the Windows service or systemd unit. Install
+prompts for the API URL on first run if `agent.json` is missing.
+
+### 8. Repo layout — `src/Agent/`
+
+New project sits at `src/Agent/Agent.csproj`, sibling to `src/Web/`
+and `src/ApiService/`. Not orchestrated by Aspire AppHost — the agent
+is a client of the API, not part of the dev orchestration graph.
+
+## Alternatives considered
+
+**Hosting**
+
+- **Worker Service template + `IHost` directly** (no `WebApplication`).
+  Rejected because the original `Localhost UI` idea wanted Kestrel
+  in-process. With the UI moved to the Web app (§6) this option is back
+  on the table, but the cost of `WebApplicationBuilder` over a plain
+  worker host is negligible (~50 ms boot) and the future "add a tiny
+  health endpoint" path stays open without a refactor.
+- **NSSM-wrapped binary on Windows**. Forced an external dep on every
+  user's machine. The hosting-shim approach uses only what ships with
+  the runtime.
+
+**Logging**
+
+- **`Microsoft.Extensions.Logging` default providers only** (no file
+  sink). Loses persistent logs entirely — the moment the service window
+  closes on Windows, all forensic data is gone. Not acceptable.
+- **NLog**. Similar capability profile to Serilog. Chose Serilog for
+  the cleaner Hosting integration; if NLog had been a sunk cost
+  elsewhere in the project we'd have stayed there.
+
+**Wire protocol**
+
+- **Multipart with metadata fields** instead of headers. More
+  HTTP-idiomatic, but multipart parsing adds server-side complexity
+  for no payoff — single-file uploads with sidecar metadata fit headers
+  cleanly. Reconsider if v2 adds multi-file batched uploads.
+- **gRPC**. Cleaner streaming + typed contracts, more upfront tooling.
+  Wrong shape for "occasional file upload" — gRPC shines when you
+  have RPC calls in both directions and benefit from streaming.
+- **Agent pre-parses then ships a JSON payload**. Tighter
+  client-server coupling: every save-format change requires shipping
+  a new agent + server in lockstep. Rejected — server-side parse keeps
+  the agent dumb and patches narrowly scoped.
+
+**Auth seam**
+
+- **Bearer in `Authorization` header**. Hijacks the OAuth-style
+  convention before we've picked an OAuth approach. A custom header
+  signals "this is our protocol's identity field, not RFC 6750" and
+  leaves `Authorization` free for a future OAuth flow.
+- **Token in URL query**. Leaks the token into logs and proxies.
+  Rejected on principle.
+- **mTLS**. Wildly heavy for a hobby agent. Not even on the radar.
+
+**Distribution**
+
+- **Framework-dependent publish** (user installs .NET 10 first).
+  Adds a discoverable failure mode (wrong runtime version) and a
+  cross-platform dependency story we don't want to maintain.
+  Self-contained is bigger (~80 MB per RID) but every user gets a
+  working binary on first download.
+- **MSI / DEB / RPM packages**. Real install UX, but requires
+  signing infrastructure and per-platform tooling. Defer to v2 if
+  there's a real audience past Chris.
+- **Auto-update from a manifest URL**. Important once there are users;
+  defer until then.
+
+## Consequences
+
+**Easier**
+
+- Single binary per OS, same source. Reasoning about behaviour across
+  Windows-service / systemd / console contexts is straightforward.
+- The "shareable component" pattern (`Web.Shared/AgentStatusCard`)
+  graduates lazy [#181](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/181)
+  into a concrete library. Future shared pieces (planner UI? catalogue
+  browser?) have a place to land without rebikeshedding.
+- Server-side parse means a Satisfactory patch only forces a server
+  redeploy, not an agent re-release.
+- Authoring the agent as a thin client (HTTP + file watcher + status)
+  keeps it under ~500 LOC. Easy to reason about, easy to swap.
+
+**Harder**
+
+- Self-contained publishes are ~80 MB each. Acceptable for a
+  GitHub-Releases distribution but worth noting if we ever
+  framework-dependent later.
+- macOS launchd is a known gap. Users on Mac have to start the binary
+  manually for v1.
+- The token-seam-without-validation invites a "we'll fix it later"
+  drift. Mitigate by documenting the contract loudly in code comments
+  + the agent README, and by gating real-data write paths in the API
+  on a future feature flag tied to the auth ADR.
+
+**Follow-up** (each tracked under
+[milestone #17](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/17))
+
+- [#198](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/198)
+  — scaffold `src/Agent/` per §1, §2, §3.
+- [#199](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/199)
+  — API endpoints `POST /agent/savegames/satisfactory` + `GET /agent/status`
+  per §4, §5.
+- [#200](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/200)
+  — `src/Web.Shared/` + `AgentStatusCard` per §6.
+- [#201](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/201)
+  — `--install`/`--uninstall` flags + per-RID GitHub Release zips per §7.
+
+A future ADR-0025 picks the auth scheme (anonymous-per-install vs.
+OAuth vs. magic-link) and replaces the unvalidated `X-Agent-Token`
+acceptance with real validation. Until then, the v1 deployment is
+single-user-shaped on purpose.
+
+## Explicitly out of scope
+
+- Catalogue upload (Satisfactory `Docs.json` or CoI extractor output).
+  Same wire pattern would work; deferred until the save loop ships.
+- CoI saves. Save-file format R&D is a separate undertaking.
+- Real auth, token rotation, multi-user storage.
+- macOS launchd registration.
+- Auto-update of the agent itself.
+- In-game overlay / mod hooks.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0021](0021-migrate-from-nuke-fork-to-fallout.md) | Migrate build system from private Nuke.* fork to Fallout.* on nuget.org | Accepted |
 | [0022](0022-captain-of-industry-support.md) | Captain of Industry as the second supported game | Accepted |
 | [0023](0023-hosting-deployment-approach.md) | Hosting + deployment via homelab Docker behind Cloudflare Tunnel | Accepted |
+| [0024](0024-agent-v1-shape.md) | Game agent v1 PoC — shape, wire protocol, distribution | Accepted |


### PR DESCRIPTION
Closes #197.

ADR-0024 pins the v1 scope for the agent milestone so the four implementation issues (#198–#201) can land in parallel without re-litigating the basics. Eight decisions captured:

1. **Hosting** — generic host + `BackgroundService` + `UseWindowsService()` / `UseSystemd()` shims. One binary, three runtime contexts (console / Windows service / systemd unit).
2. **Logging** — `ILogger` everywhere in app code; Serilog file sink at the boundary so swap cost is one Program.cs line.
3. **Save-folder discovery** — config override → Windows default → Linux Proton path. Degraded boot if none resolve.
4. **Wire protocol** — raw `.sav` POST, three custom headers (`X-Agent-Token`, `X-Agent-FileName`, `X-Agent-Version`), camelCase JSON response. Agent doesn't parse — server-side parse via `SatisfactorySaveNet` keeps the agent dependency-light and patch updates server-only.
5. **Auth seam** — `X-Agent-Token` accepted but unvalidated. 401 on missing/empty token so a future ADR-0025 dropping in real validation doesn't change status semantics.
6. **Web UI** — `src/Web.Shared/` Razor class library; `AgentStatusCard` component graduates the lazy #181 tracker into a concrete shared lib.
7. **Distribution** — `dotnet publish` self-contained per RID (win-x64 + linux-x64). GitHub Release zips on tag. macOS deferred.
8. **Repo layout** — `src/Agent/` sibling. **Not** Aspire-orchestrated (it's a client of the API, not part of the dev stack).

## Notable rejected alternatives

- **Bearer in `Authorization` header** — would hijack the OAuth convention before we've picked an OAuth approach. Custom header signals "our protocol's identity field" and leaves `Authorization` free for later.
- **Agent pre-parses then ships JSON** — tighter client-server coupling, every save-format change needs lockstep releases. Server-side parse keeps patches scoped.
- **gRPC / multipart** — wrong shape for "occasional file upload"; reconsider in v2 if multi-file batching becomes a real ask.
- **Framework-dependent publish** — saves ~80 MB per RID but adds "user installs .NET 10 first" as a failure mode. Self-contained wins for first-download success rate.

## What this unblocks

- **#198** (scaffold `src/Agent/`) — knows the hosting + logging + folder-discovery shape.
- **#199** (API endpoints) — knows the URL, headers, status codes, response shape.
- **#200** (Web UI shared component) — knows the library lives at `src/Web.Shared/`.
- **#201** (distribution) — knows the RIDs, the publish flags, the zip-per-platform pattern.

## Test plan

- [x] ADR README index updated.
- [x] Cross-references to ADR-0017 / 0023 / 0014 verified.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)