### PR TITLE
ci(ui-tests): fix broken path filter — Playwright was running on docs PRs

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -52,18 +52,23 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
-          # Match *UI-relevant* files only — Dockerfile, *.md, *.dockerignore
-          # don't change rendered output, so they shouldn't burn ~15 min of
-          # Playwright runner time. dorny/paths-filter supports `!neg`.
-          # Add more excludes here as new non-UI artefacts land under web dirs.
+          # Explicit positive patterns ONLY. dorny/paths-filter's `!`
+          # syntax does NOT subtract from prior patterns the way the
+          # README implies — under the default `some` quantifier each
+          # `!` line is an independent positive match for "file does
+          # NOT match this glob", which OR-combines with the others and
+          # ends up matching almost everything (e.g. an ADR .md outside
+          # any src/ path matched the previous `!**/Dockerfile` line
+          # because it isn't a Dockerfile). Lesson: enumerate the
+          # extensions that actually move pixels.
           filters: |
             web:
-              - 'src/Web/**'
-              - 'src/CaptainOfIndustry/Web/**'
-              - 'src/Web.Shared/**'
+              - 'src/Web/**/*.{cs,razor,razor.css,css,js,html,json}'
+              - 'src/Web/wwwroot/**'
+              - 'src/CaptainOfIndustry/Web/**/*.{cs,razor,razor.css,css,js,html,json}'
+              - 'src/CaptainOfIndustry/Web/wwwroot/**'
+              - 'src/Web.Shared/**/*.{cs,razor,razor.css,css,js,html}'
               - 'test/Web/**'
-              - '!**/Dockerfile'
-              - '!**/*.md'
 
       - name: Compute gate
         id: gate


### PR DESCRIPTION
Fixes the trigger that burned Chris's runner quota across two recent PRs.

## What was broken

The path filter in `.github/workflows/ui-tests.yml` used `dorny/paths-filter`'s `!` syntax for exclusions:

\`\`\`yaml
web:
  - 'src/Web/**'
  - 'src/CaptainOfIndustry/Web/**'
  - 'src/Web.Shared/**'
  - 'test/Web/**'
  - '!**/Dockerfile'
  - '!**/*.md'
\`\`\`

Intent: trigger on any file under web dirs, except Dockerfiles and markdown.

Reality: under the default `predicate-quantifier: some`, dorny treats each \`!\` line as an independent positive pattern meaning "file does NOT match this glob". They get OR'd with the includes, so every file *outside* the include set ALSO matched whichever \`!\` pattern it didn't satisfy. ADRs under \`docs/adr/\` matched \`!**/Dockerfile\` because they aren't Dockerfiles. Result: Playwright ran on the ADR-only PR #202.

## Evidence

From the [#202 run log](https://github.com/ChrisonSimtian/ErpForFactoryGames/actions/runs/26218979080):

\`\`\`
[added] docs/adr/0024-agent-v1-shape.md
[modified] docs/adr/README.md
##[group]Filter web = true
Matching files:
docs/adr/0024-agent-v1-shape.md [added]
docs/adr/README.md [modified]
\`\`\`

The filter said `web = true` for an ADR-only diff.

## What this PR does

Switch to **explicit positive patterns by extension**. No `!` exclusions at all. Verbose but unambiguous:

\`\`\`yaml
web:
  - 'src/Web/**/*.{cs,razor,razor.css,css,js,html,json}'
  - 'src/Web/wwwroot/**'
  - 'src/CaptainOfIndustry/Web/**/*.{cs,razor,razor.css,css,js,html,json}'
  - 'src/CaptainOfIndustry/Web/wwwroot/**'
  - 'src/Web.Shared/**/*.{cs,razor,razor.css,css,js,html}'
  - 'test/Web/**'
\`\`\`

Comment in the workflow documents the gotcha so the next person doesn't reintroduce it.

## Effect

| Change | Old filter | New filter |
|---|---|---|
| Touch `src/Web/Components/Pages/Foo.razor` | ✅ run | ✅ run |
| Touch `src/Web/Dockerfile` | ❌ ran (waste) | ✅ skip |
| Add ADR `docs/adr/0099-x.md` | ❌ ran (waste) | ✅ skip |
| Add `src/CaptainOfIndustry/Web/Components/Pages/Foo.razor` | ❌ didn't run before #196 | ✅ run |
| Add `src/Web.Shared/AgentStatusCard.razor` (future) | ❌ won't run | ✅ run |

## Test plan

- [x] Filter syntax validated by reading the failure mode in the #202 run log.
- [ ] CI green on this branch (this PR touches only `.github/workflows/`, so should skip UI tests itself).
- [ ] After merge: the next PR touching ADRs or Dockerfiles should not trigger UI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)