### PR TITLE
feat(agent): scaffold the headless agent (#198)

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/src/">
+    <Project Path="src/Agent/Agent.csproj" />
     <Project Path="src/ApiService/ApiService.csproj" />
     <Project Path="src/AppHost/AppHost.csproj" />
     <Project Path="src/ServiceDefaults/ServiceDefaults.csproj" />
@@ -38,6 +39,9 @@
     <Project Path="src/CaptainOfIndustry/Web/CaptainOfIndustry.Web.csproj" />
   </Folder>
   <Folder Name="/test/" />
+  <Folder Name="/test/Agent.Tests/">
+    <Project Path="test/Agent.Tests/Agent.Tests.csproj" />
+  </Folder>
   <Folder Name="/test/ApiService.Tests/" />
   <Folder Name="/test/ERP/" />
   <Folder Name="/test/ERP/Application.Tests/">

--- a/src/Agent/Agent.csproj
+++ b/src/Agent/Agent.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Agent</RootNamespace>
+    <AssemblyName>erp-agent</AssemblyName>
+    <UserSecretsId>erp-agent-7c964c83-0170-4f31-8314-ae3569267de9</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Generic host + service-host shims (see ADR-0024 §1). One binary,
+         three contexts (console / Windows service / systemd unit). -->
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+
+    <!-- Serilog file sink behind ILogger (ADR-0024 §2). App code uses
+         ILogger<T> only; Serilog stays at the boundary. -->
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Agent/AgentOptions.cs
+++ b/src/Agent/AgentOptions.cs
@@ -1,0 +1,37 @@
+namespace Agent;
+
+/// <summary>
+/// Bound from the <c>Agent</c> configuration section. Env vars win
+/// (<c>ERP_AGENT_*</c>), then <c>appsettings.json</c> / <c>agent.json</c>,
+/// then defaults.
+/// </summary>
+public sealed class AgentOptions
+{
+    /// <summary>
+    /// Base URL of the ApiService that hosts <c>/agent/savegames/satisfactory</c>
+    /// and <c>/agent/status</c>. No default — must be configured.
+    /// </summary>
+    public string ApiBaseUrl { get; set; } = "";
+
+    /// <summary>
+    /// Opaque token sent as <c>X-Agent-Token</c> on every API call. v1 server
+    /// accepts any non-empty value (auth seam — see ADR-0024 §5). User
+    /// generates locally for now; a future ADR-0025 picks a real issuance
+    /// mechanism.
+    /// </summary>
+    public string AgentToken { get; set; } = "";
+
+    /// <summary>
+    /// Override the auto-detected Satisfactory save folder.
+    /// <see cref="SaveFolderResolver"/> falls back to OS defaults when this
+    /// is null/empty.
+    /// </summary>
+    public string? SaveFolderPath { get; set; }
+
+    /// <summary>
+    /// Debounce after a <see cref="System.IO.FileSystemEventArgs"/> before
+    /// reading the file. Satisfactory writes saves in chunks — uploading
+    /// mid-write produces a truncated file.
+    /// </summary>
+    public TimeSpan WriteDebounce { get; set; } = TimeSpan.FromMilliseconds(500);
+}

--- a/src/Agent/AgentStatus.cs
+++ b/src/Agent/AgentStatus.cs
@@ -1,0 +1,61 @@
+namespace Agent;
+
+/// <summary>
+/// In-process snapshot of what the agent is doing. The future Web UI
+/// component <c>AgentStatusCard</c> (#200) reads a server-side projection of
+/// this via <c>GET /agent/status</c>; the agent itself uses it to publish
+/// its own state to the API on each upload.
+/// </summary>
+public interface IAgentStatus
+{
+    /// <summary>Resolved save folder the watcher is using, or null if none.</summary>
+    string? SaveFolderInUse { get; }
+
+    /// <summary>True iff <see cref="SaveFolderInUse"/> exists and is readable.</summary>
+    bool SaveFolderAccessible { get; }
+
+    /// <summary>Most recent save file the watcher noticed, by full path. Null if no event yet.</summary>
+    string? LastDetectedSavePath { get; }
+    DateTimeOffset? LastDetectedAt { get; }
+
+    /// <summary>Last upload attempt (success or failure). Null if no attempt yet.</summary>
+    UploadAttempt? LastUpload { get; }
+
+    void RecordSaveFolder(string? path, bool accessible);
+    void RecordDetected(string path);
+    void RecordUpload(UploadAttempt attempt);
+}
+
+/// <summary>One row in the agent's recent-uploads ledger. Surfaces in the UI card.</summary>
+public sealed record UploadAttempt(
+    string FileName,
+    DateTimeOffset AttemptedAt,
+    bool Succeeded,
+    int? StatusCode,
+    string? Detail);
+
+internal sealed class AgentStatus : IAgentStatus
+{
+    // No locking — these properties are written by the BackgroundService thread
+    // and read by anything that injects IAgentStatus. Reference assignment is
+    // atomic in .NET; the worst case is a slightly-stale read.
+    public string? SaveFolderInUse { get; private set; }
+    public bool SaveFolderAccessible { get; private set; }
+    public string? LastDetectedSavePath { get; private set; }
+    public DateTimeOffset? LastDetectedAt { get; private set; }
+    public UploadAttempt? LastUpload { get; private set; }
+
+    public void RecordSaveFolder(string? path, bool accessible)
+    {
+        SaveFolderInUse = path;
+        SaveFolderAccessible = accessible;
+    }
+
+    public void RecordDetected(string path)
+    {
+        LastDetectedSavePath = path;
+        LastDetectedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void RecordUpload(UploadAttempt attempt) => LastUpload = attempt;
+}

--- a/src/Agent/ISaveUploader.cs
+++ b/src/Agent/ISaveUploader.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Agent;
+
+/// <summary>
+/// Ships a Satisfactory <c>.sav</c> file to the hosted API. Returns the
+/// outcome rather than throwing so the watcher can record it in the status
+/// ledger and surface the failure to the user without restarting the host.
+/// </summary>
+public interface ISaveUploader
+{
+    Task<UploadAttempt> UploadAsync(string filePath, CancellationToken ct);
+}
+
+/// <summary>
+/// HTTP implementation. Wire shape per ADR-0024 §4 — raw bytes,
+/// <c>application/octet-stream</c>, three custom headers.
+/// </summary>
+internal sealed class HttpSaveUploader : ISaveUploader
+{
+    private const string UploadPath = "/agent/savegames/satisfactory";
+
+    private readonly HttpClient _http;
+    private readonly AgentOptions _options;
+    private readonly ILogger<HttpSaveUploader> _logger;
+
+    public HttpSaveUploader(
+        HttpClient http,
+        IOptions<AgentOptions> options,
+        ILogger<HttpSaveUploader> logger)
+    {
+        _http = http;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<UploadAttempt> UploadAsync(string filePath, CancellationToken ct)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var attemptedAt = DateTimeOffset.UtcNow;
+
+        try
+        {
+            await using var stream = new FileStream(
+                filePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+                bufferSize: 64 * 1024, useAsync: true);
+
+            using var content = new StreamContent(stream);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, UploadPath) { Content = content };
+            request.Headers.TryAddWithoutValidation("X-Agent-Token", _options.AgentToken);
+            request.Headers.TryAddWithoutValidation("X-Agent-FileName", Uri.EscapeDataString(fileName));
+            request.Headers.TryAddWithoutValidation(
+                "X-Agent-Version",
+                typeof(HttpSaveUploader).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+
+            using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Uploaded {File} -> {Status}", fileName, (int)response.StatusCode);
+                return new UploadAttempt(fileName, attemptedAt, Succeeded: true,
+                    StatusCode: (int)response.StatusCode, Detail: null);
+            }
+
+            var detail = await SafeReadFirstLineAsync(response, ct).ConfigureAwait(false);
+            _logger.LogWarning("Upload of {File} failed: {Status} {Detail}",
+                fileName, (int)response.StatusCode, detail);
+            return new UploadAttempt(fileName, attemptedAt, Succeeded: false,
+                StatusCode: (int)response.StatusCode, Detail: detail);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Upload of {File} threw", fileName);
+            return new UploadAttempt(fileName, attemptedAt, Succeeded: false,
+                StatusCode: null, Detail: ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    private static async Task<string?> SafeReadFirstLineAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var line = body.AsSpan().IndexOf('\n') is var idx and >= 0 ? body[..idx] : body;
+            return string.IsNullOrWhiteSpace(line) ? null : line.Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Agent/Program.cs
+++ b/src/Agent/Program.cs
@@ -1,0 +1,118 @@
+using Agent;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// ---------------------------------------------------------------------
+// Service-host shims — see ADR-0024 §1.
+// Both calls are no-ops when not launched as the matching service type,
+// so the same binary works for `dotnet run`, Windows-service, and systemd.
+// ---------------------------------------------------------------------
+builder.Services.AddWindowsService(o => o.ServiceName = "ERP for Factory Games — Agent");
+builder.Services.AddSystemd();
+
+// ---------------------------------------------------------------------
+// Configuration — picks up appsettings.json next to the binary plus the
+// per-user agent.json (writeable; the install flow drops the token there)
+// plus env vars (ERP_AGENT_*). User-secrets only outside Production.
+// ---------------------------------------------------------------------
+builder.Configuration.AddJsonFile(UserConfigPath(), optional: true, reloadOnChange: true);
+builder.Configuration.AddEnvironmentVariables(prefix: "ERP_AGENT_");
+
+builder.Services.Configure<AgentOptions>(builder.Configuration.GetSection("Agent"));
+
+// ---------------------------------------------------------------------
+// Logging — Serilog file sink + console, see ADR-0024 §2. App code stays
+// on ILogger<T>; Serilog is only referenced here at the boundary.
+// ---------------------------------------------------------------------
+builder.Logging.ClearProviders();
+builder.Services.AddSerilog((sp, lc) =>
+{
+    var cfg = sp.GetRequiredService<IConfiguration>();
+    lc.ReadFrom.Configuration(cfg)
+      .Enrich.FromLogContext()
+      .WriteTo.Console()
+      .WriteTo.File(
+          path: Path.Combine(LogsDirectory(), "agent-.log"),
+          rollingInterval: RollingInterval.Day,
+          retainedFileCountLimit: 7,
+          shared: true);
+});
+
+// ---------------------------------------------------------------------
+// Domain services. The HttpClient's BaseAddress comes from
+// AgentOptions.ApiBaseUrl after the configuration system has bound; we
+// configure it here so HttpClientFactory hands out clients with the right
+// base for every request.
+// ---------------------------------------------------------------------
+builder.Services.AddSingleton<SaveFolderResolver>();
+builder.Services.AddSingleton<IAgentStatus, AgentStatus>();
+
+builder.Services.AddHttpClient<ISaveUploader, HttpSaveUploader>((sp, http) =>
+{
+    var opts = sp.GetRequiredService<IOptions<AgentOptions>>().Value;
+    if (!string.IsNullOrWhiteSpace(opts.ApiBaseUrl))
+    {
+        http.BaseAddress = new Uri(opts.ApiBaseUrl, UriKind.Absolute);
+    }
+    http.Timeout = TimeSpan.FromMinutes(2);
+});
+
+builder.Services.AddHostedService<SaveFolderWatcher>();
+
+var host = builder.Build();
+
+// Surface unconfigured ApiBaseUrl early — the watcher will still boot in
+// degraded mode if the save folder is missing, but uploads can't go
+// anywhere without a target.
+var options = host.Services.GetRequiredService<IOptions<AgentOptions>>().Value;
+if (string.IsNullOrWhiteSpace(options.ApiBaseUrl))
+{
+    var log = host.Services.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Program>>();
+    log.LogWarning(
+        "Agent:ApiBaseUrl is not configured. Set it via {ConfigPath} or ERP_AGENT_ApiBaseUrl. "
+        + "Uploads will fail until this is set.",
+        UserConfigPath());
+}
+if (string.IsNullOrWhiteSpace(options.AgentToken))
+{
+    var log = host.Services.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Program>>();
+    log.LogWarning(
+        "Agent:AgentToken is empty. The v1 server rejects empty tokens with 401 "
+        + "(auth seam per ADR-0024 §5). Set any non-empty string.");
+}
+
+await host.RunAsync().ConfigureAwait(false);
+
+// Local helpers — file paths are OS-specific. See ADR-0024 §2.
+static string LogsDirectory()
+{
+    var baseDir = OperatingSystem.IsWindows()
+        ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        : Environment.GetEnvironmentVariable("XDG_STATE_HOME")
+          ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "state");
+    var dir = Path.Combine(baseDir, "ErpForFactoryGames", "agent-logs");
+    Directory.CreateDirectory(dir);
+    return dir;
+}
+
+static string UserConfigPath()
+{
+    var baseDir = OperatingSystem.IsWindows()
+        ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        : Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+          ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
+    var dir = Path.Combine(baseDir, "ErpForFactoryGames");
+    Directory.CreateDirectory(dir);
+    return Path.Combine(dir, "agent.json");
+}
+
+// Lets ILogger<Program> work — the top-level statements compile into a
+// generated `Program` class, but Microsoft.Extensions.Logging needs a
+// concrete public type for the generic parameter.
+public partial class Program { }

--- a/src/Agent/SaveFolderResolver.cs
+++ b/src/Agent/SaveFolderResolver.cs
@@ -1,0 +1,74 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Options;
+
+namespace Agent;
+
+/// <summary>
+/// Decides where the Satisfactory save folder lives on this machine. Order
+/// (per ADR-0024 §3):
+///   1. <see cref="AgentOptions.SaveFolderPath"/> from configuration.
+///   2. Windows: <c>%LocalAppData%/FactoryGame/Saved/SaveGames/</c>.
+///   3. Linux: the Proton path under <c>~/.steam/steam/steamapps/compatdata/526870/</c>.
+/// macOS deferred — returns null + the watcher boots in a degraded state.
+/// </summary>
+public sealed class SaveFolderResolver
+{
+    // App ID for Satisfactory on Steam. Same on every install — drives the
+    // Proton compatdata path on Linux.
+    private const string SatisfactorySteamAppId = "526870";
+
+    private readonly AgentOptions _options;
+
+    public SaveFolderResolver(IOptions<AgentOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Returns the resolved directory, or null if nothing was found and the
+    /// user hasn't configured an override.
+    /// </summary>
+    public string? Resolve()
+    {
+        if (!string.IsNullOrWhiteSpace(_options.SaveFolderPath)
+            && Directory.Exists(_options.SaveFolderPath))
+        {
+            return _options.SaveFolderPath;
+        }
+
+        foreach (var candidate in EnumerateDefaults())
+        {
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the configured override path verbatim (whether or not it
+    /// exists) so callers can show it to the user in error messages.
+    /// </summary>
+    public string? ConfiguredOverride => _options.SaveFolderPath;
+
+    private static IEnumerable<string> EnumerateDefaults()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrEmpty(localAppData))
+                yield return Path.Combine(localAppData, "FactoryGame", "Saved", "SaveGames");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var home = Environment.GetEnvironmentVariable("HOME");
+            if (!string.IsNullOrEmpty(home))
+            {
+                // Steam Proton: %HOME%/.steam/steam/steamapps/compatdata/<appid>/pfx/drive_c/users/steamuser/AppData/Local/FactoryGame/Saved/SaveGames/
+                yield return Path.Combine(home, ".steam", "steam", "steamapps", "compatdata",
+                    SatisfactorySteamAppId, "pfx", "drive_c", "users", "steamuser",
+                    "AppData", "Local", "FactoryGame", "Saved", "SaveGames");
+            }
+        }
+        // macOS / other: yield nothing. Configured override is the only path
+        // in v1; documented in ADR-0024 §3.
+    }
+}

--- a/src/Agent/SaveFolderWatcher.cs
+++ b/src/Agent/SaveFolderWatcher.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Agent;
+
+/// <summary>
+/// Watches the resolved Satisfactory save folder and ships new/changed
+/// <c>.sav</c> files to the API via <see cref="ISaveUploader"/>.
+///
+/// Satisfactory writes saves in chunks — see <see cref="AgentOptions.WriteDebounce"/>.
+/// We coalesce bursts per-file so a single save flush triggers one upload.
+/// </summary>
+internal sealed class SaveFolderWatcher : BackgroundService
+{
+    private readonly SaveFolderResolver _resolver;
+    private readonly ISaveUploader _uploader;
+    private readonly IAgentStatus _status;
+    private readonly AgentOptions _options;
+    private readonly ILogger<SaveFolderWatcher> _logger;
+
+    // Pending debounced uploads. Key = full path; value = CTS that the next
+    // event for the same file cancels before scheduling a fresh delay.
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _pending = new();
+
+    public SaveFolderWatcher(
+        SaveFolderResolver resolver,
+        ISaveUploader uploader,
+        IAgentStatus status,
+        IOptions<AgentOptions> options,
+        ILogger<SaveFolderWatcher> logger)
+    {
+        _resolver = resolver;
+        _uploader = uploader;
+        _status = status;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var folder = _resolver.Resolve();
+        var accessible = folder is not null && Directory.Exists(folder);
+        _status.RecordSaveFolder(folder, accessible);
+
+        if (folder is null)
+        {
+            _logger.LogWarning(
+                "Save folder not detected on this OS and no override configured. "
+                + "Set Agent:SaveFolderPath (or ERP_AGENT_SAVE_FOLDER_PATH) and restart. "
+                + "Configured override was: {Override}",
+                _resolver.ConfiguredOverride ?? "<none>");
+            // Sit idle until cancellation — the host still runs, status UI
+            // can show the "not configured" state, and Win-service / systemd
+            // will keep it alive until the user reconfigures + restarts.
+            return Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+
+        if (!accessible)
+        {
+            _logger.LogWarning(
+                "Save folder {Folder} is not accessible (does not exist or not readable). Idling.",
+                folder);
+            return Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+
+        _logger.LogInformation("Watching {Folder} for *.sav changes", folder);
+
+        using var watcher = new FileSystemWatcher(folder)
+        {
+            Filter = "*.sav",
+            IncludeSubdirectories = false,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+            EnableRaisingEvents = true,
+        };
+
+        watcher.Created += (_, e) => Enqueue(e.FullPath, stoppingToken);
+        watcher.Changed += (_, e) => Enqueue(e.FullPath, stoppingToken);
+        watcher.Renamed += (_, e) => Enqueue(e.FullPath, stoppingToken);
+        watcher.Error += (_, e) => _logger.LogError(e.GetException(), "FileSystemWatcher error");
+
+        return Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+
+    private void Enqueue(string fullPath, CancellationToken hostCt)
+    {
+        // Cancel any pending upload for this exact file — new event = new
+        // chunk write. The fresh CTS gets a full debounce window before
+        // firing.
+        if (_pending.TryRemove(fullPath, out var existing))
+        {
+            try { existing.Cancel(); } catch { /* already disposed */ }
+            existing.Dispose();
+        }
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(hostCt);
+        _pending[fullPath] = cts;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(_options.WriteDebounce, cts.Token).ConfigureAwait(false);
+                _pending.TryRemove(fullPath, out _);
+
+                _status.RecordDetected(fullPath);
+                var result = await _uploader.UploadAsync(fullPath, cts.Token).ConfigureAwait(false);
+                _status.RecordUpload(result);
+            }
+            catch (OperationCanceledException) { /* replaced by a newer event */ }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process save change for {Path}", fullPath);
+            }
+            finally
+            {
+                cts.Dispose();
+            }
+        }, hostCt);
+    }
+}

--- a/src/Agent/agent.json.example
+++ b/src/Agent/agent.json.example
@@ -1,0 +1,7 @@
+{
+  "Agent": {
+    "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
+    "AgentToken": "paste-any-non-empty-string-here-for-v1",
+    "SaveFolderPath": null
+  }
+}

--- a/src/Agent/appsettings.json
+++ b/src/Agent/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System.Net.Http.HttpClient": "Warning"
+      }
+    }
+  },
+  "Agent": {
+    "ApiBaseUrl": "",
+    "AgentToken": "",
+    "SaveFolderPath": null
+  }
+}

--- a/test/Agent.Tests/Agent.Tests.csproj
+++ b/test/Agent.Tests/Agent.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Agent.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Agent\Agent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Agent.Tests/SaveFolderResolverTests.cs
+++ b/test/Agent.Tests/SaveFolderResolverTests.cs
@@ -1,0 +1,77 @@
+using Agent;
+using Microsoft.Extensions.Options;
+
+namespace Agent.Tests;
+
+public class SaveFolderResolverTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SaveFolderResolverTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Configured_Override_Wins_When_Directory_Exists()
+    {
+        var resolver = new SaveFolderResolver(Options.Create(new AgentOptions
+        {
+            SaveFolderPath = _tempDir,
+        }));
+
+        Assert.Equal(_tempDir, resolver.Resolve());
+    }
+
+    [Fact]
+    public void Override_Ignored_When_Directory_Missing()
+    {
+        var missing = Path.Combine(_tempDir, "does-not-exist");
+        var resolver = new SaveFolderResolver(Options.Create(new AgentOptions
+        {
+            SaveFolderPath = missing,
+        }));
+
+        // Configured override doesn't exist → falls through to OS defaults.
+        // On a dev box that has Satisfactory installed at the default path,
+        // this could return the real folder; on CI it'll return null. Either
+        // way it should NOT return the bogus override.
+        var resolved = resolver.Resolve();
+        Assert.NotEqual(missing, resolved);
+    }
+
+    [Fact]
+    public void ConfiguredOverride_Exposes_The_Configured_Value_Verbatim()
+    {
+        var resolver = new SaveFolderResolver(Options.Create(new AgentOptions
+        {
+            SaveFolderPath = @"C:\some\nonsense\that\never\exists",
+        }));
+
+        Assert.Equal(@"C:\some\nonsense\that\never\exists", resolver.ConfiguredOverride);
+    }
+
+    [Fact]
+    public void No_Override_And_No_Default_Returns_Null_On_Unknown_Platform()
+    {
+        // On any OS, if the override is null/whitespace and no default
+        // directory exists, Resolve() must return null rather than
+        // throwing. This guards against host crashes when Satisfactory
+        // isn't installed.
+        var resolver = new SaveFolderResolver(Options.Create(new AgentOptions
+        {
+            SaveFolderPath = null,
+        }));
+
+        // We can't reliably assert null here because a dev box might have
+        // Satisfactory installed at the default path. Just verify it
+        // doesn't throw.
+        var _ = resolver.Resolve();
+    }
+}


### PR DESCRIPTION
Closes #198. First half of milestone #17, implementing ADR-0024.

## Smoke-tested live

\`\`\`
[WRN] Agent:ApiBaseUrl is not configured. Set it via C:\Users\ChrisSimon\AppData\Local\ErpForFactoryGames\agent.json or ERP_AGENT_ApiBaseUrl. Uploads will fail until this is set.
[WRN] Agent:AgentToken is empty. The v1 server rejects empty tokens with 401 (auth seam per ADR-0024 §5). Set any non-empty string.
[INF] Application started. Press Ctrl+C to shut down.
[INF] Watching C:\Users\ChrisSimon\AppData\Local\FactoryGame\Saved\SaveGames for *.sav changes
\`\`\`

Save-folder auto-detection found a real Satisfactory install at the default path. Empty config produces clear warnings, not crashes.

## What landed

| File | Why |
|---|---|
| \`AgentOptions.cs\` | Bound config: \`ApiBaseUrl\`, \`AgentToken\`, \`SaveFolderPath\`, \`WriteDebounce\`. |
| \`SaveFolderResolver.cs\` | Override → Win \`%LocalAppData%/FactoryGame/...\` → Linux Proton compatdata. macOS = null → degraded boot. |
| \`AgentStatus.cs\` | In-process singleton holding the watcher's current state. Future #200 reads a server-side projection. |
| \`ISaveUploader.cs\` | \`HttpSaveUploader\` POSTs raw \`.sav\` with the three \`X-Agent-*\` headers per ADR-0024 §4. Returns \`UploadAttempt\`, never throws. |
| \`SaveFolderWatcher.cs\` | \`BackgroundService\` + \`FileSystemWatcher\`. Per-file debounce coalesces Satisfactory's chunked save writes. Boots in degraded state if folder is missing. |
| \`Program.cs\` | Generic host + \`UseWindowsService()\` + \`UseSystemd()\` + Serilog file sink. ILogger<T> everywhere in app code. |

## Design notes

- **`erp-agent` is the assembly name** so the published binary is `erp-agent.exe` / `erp-agent` on Linux. Friendly for `--install` / `--uninstall` usage in #201.
- **Debounce is per-file, not global.** Two simultaneous saves (e.g. autosave + manual) both upload; same save written in chunks uploads once.
- **`UploadAttempt` records the outcome** rather than the uploader throwing. The watcher carries on after a failure and the next save will re-attempt; surfaces in status either way.
- **The agent does NOT reference \`ERP.Application\` or \`Satisfactory.Save\`.** It's a thin client that ships bytes; server parses (per ADR-0024 §4).

## Tests

- 4 unit tests in \`test/Agent.Tests/\` covering \`SaveFolderResolver\`.
- Watcher + uploader are integration-test territory once #199 lands a server endpoint we can target.

## What's NOT here (next issues)

- API endpoints (#199) — server-side counterpart that actually receives + parses uploads, and serves \`GET /agent/status\`.
- Shared Web UI status card (#200).
- Service registration + per-RID GitHub Release zips (#201).

## Test plan

- [x] \`dotnet build src/Agent/\` → 0 warnings, 0 errors.
- [x] \`dotnet test test/Agent.Tests/\` → 4 passed.
- [x] \`dotnet format --verify-no-changes\` → clean.
- [x] Manual smoke: agent boots, detects save folder, watches without crashing.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)