### PR TITLE
feat(agent): service registration + per-RID release publish

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,12 +1,19 @@
-# Builds + pushes runtime container images to GHCR on tag.
+# Builds + pushes runtime container images to GHCR on tag, plus the
+# per-RID agent binaries attached to the GitHub Release.
 #
 # Triggered by tags shaped `v*` (e.g. v0.5.0). Tags become the image
-# tag, and the always-moving `:latest` label is updated to match. Per
-# ADR-0023:
+# tag, and the always-moving `:latest` label is updated to match.
+#
+# Container images (per ADR-0023):
 #   - Satisfactory Web (src/Web/Dockerfile) -> ghcr.io/<owner>/erp-web
 #   - Planner ApiService (src/ApiService/Dockerfile) -> ghcr.io/<owner>/erp-api
-# CoI Web image is deliberately not built here yet; it's deferred to the
-# game-agent milestone which will solve catalogue distribution.
+#   CoI Web image is deliberately not built here yet — agent milestone solves
+#   catalogue distribution first.
+#
+# Agent binaries (per ADR-0024 §7):
+#   - erp-agent-win-x64.zip   (Windows service-capable)
+#   - erp-agent-linux-x64.tar.gz   (systemd --user capable)
+#   Attached to the GitHub Release created from the tag.
 
 name: Release images
 
@@ -77,3 +84,78 @@ jobs:
           # GHA cache backend keeps subsequent builds quick across runs.
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
+
+  # ---------------------------------------------------------------------------
+  # Agent — per-RID self-contained single-file publish. Skipped on
+  # workflow_dispatch (no release to attach to); only fires on tag push.
+  # ---------------------------------------------------------------------------
+  publish-agent:
+    name: Publish agent (${{ matrix.rid }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write   # gh release upload
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            runner: windows-latest
+            archive_ext: zip
+          - rid: linux-x64
+            runner: ubuntu-latest
+            archive_ext: tar.gz
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # NB.GV needs git history for version-height calc
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ matrix.runner }}-agent-nuget-${{ hashFiles('**/*.csproj', '**/global.json') }}
+          restore-keys: ${{ matrix.runner }}-agent-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Publish
+        # The csproj already locks in PublishSingleFile / SelfContained / R2R;
+        # this just pins the RID and output dir for this run.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # nuget.config reads it
+        run: dotnet publish src/Agent/Agent.csproj -c Release -r ${{ matrix.rid }} -o publish/${{ matrix.rid }}
+
+      - name: Pack zip (Windows)
+        if: matrix.archive_ext == 'zip'
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $name = "erp-agent-${{ matrix.rid }}-$version.zip"
+          Compress-Archive -Path publish/${{ matrix.rid }}/* -DestinationPath $name
+          "ARCHIVE_NAME=$name" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Pack tar.gz (Linux)
+        if: matrix.archive_ext == 'tar.gz'
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          name="erp-agent-${{ matrix.rid }}-${version}.tar.gz"
+          tar -czf "$name" -C publish/${{ matrix.rid }} .
+          echo "ARCHIVE_NAME=$name" >> "$GITHUB_ENV"
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          # The tag push triggers the GitHub auto-release-from-tag flow; the
+          # release may or may not exist when this job lands depending on
+          # ordering. Create it if needed (idempotent), then upload.
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
+            || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes "See CHANGELOG / commit history. Container images on ghcr.io/${GITHUB_REPOSITORY_OWNER,,}."
+          gh release upload "${GITHUB_REF_NAME}" "${ARCHIVE_NAME}" --clobber

--- a/src/Agent/Agent.csproj
+++ b/src/Agent/Agent.csproj
@@ -8,7 +8,34 @@
     <RootNamespace>Agent</RootNamespace>
     <AssemblyName>erp-agent</AssemblyName>
     <UserSecretsId>erp-agent-7c964c83-0170-4f31-8314-ae3569267de9</UserSecretsId>
+    <!-- Single-file self-contained publish per ADR-0024 §7. Set on the
+         command line via -r <RID>; this file just locks in the flags so
+         CI + local publish produce the same shape. -->
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <!-- Trim is off — ILogger / Serilog / Microsoft.Extensions.* are
+         reflection-heavy and we'd spend weeks chasing trim warnings for
+         minimal size payoff on a single-file binary. -->
+    <PublishTrimmed>false</PublishTrimmed>
+    <!-- Force ReadyToRun on so first-launch isn't a 3s JIT pause as
+         systemd / SCM watches the start-up notify. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <!-- Embed symbols inside the exe so we get useful crash traces without
+         shipping a separate .pdb that confuses end-users. -->
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- These travel into the published output next to the binary so a
+         freshly-extracted zip has the user-facing docs + the template
+         config + the default-settings file right where the user looks.
+         The Worker SDK auto-includes appsettings.json; Microsoft.NET.Sdk
+         doesn't, so spell it out. -->
+    <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="INSTALL.md" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="agent.json.example" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 
   <ItemGroup>
     <!-- Generic host + service-host shims (see ADR-0024 §1). One binary,

--- a/src/Agent/INSTALL.md
+++ b/src/Agent/INSTALL.md
@@ -1,0 +1,112 @@
+# ERP Agent — install
+
+The ERP Agent watches your Satisfactory save folder and uploads each
+new save to the hosted planner web app, so your factory's live state
+shows up alongside your plans.
+
+Single-file self-contained binary — no .NET install required.
+
+## Windows
+
+1. Download `erp-agent-win-x64.zip` from the latest [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
+2. Extract somewhere stable, e.g. `C:\Program Files\ErpForFactoryGames\`.
+3. Edit `%LocalAppData%\ErpForFactoryGames\agent.json` (created on first
+   run; use the bundled `agent.json.example` as a template):
+
+   ```json
+   {
+     "Agent": {
+       "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
+       "AgentToken": "<any-non-empty-string-for-v1>"
+     }
+   }
+   ```
+
+4. Right-click `erp-agent.exe` → **Run as administrator**, then in a
+   terminal (still elevated):
+
+   ```powershell
+   .\erp-agent.exe --install
+   ```
+
+5. Done. The service auto-starts at boot (delayed-auto), restarts on
+   crash. Logs at `%LocalAppData%\ErpForFactoryGames\agent-logs\`.
+
+To remove: `.\erp-agent.exe --uninstall` (elevated).
+
+## Linux (systemd)
+
+1. Download `erp-agent-linux-x64.tar.gz` from the [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
+2. Extract to `~/.local/bin/` (or anywhere on `$PATH`).
+3. Edit `$XDG_CONFIG_HOME/ErpForFactoryGames/agent.json` (defaults to
+   `~/.config/ErpForFactoryGames/agent.json`):
+
+   ```json
+   {
+     "Agent": {
+       "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
+       "AgentToken": "<any-non-empty-string-for-v1>"
+     }
+   }
+   ```
+
+4. Register the user-mode systemd unit (no `sudo`):
+
+   ```bash
+   ~/.local/bin/erp-agent --install
+   ```
+
+5. To keep the agent running after you log out:
+
+   ```bash
+   loginctl enable-linger "$USER"
+   ```
+
+Logs land in `$XDG_STATE_HOME/ErpForFactoryGames/agent-logs/` (default
+`~/.local/state/...`). `systemctl --user status erp-agent` shows the
+journal-side view.
+
+To remove: `~/.local/bin/erp-agent --uninstall`.
+
+## macOS
+
+Not supported by `--install` in v1 — the binary still runs cross-platform,
+but launchd integration isn't wired yet. Run it manually in a terminal:
+
+```bash
+./erp-agent
+```
+
+A future release will add `launchctl` registration.
+
+## What "auth" means today
+
+There's no real authentication in v1. The agent sends an
+`X-Agent-Token` header on every request; the server accepts any
+non-empty string. Put a long random value in `agent.json` and treat it
+like a password — when real auth lands (future ADR-0025) the upgrade
+path will preserve any tokens you've already issued.
+
+## Save folder
+
+The agent auto-detects Satisfactory's default save folder:
+
+- **Windows**: `%LocalAppData%\FactoryGame\Saved\SaveGames\`
+- **Linux (Steam Proton)**: `~/.steam/steam/steamapps/compatdata/526870/pfx/drive_c/users/steamuser/AppData/Local/FactoryGame/Saved/SaveGames/`
+
+If you've moved your saves elsewhere, set
+`Agent:SaveFolderPath` in `agent.json` (or the
+`ERP_AGENT_SaveFolderPath` env var) to the directory containing your
+`.sav` files.
+
+## Troubleshooting
+
+- **Service installed but won't start**: check
+  `%LocalAppData%\ErpForFactoryGames\agent-logs\` for the file log, and
+  the Windows Event Viewer (Application log) for service-host errors.
+- **Saves not uploading**: confirm `ApiBaseUrl` is correct and the
+  server is reachable (`curl -i $ApiBaseUrl/health`). The agent logs
+  every upload attempt with the response status code.
+- **First-time `agent.json` doesn't exist**: the agent creates the
+  containing folder on first run. Just create `agent.json` there
+  yourself with the snippet above; it's reloaded automatically.

--- a/src/Agent/Program.cs
+++ b/src/Agent/Program.cs
@@ -6,6 +6,28 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Serilog;
 
+// ---------------------------------------------------------------------
+// CLI entry — handle --install / --uninstall / --help before any host
+// machinery boots. These flags do one thing and exit; the long-running
+// service path is the default when no flag is given.
+// ---------------------------------------------------------------------
+foreach (var arg in args)
+{
+    switch (arg)
+    {
+        case "--install":
+            return await ServiceRegistrar.InstallAsync().ConfigureAwait(false);
+        case "--uninstall":
+            return await ServiceRegistrar.UninstallAsync().ConfigureAwait(false);
+        case "--version" or "-v":
+            Console.WriteLine(typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+            return 0;
+        case "--help" or "-h":
+            PrintUsage();
+            return 0;
+    }
+}
+
 var builder = Host.CreateApplicationBuilder(args);
 
 // ---------------------------------------------------------------------
@@ -88,6 +110,31 @@ if (string.IsNullOrWhiteSpace(options.AgentToken))
 }
 
 await host.RunAsync().ConfigureAwait(false);
+return 0;
+
+static void PrintUsage()
+{
+    Console.WriteLine("""
+        erp-agent — ERP for Factory Games local-data agent.
+
+        Usage:
+          erp-agent                  Run in the foreground (or as a registered
+                                     service when launched by the SCM / systemd).
+          erp-agent --install        Register as a Windows service (run elevated)
+                                     or a systemd --user unit.
+          erp-agent --uninstall      Reverse of --install.
+          erp-agent --version, -v    Print the agent version.
+          erp-agent --help, -h       This help.
+
+        Configuration:
+          appsettings.json next to the binary holds defaults.
+          agent.json under %LocalAppData%/ErpForFactoryGames/ (Windows) or
+          $XDG_CONFIG_HOME/ErpForFactoryGames/ (Linux) is the writeable
+          per-user override — that's where you put your API URL + token.
+
+        See INSTALL.md next to the binary for the full first-run guide.
+        """);
+}
 
 // Local helpers — file paths are OS-specific. See ADR-0024 §2.
 static string LogsDirectory()

--- a/src/Agent/ServiceRegistrar.cs
+++ b/src/Agent/ServiceRegistrar.cs
@@ -1,0 +1,246 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+namespace Agent;
+
+/// <summary>
+/// Self-install / self-uninstall handlers driven from the agent CLI
+/// (<c>--install</c>, <c>--uninstall</c>). Per ADR-0024 §7 the goal is a
+/// one-shot install UX: extract the zip, run the binary with the flag,
+/// it registers itself as a Windows service or systemd user unit.
+/// </summary>
+/// <remarks>
+/// Windows: shells out to <c>sc.exe</c> with the elevated-token check
+/// upfront — registering services without admin always fails, so we'd
+/// rather print the reason than let <c>sc</c> emit a generic error.
+///
+/// Linux: writes a user-mode systemd unit to
+/// <c>~/.config/systemd/user/erp-agent.service</c> and calls
+/// <c>systemctl --user</c>. No root required, which matches typical
+/// gamer dev-box ownership.
+///
+/// macOS: prints "not supported in v1" and exits non-zero. Users on Mac
+/// run the binary manually for now (see <c>INSTALL.md</c>).
+/// </remarks>
+internal static class ServiceRegistrar
+{
+    private const string ServiceName = "erp-agent";
+    private const string DisplayName = "ERP for Factory Games — Agent";
+    private const string Description =
+        "Watches the game save folder and uploads saves to the ERP planner web app. "
+        + "See https://github.com/ChrisonSimtian/ErpForFactoryGames";
+
+    public static async Task<int> InstallAsync()
+    {
+        var binary = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(binary))
+        {
+            Console.Error.WriteLine("Could not resolve the agent's binary path. Aborting.");
+            return 2;
+        }
+
+        if (OperatingSystem.IsWindows()) return await InstallWindowsAsync(binary).ConfigureAwait(false);
+        if (OperatingSystem.IsLinux()) return await InstallSystemdUserAsync(binary).ConfigureAwait(false);
+
+        Console.Error.WriteLine("Service registration is not supported on this OS in v1.");
+        Console.Error.WriteLine("Run the binary manually — see INSTALL.md.");
+        return 3;
+    }
+
+    public static async Task<int> UninstallAsync()
+    {
+        if (OperatingSystem.IsWindows()) return await UninstallWindowsAsync().ConfigureAwait(false);
+        if (OperatingSystem.IsLinux()) return await UninstallSystemdUserAsync().ConfigureAwait(false);
+
+        Console.Error.WriteLine("Service uninstallation is not supported on this OS in v1.");
+        return 3;
+    }
+
+    // ---------- Windows --------------------------------------------------
+
+    private static async Task<int> InstallWindowsAsync(string binary)
+    {
+        if (!IsWindowsElevated())
+        {
+            Console.Error.WriteLine("--install must be run elevated on Windows (right-click → 'Run as administrator').");
+            Console.Error.WriteLine("Aborting; no changes made.");
+            return 5;
+        }
+
+        // `binStart=` keeps the path quoted as a single argument so spaces in
+        // Program Files paths don't break sc's argv split.
+        var binStart = $"\"{binary}\"";
+
+        // Cleanly handle "already installed" — uninstall first so re-running
+        // --install bumps to the new binary path.
+        if (await ServiceExistsAsync().ConfigureAwait(false))
+        {
+            Console.Out.WriteLine($"Service '{ServiceName}' already exists; replacing.");
+            await RunAsync("sc.exe", $"stop {ServiceName}").ConfigureAwait(false);
+            await RunAsync("sc.exe", $"delete {ServiceName}").ConfigureAwait(false);
+        }
+
+        var create = await RunAsync(
+            "sc.exe",
+            $"create {ServiceName} binPath= {binStart} DisplayName= \"{DisplayName}\" start= delayed-auto").ConfigureAwait(false);
+        if (create.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"sc create failed (exit {create.ExitCode}): {create.Stdout} {create.Stderr}");
+            return create.ExitCode;
+        }
+
+        await RunAsync("sc.exe", $"description {ServiceName} \"{Description}\"").ConfigureAwait(false);
+        // Restart twice on failure, then give up. Standard service hygiene.
+        await RunAsync("sc.exe", $"failure {ServiceName} reset= 86400 actions= restart/60000/restart/60000//").ConfigureAwait(false);
+
+        var start = await RunAsync("sc.exe", $"start {ServiceName}").ConfigureAwait(false);
+        if (start.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"Service installed but failed to start (exit {start.ExitCode}): {start.Stderr}");
+            Console.Error.WriteLine($"Check the Windows Event Viewer or the file log at %LocalAppData%\\ErpForFactoryGames\\agent-logs\\.");
+            return start.ExitCode;
+        }
+
+        Console.Out.WriteLine($"Service '{ServiceName}' installed and started.");
+        Console.Out.WriteLine($"Configure the API URL + token at %LocalAppData%\\ErpForFactoryGames\\agent.json then restart the service.");
+        return 0;
+    }
+
+    private static async Task<int> UninstallWindowsAsync()
+    {
+        if (!IsWindowsElevated())
+        {
+            Console.Error.WriteLine("--uninstall must be run elevated on Windows.");
+            return 5;
+        }
+        if (!await ServiceExistsAsync().ConfigureAwait(false))
+        {
+            Console.Out.WriteLine($"Service '{ServiceName}' is not installed; nothing to do.");
+            return 0;
+        }
+
+        await RunAsync("sc.exe", $"stop {ServiceName}").ConfigureAwait(false);
+        var del = await RunAsync("sc.exe", $"delete {ServiceName}").ConfigureAwait(false);
+        if (del.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"sc delete failed (exit {del.ExitCode}): {del.Stderr}");
+            return del.ExitCode;
+        }
+
+        Console.Out.WriteLine($"Service '{ServiceName}' uninstalled.");
+        return 0;
+    }
+
+    private static async Task<bool> ServiceExistsAsync()
+    {
+        var result = await RunAsync("sc.exe", $"query {ServiceName}").ConfigureAwait(false);
+        return result.ExitCode == 0;
+    }
+
+    private static bool IsWindowsElevated()
+    {
+        if (!OperatingSystem.IsWindows()) return false;
+#pragma warning disable CA1416 // We just checked the platform.
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+#pragma warning restore CA1416
+    }
+
+    // ---------- Linux (systemd --user) -----------------------------------
+
+    private static async Task<int> InstallSystemdUserAsync(string binary)
+    {
+        var unitDir = Path.Combine(
+            Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+              ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config"),
+            "systemd", "user");
+        Directory.CreateDirectory(unitDir);
+
+        var unitPath = Path.Combine(unitDir, $"{ServiceName}.service");
+        var unit = $"""
+            [Unit]
+            Description={DisplayName}
+            After=network-online.target
+            Wants=network-online.target
+
+            [Service]
+            Type=notify
+            ExecStart={binary}
+            Restart=on-failure
+            RestartSec=10s
+            # Logs land in $XDG_STATE_HOME/ErpForFactoryGames/agent-logs/ by the agent itself;
+            # journal still picks up stdout for `systemctl --user status erp-agent`.
+            StandardOutput=journal
+            StandardError=journal
+
+            [Install]
+            WantedBy=default.target
+            """;
+        await File.WriteAllTextAsync(unitPath, unit).ConfigureAwait(false);
+        Console.Out.WriteLine($"Wrote unit {unitPath}");
+
+        // daemon-reload picks up the new file, enable --now starts it + sets up auto-start at user login.
+        var reload = await RunAsync("systemctl", "--user daemon-reload").ConfigureAwait(false);
+        if (reload.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"systemctl --user daemon-reload failed (exit {reload.ExitCode}): {reload.Stderr}");
+            return reload.ExitCode;
+        }
+
+        var enable = await RunAsync("systemctl", $"--user enable --now {ServiceName}").ConfigureAwait(false);
+        if (enable.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"systemctl --user enable failed (exit {enable.ExitCode}): {enable.Stderr}");
+            return enable.ExitCode;
+        }
+
+        Console.Out.WriteLine($"Unit '{ServiceName}.service' installed and started.");
+        Console.Out.WriteLine("Configure the API URL + token at $XDG_CONFIG_HOME/ErpForFactoryGames/agent.json and restart with:");
+        Console.Out.WriteLine($"  systemctl --user restart {ServiceName}");
+        Console.Out.WriteLine("To survive logout, enable user lingering: loginctl enable-linger \"$USER\"");
+        return 0;
+    }
+
+    private static async Task<int> UninstallSystemdUserAsync()
+    {
+        await RunAsync("systemctl", $"--user disable --now {ServiceName}").ConfigureAwait(false);
+
+        var unitPath = Path.Combine(
+            Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+              ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config"),
+            "systemd", "user", $"{ServiceName}.service");
+        if (File.Exists(unitPath))
+        {
+            File.Delete(unitPath);
+            Console.Out.WriteLine($"Removed {unitPath}");
+        }
+
+        await RunAsync("systemctl", "--user daemon-reload").ConfigureAwait(false);
+        Console.Out.WriteLine($"Unit '{ServiceName}.service' uninstalled.");
+        return 0;
+    }
+
+    // ---------- shell helper --------------------------------------------
+
+    private static async Task<ProcessResult> RunAsync(string file, string args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = file,
+            Arguments = args,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        using var p = Process.Start(psi)!;
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        await p.WaitForExitAsync().ConfigureAwait(false);
+        return new ProcessResult(p.ExitCode, await stdoutTask.ConfigureAwait(false), await stderrTask.ConfigureAwait(false));
+    }
+
+    private readonly record struct ProcessResult(int ExitCode, string Stdout, string Stderr);
+}


### PR DESCRIPTION
Closes #201. Per ADR-0024 §7.

## Summary

- `ServiceRegistrar` — `--install` / `--uninstall` handlers:
  - **Windows**: `sc.exe` with `start= delayed-auto`, 2× restart-on-failure, sensible description. Elevation checked upfront with a clear error if not.
  - **Linux**: writes `~/.config/systemd/user/erp-agent.service` (`Type=notify`), runs `systemctl --user enable --now`. No `sudo` required.
  - **macOS**: prints "not supported in v1" + suggests running the binary manually.
- `Program.cs` CLI dispatch — `--install` / `--uninstall` / `--version` / `--help` short-circuit before the generic host boots.
- `Agent.csproj` — single-file self-contained publish (`PublishSingleFile=true`, `SelfContained=true`, `IncludeNativeLibrariesForSelfExtract=true`, `PublishReadyToRun=true`, `DebugType=embedded`). Symbols ride inside the exe so crash traces work without a separate `.pdb`.
- `INSTALL.md` — first-run guide for Windows + Linux + the macOS deferral, config layout, save-folder auto-detect, troubleshooting.
- `release-images.yml` — new `publish-agent` job (matrix: `win-x64` on windows-latest → `.zip`, `linux-x64` on ubuntu-latest → `.tar.gz`). `gh release upload --clobber`; idempotent release-create if the tag-auto-flow hasn't fired yet.

## Smoke-tested locally

```
$ dotnet publish src/Agent/Agent.csproj -c Release -r win-x64 -o /tmp/agent-publish
$ ls -lh /tmp/agent-publish/
  3.6K INSTALL.md
   179 agent.json.example
   350 appsettings.json
   86M erp-agent.exe          ← single-file self-contained, no .pdb sibling
```

`erp-agent --help` and `erp-agent --version` (returns `0.4.0.0` from NB.GV) both work.

## Design calls

- **Embedded symbols** (`DebugType=embedded`) — no separate `.pdb` to ship/lose, crash traces still readable.
- **No `PublishTrimmed`** — `ILogger` / Serilog / `Microsoft.Extensions.*` are reflection-heavy; trim warnings would eat days for marginal size payoff on a single binary.
- **`PublishReadyToRun=true`** — first launch isn't a 3s JIT pause while SCM / systemd's notify-watchdog frets.
- **Windows: `sc.exe` not `ServiceController`** — `sc` is the boring, well-documented surface; `ServiceController` doesn't expose `start= delayed-auto` or `failure` config without P/Invoke.
- **Linux: `--user` not system-wide** — gamer dev boxes don't want sudo prompts. Documented in INSTALL.md that `loginctl enable-linger` is the lingering survival path.

## Test plan

- [x] `dotnet build src/Agent/` → 0 warnings, 0 errors.
- [x] `dotnet publish -c Release -r win-x64` → 86 MB exe with INSTALL.md + appsettings.json + agent.json.example, no .pdb.
- [x] `dotnet test test/Agent.Tests/` → 4 passed.
- [x] `dotnet format --verify-no-changes` → clean.
- [x] `erp-agent --help` / `--version` smoke.
- [ ] CI green.
- [ ] After merge: cut a `v0.5.0` tag. Verify the `publish-agent` matrix attaches both archives to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)