### PR TITLE
feat(api): agent upload + status endpoints

### DIFF
--- a/src/ApiService/AgentUploadOptions.cs
+++ b/src/ApiService/AgentUploadOptions.cs
@@ -1,0 +1,38 @@
+namespace ApiService;
+
+/// <summary>
+/// Bound from <c>AgentUploads</c> in configuration. Controls where uploaded
+/// <c>.sav</c> files land on the server.
+/// </summary>
+public sealed class AgentUploadOptions
+{
+    /// <summary>
+    /// Directory the server writes uploaded saves into. The agent's last
+    /// upload is also persisted at <c>{UploadDirectory}/satisfactory-latest.sav</c>
+    /// so a process restart can pick up where we left off via the existing
+    /// <see cref="ERP.Application.IFactoryStateProvider.LoadFromPath"/>.
+    /// Defaults to <c>%LocalAppData%/ErpForFactoryGames/uploads/</c> on
+    /// Windows or <c>$XDG_STATE_HOME/ErpForFactoryGames/uploads/</c> on
+    /// Linux. Override for containerised deployments to point at a mounted
+    /// volume.
+    /// </summary>
+    public string? UploadDirectory { get; set; }
+
+    /// <summary>
+    /// How big a single upload can be. Satisfactory saves run 50–200 MB on
+    /// real worlds; cap at 512 MB to leave headroom without being a DoS
+    /// gift.
+    /// </summary>
+    public long MaxUploadBytes { get; set; } = 512L * 1024 * 1024;
+
+    public string ResolveUploadDirectory()
+    {
+        if (!string.IsNullOrWhiteSpace(UploadDirectory)) return UploadDirectory;
+
+        var baseDir = OperatingSystem.IsWindows()
+            ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+            : Environment.GetEnvironmentVariable("XDG_STATE_HOME")
+              ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "state");
+        return Path.Combine(baseDir, "ErpForFactoryGames", "uploads");
+    }
+}

--- a/src/ApiService/AgentUploadStatus.cs
+++ b/src/ApiService/AgentUploadStatus.cs
@@ -1,0 +1,36 @@
+namespace ApiService;
+
+/// <summary>
+/// Server-side snapshot of what the agent last uploaded, for the
+/// <c>GET /agent/status</c> endpoint and the Web UI status card (#200).
+/// Singleton; replaced atomically on each upload.
+/// </summary>
+public interface IAgentUploadStatus
+{
+    UploadSnapshot? Latest { get; }
+
+    void Record(UploadSnapshot snapshot);
+}
+
+/// <summary>
+/// One row in the recent-uploads ledger. Wire-equivalent of the agent's own
+/// <c>UploadAttempt</c>, projected for the UI.
+/// </summary>
+public sealed record UploadSnapshot(
+    string FileName,
+    DateTimeOffset ParsedAt,
+    int? SaveVersion,
+    int? BuildVersion,
+    bool Succeeded,
+    int StatusCode,
+    string? Detail,
+    string? AgentVersion);
+
+internal sealed class AgentUploadStatus : IAgentUploadStatus
+{
+    // Reference assignment is atomic in .NET — no locking. Worst case is a
+    // slightly-stale read in another thread, fine for a status snapshot.
+    public UploadSnapshot? Latest { get; private set; }
+
+    public void Record(UploadSnapshot snapshot) => Latest = snapshot;
+}

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -29,6 +29,11 @@ builder.Services.AddErpPersistence(builder.Configuration);
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
 
+// Agent upload tracking + config. Server-side counterpart to the agent's
+// IAgentStatus. Singleton — atomic snapshot replacement per upload.
+builder.Services.Configure<AgentUploadOptions>(builder.Configuration.GetSection("AgentUploads"));
+builder.Services.AddSingleton<IAgentUploadStatus, AgentUploadStatus>();
+
 var app = builder.Build();
 
 // Apply pending plan-storage migrations on startup so the SQLite default Just
@@ -557,6 +562,138 @@ app.MapGet("/plans/shared/{token}", async (
 
     var plan = await plans.GetAsync(entity.PlanId, ct);
     return plan is null ? Results.NotFound() : Results.Ok(SavedPlanDto.From(plan));
+});
+
+// ---------------------------------------------------------------------------
+// Agent endpoints (#199). Wire shape per ADR-0024 §4 + §5.
+//
+//   POST /agent/savegames/satisfactory  — raw .sav body, three X-Agent-*
+//     headers. Token accepted as opaque (auth seam; future ADR-0025 wires
+//     real validation). Parser failures land 422 with the exception type +
+//     first-line of the message in the body.
+//
+//   GET  /agent/status                  — last upload snapshot for the
+//     Web UI status card (#200).
+// ---------------------------------------------------------------------------
+
+app.MapPost("/agent/savegames/satisfactory", async (
+    HttpRequest http,
+    IFactoryStateProvider provider,
+    IAgentUploadStatus uploadStatus,
+    Microsoft.Extensions.Options.IOptions<AgentUploadOptions> uploadOptions,
+    ILoggerFactory loggerFactory,
+    CancellationToken ct) =>
+{
+    var log = loggerFactory.CreateLogger("AgentUpload");
+
+    var token = http.Headers["X-Agent-Token"].ToString();
+    if (string.IsNullOrWhiteSpace(token))
+    {
+        // 401 (not 400/403) so the eventual real-auth ADR-0025 keeps the
+        // same status-code semantics — see ADR-0024 §5.
+        return Results.Json(new { error = "X-Agent-Token header is required." }, statusCode: 401);
+    }
+
+    if (!string.Equals(http.ContentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.Json(
+            new { error = $"Content-Type must be application/octet-stream; got '{http.ContentType}'." },
+            statusCode: 415);
+    }
+
+    var opts = uploadOptions.Value;
+    if (http.ContentLength is { } len && len > opts.MaxUploadBytes)
+    {
+        return Results.Json(
+            new { error = $"Upload exceeds MaxUploadBytes ({opts.MaxUploadBytes})." },
+            statusCode: 413);
+    }
+
+    var fileNameHeader = http.Headers["X-Agent-FileName"].ToString();
+    var displayName = string.IsNullOrWhiteSpace(fileNameHeader)
+        ? "uploaded.sav"
+        : Uri.UnescapeDataString(fileNameHeader);
+    var agentVersion = http.Headers["X-Agent-Version"].ToString();
+    if (string.IsNullOrWhiteSpace(agentVersion)) agentVersion = null;
+
+    var uploadDir = opts.ResolveUploadDirectory();
+    Directory.CreateDirectory(uploadDir);
+    var targetPath = Path.Combine(uploadDir, "satisfactory-latest.sav");
+    var tempPath = targetPath + ".upload";
+
+    try
+    {
+        await using (var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None,
+                         bufferSize: 64 * 1024, useAsync: true))
+        {
+            await http.Body.CopyToAsync(fs, ct).ConfigureAwait(false);
+        }
+        File.Move(tempPath, targetPath, overwrite: true);
+
+        var parsedAt = DateTimeOffset.UtcNow;
+        try
+        {
+            var status = provider.LoadFromPath(targetPath);
+            uploadStatus.Record(new UploadSnapshot(
+                FileName: displayName,
+                ParsedAt: parsedAt,
+                SaveVersion: status.SaveVersion,
+                BuildVersion: status.BuildVersion,
+                Succeeded: true,
+                StatusCode: 200,
+                Detail: null,
+                AgentVersion: agentVersion));
+            log.LogInformation(
+                "Agent upload {File} ({Bytes} bytes, agent v{Agent}) → save v{SaveVersion}, build {BuildVersion}",
+                displayName, http.ContentLength ?? -1, agentVersion ?? "?", status.SaveVersion, status.BuildVersion);
+            return Results.Ok(new
+            {
+                saveVersion = status.SaveVersion,
+                buildVersion = status.BuildVersion,
+                parsedAt,
+            });
+        }
+        catch (Exception parseEx)
+        {
+            uploadStatus.Record(new UploadSnapshot(
+                FileName: displayName,
+                ParsedAt: parsedAt,
+                SaveVersion: null,
+                BuildVersion: null,
+                Succeeded: false,
+                StatusCode: 422,
+                Detail: parseEx.GetType().Name + ": " + parseEx.Message,
+                AgentVersion: agentVersion));
+            log.LogWarning(parseEx, "Agent upload {File} parse failed", displayName);
+            return Results.Json(
+                new { error = "Save parse failed.", detail = parseEx.Message, type = parseEx.GetType().Name },
+                statusCode: 422);
+        }
+    }
+    catch (Exception ex)
+    {
+        log.LogError(ex, "Agent upload {File} threw before/after parse", displayName);
+        try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { /* best effort */ }
+        return Results.Problem(title: "Upload failed", detail: ex.Message, statusCode: 500);
+    }
+});
+
+app.MapGet("/agent/status", (IAgentUploadStatus status, TimeProvider clock) =>
+{
+    var latest = status.Latest;
+    // isStale = no upload in the last 10 minutes. The watcher only fires
+    // on save change; expect long quiet periods on a paused game. Tune
+    // later if the UI complains.
+    var stalenessThreshold = TimeSpan.FromMinutes(10);
+    var now = clock.GetUtcNow();
+    var isStale = latest is null || (now - latest.ParsedAt) > stalenessThreshold;
+
+    return Results.Ok(new
+    {
+        lastUpload = latest,
+        agentSeen = latest?.ParsedAt,
+        isStale,
+    });
 });
 
 app.MapDefaultEndpoints();

--- a/test/ApiService.Tests/AgentEndpointsTests.cs
+++ b/test/ApiService.Tests/AgentEndpointsTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace ApiService.Tests;
+
+/// <summary>
+/// Integration tests for the agent upload + status endpoints (#199).
+/// Token validation, content-type rejection, and the status snapshot
+/// surface are covered; round-tripping a real <c>.sav</c> through the
+/// parser is left to manual smoke (no committed fixture, and the parser
+/// is exercised by the existing /factory/ingest tests).
+/// </summary>
+public sealed class AgentEndpointsTests : IClassFixture<AgentEndpointsTests.AgentApiFactory>
+{
+    private readonly AgentApiFactory _factory;
+
+    public AgentEndpointsTests(AgentApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Upload_without_token_returns_401()
+    {
+        var client = _factory.CreateClient();
+        var content = new ByteArrayContent(new byte[] { 0x01, 0x02 });
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        var response = await client.PostAsync("/agent/savegames/satisfactory", content);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Upload_with_wrong_content_type_returns_415()
+    {
+        var client = _factory.CreateClient();
+        var content = new StringContent("not a save", System.Text.Encoding.UTF8, "text/plain");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/agent/savegames/satisfactory")
+        {
+            Content = content,
+        };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", "any-non-empty");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Upload_with_garbage_body_returns_422_and_records_failure()
+    {
+        var client = _factory.CreateClient();
+        var content = new ByteArrayContent(new byte[] { 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00 });
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/agent/savegames/satisfactory")
+        {
+            Content = content,
+        };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", "any-non-empty");
+        request.Headers.TryAddWithoutValidation("X-Agent-FileName", "garbage.sav");
+        request.Headers.TryAddWithoutValidation("X-Agent-Version", "0.0.0-test");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+
+        // The failure should be visible on /agent/status too.
+        var status = await client.GetFromJsonAsync<StatusEnvelope>("/agent/status");
+        Assert.NotNull(status);
+        Assert.NotNull(status!.LastUpload);
+        Assert.False(status.LastUpload!.Succeeded);
+        Assert.Equal(422, status.LastUpload.StatusCode);
+        Assert.Equal("garbage.sav", status.LastUpload.FileName);
+        Assert.Equal("0.0.0-test", status.LastUpload.AgentVersion);
+    }
+
+    [Fact]
+    public async Task Status_returns_isStale_true_with_no_upload()
+    {
+        // Fresh factory — never received an upload. /agent/status should
+        // surface that as isStale=true with null lastUpload.
+        await using var fresh = new AgentApiFactory();
+        var client = fresh.CreateClient();
+
+        var status = await client.GetFromJsonAsync<StatusEnvelope>("/agent/status");
+
+        Assert.NotNull(status);
+        Assert.True(status!.IsStale);
+        Assert.Null(status.LastUpload);
+        Assert.Null(status.AgentSeen);
+    }
+
+    // Wire-equivalent of the JSON the endpoint emits. Matches the
+    // anonymous-object shape in Program.cs.
+    private sealed record StatusEnvelope(UploadSnapshotView? LastUpload, DateTimeOffset? AgentSeen, bool IsStale);
+    private sealed record UploadSnapshotView(
+        string FileName,
+        DateTimeOffset ParsedAt,
+        int? SaveVersion,
+        int? BuildVersion,
+        bool Succeeded,
+        int StatusCode,
+        string? Detail,
+        string? AgentVersion);
+
+    public sealed class AgentApiFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"erp-agent-tests-{Guid.NewGuid():N}.db");
+        private readonly string _uploadDir = Path.Combine(Path.GetTempPath(), $"erp-agent-uploads-{Guid.NewGuid():N}");
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Persistence:Provider"] = "sqlite",
+                    ["ConnectionStrings:Plans"] = $"Data Source={_dbPath}",
+                    ["AgentUploads:UploadDirectory"] = _uploadDir,
+                });
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best-effort */ }
+            try { if (Directory.Exists(_uploadDir)) Directory.Delete(_uploadDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}


### PR DESCRIPTION
Closes #199. Server-side counterpart to the agent's `HttpSaveUploader` (#198) — closes the upload loop.

## Endpoints (per ADR-0024 §4 + §5)

### `POST /agent/savegames/satisfactory`

- **Body**: raw `.sav` (`application/octet-stream`).
- **Headers**:
  - `X-Agent-Token` — required, accepted as opaque (auth seam).
  - `X-Agent-FileName` — URL-encoded display name, surfaces in status.
  - `X-Agent-Version` — logged but not validated.
- **Status codes**:
  - `401` on missing/empty token.
  - `415` on wrong content-type.
  - `413` on body exceeding `AgentUploads:MaxUploadBytes` (default 512 MB).
  - `422` on parse failure, with `{ error, detail, type }` body.
  - `200` with `{ saveVersion, buildVersion, parsedAt }`.

Writes to `{UploadDirectory}/satisfactory-latest.sav` (overwriting, via temp + rename for atomicity), then invokes `IFactoryStateProvider.LoadFromPath` which goes through the vendored `SatisfactorySaveNet` parser.

### `GET /agent/status`

Returns `{ lastUpload, agentSeen, isStale }`. `isStale: true` when no upload in the last 10 minutes. Schema designed for the #200 `AgentStatusCard` component — camelCase, nullable-friendly so a fresh server with no uploads renders cleanly.

## Tests (4, all passing)

- `Upload_without_token_returns_401`
- `Upload_with_wrong_content_type_returns_415`
- `Upload_with_garbage_body_returns_422_and_records_failure` — also verifies the failure shows up on `/agent/status`
- `Status_returns_isStale_true_with_no_upload`

Round-tripping a real `.sav` is left to manual smoke (no committed fixture, and `/factory/ingest` already exercises the parser).

## Test plan

- [x] `dotnet build src/ApiService/` → 0 errors.
- [x] `dotnet test test/ApiService.Tests/ --filter AgentEndpointsTests` → 4 passed.
- [x] `dotnet format --verify-no-changes` → clean.
- [ ] CI green.
- [ ] After merge: configure local agent (`agent.json`) against this API, save a game in-engine, watch the upload land + the status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)