### PR TITLE
feat(web): shared AgentStatusCard component

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -10,6 +10,7 @@
     <Project Path="src/AppHost/AppHost.csproj" />
     <Project Path="src/ServiceDefaults/ServiceDefaults.csproj" />
     <Project Path="src/Web/Web.csproj" />
+    <Project Path="src/Web.Shared/Web.Shared.csproj" />
   </Folder>
   <Folder Name="/src/ERP/" />
   <Folder Name="/src/ERP/Application/">

--- a/src/Web.Shared/AgentStatusCard.razor
+++ b/src/Web.Shared/AgentStatusCard.razor
@@ -1,0 +1,152 @@
+@* Shared status card for the agent's last upload. Lives in Web.Shared so
+   both Satisfactory's src/Web/ and CoI's src/CaptainOfIndustry/Web/ can
+   drop it on any page. Styling is host-app responsibility — pass
+   `CssClass`/`HeaderClass` to match each app's theme.
+
+   The component takes its HttpClient as a Parameter rather than DI-injecting,
+   so each host app can pass whichever client it already has pointed at its
+   API (Satisfactory: the `apiservice` Aspire reference; CoI: the in-process
+   ApiService when one ships). Avoids forcing a default HttpClient registration
+   on the host. *@
+
+@implements IDisposable
+
+<div class="@CssClass">
+    <div class="@HeaderClass">
+        <strong>Live save</strong>
+        @if (_loading)
+        {
+            <span style="opacity:.65; margin-left:.5em;">checking…</span>
+        }
+        else if (_status is null)
+        {
+            <span style="opacity:.65; margin-left:.5em;">unavailable</span>
+        }
+        else if (_status.LastUpload is null)
+        {
+            <span style="opacity:.65; margin-left:.5em;">no upload yet</span>
+        }
+        else if (_status.IsStale)
+        {
+            <span style="opacity:.65; margin-left:.5em;">stale</span>
+        }
+        else
+        {
+            <span style="opacity:.65; margin-left:.5em;">up to date</span>
+        }
+    </div>
+
+    @if (_status?.LastUpload is { } last)
+    {
+        <div>
+            <div><strong>File</strong>: @last.FileName</div>
+            <div><strong>Parsed</strong>: @last.ParsedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</div>
+            @if (last.SaveVersion is int sv)
+            {
+                <div><strong>Save / build</strong>: v@sv@(last.BuildVersion is int bv ? $" / {bv}" : "")</div>
+            }
+            <div>
+                <strong>Status</strong>:
+                @if (last.Succeeded)
+                {
+                    <span>OK (@last.StatusCode)</span>
+                }
+                else
+                {
+                    <span style="color:#c0392b;">failed (@last.StatusCode)</span>
+                    @if (!string.IsNullOrWhiteSpace(last.Detail))
+                    {
+                        <div style="font-size:.85em; opacity:.85;">@last.Detail</div>
+                    }
+                }
+            </div>
+            @if (!string.IsNullOrWhiteSpace(last.AgentVersion))
+            {
+                <div style="opacity:.65; font-size:.85em;">agent v@last.AgentVersion</div>
+            }
+        </div>
+    }
+    else if (_status is not null)
+    {
+        <div style="opacity:.85;">
+            Install the agent on the machine that runs Satisfactory and point it at this server's API URL.
+            See the agent's <code>INSTALL.md</code> for setup.
+        </div>
+    }
+    else if (_error is not null)
+    {
+        <div style="color:#c0392b; font-size:.85em;">Couldn't reach agent status endpoint: @_error</div>
+    }
+</div>
+
+@code {
+    /// <summary>HttpClient pointed at the ApiService that hosts <c>/agent/status</c>.</summary>
+    [Parameter, EditorRequired] public HttpClient Http { get; set; } = default!;
+
+    /// <summary>CSS class applied to the outer card container so the host app can theme it.</summary>
+    [Parameter] public string? CssClass { get; set; }
+
+    /// <summary>CSS class applied to the header row. Same idea.</summary>
+    [Parameter] public string? HeaderClass { get; set; }
+
+    /// <summary>
+    /// How often to re-poll <c>GET /agent/status</c>. Default 5s. The
+    /// endpoint is cheap (in-memory snapshot read) so polling is fine for v1;
+    /// SignalR push lands later if it becomes annoying.
+    /// </summary>
+    [Parameter] public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    private AgentStatusDto? _status;
+    private string? _error;
+    private bool _loading = true;
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _cts = new CancellationTokenSource();
+        await RefreshAsync(_cts.Token);
+        _ = PollLoopAsync(_cts.Token);
+    }
+
+    private async Task PollLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(PollInterval, ct);
+                await RefreshAsync(ct);
+                await InvokeAsync(StateHasChanged);
+            }
+            catch (OperationCanceledException) { return; }
+            catch
+            {
+                // RefreshAsync already wrote _error; absorb and keep polling.
+            }
+        }
+    }
+
+    private async Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            _status = await Http.GetFromJsonAsync<AgentStatusDto>("/agent/status", ct);
+            _error = null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _status = null;
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+}

--- a/src/Web.Shared/AgentStatusDto.cs
+++ b/src/Web.Shared/AgentStatusDto.cs
@@ -1,0 +1,20 @@
+namespace Web.Shared;
+
+/// <summary>
+/// Wire shape for <c>GET /agent/status</c>. Mirrors the anonymous JSON
+/// the ApiService endpoint emits (camelCase, nullable-friendly).
+/// </summary>
+public sealed record AgentStatusDto(
+    UploadSnapshotDto? LastUpload,
+    DateTimeOffset? AgentSeen,
+    bool IsStale);
+
+public sealed record UploadSnapshotDto(
+    string FileName,
+    DateTimeOffset ParsedAt,
+    int? SaveVersion,
+    int? BuildVersion,
+    bool Succeeded,
+    int StatusCode,
+    string? Detail,
+    string? AgentVersion);

--- a/src/Web.Shared/Web.Shared.csproj
+++ b/src/Web.Shared/Web.Shared.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Web.Shared</RootNamespace>
+    <!-- Per ADR-0024 §6: no MudBlazor in the shared library's public
+         surface. Each host app re-styles via CssClass parameters. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/Web.Shared/_Imports.razor
+++ b/src/Web.Shared/_Imports.razor
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using System.Net.Http
+@using System.Net.Http.Json

--- a/src/Web/Components/Pages/Home.razor
+++ b/src/Web/Components/Pages/Home.razor
@@ -1,4 +1,5 @@
 @page "/"
+@inject IHttpClientFactory HttpFactory
 
 <PageTitle>ERP.Satisfactory</PageTitle>
 
@@ -58,3 +59,22 @@
         </MudPaper>
     </MudItem>
 </MudGrid>
+
+<MudPaper Class="fx-panel pa-4 mt-4" Elevation="0">
+    @* Agent live-save status — shared component in src/Web.Shared/, also
+       intended for the future CoI Web app. See ADR-0024 §6 and #200. *@
+    <Web.Shared.AgentStatusCard Http="@_agentClient" />
+</MudPaper>
+
+@code {
+    private HttpClient _agentClient = default!;
+
+    protected override void OnInitialized()
+    {
+        // Reuse the named "planner" client registered in Program.cs so the
+        // card hits the same `apiservice` Aspire reference as the rest of
+        // the app. AddHttpClient<PlannerApiClient> registers under the
+        // typed-client name (= "PlannerApiClient") which we mimic here.
+        _agentClient = HttpFactory.CreateClient(nameof(PlannerApiClient));
+    }
+}

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
     <ProjectReference Include="..\ERP\Application\ERP.Application.csproj" />
     <ProjectReference Include="..\ERP\Infrastructure\ERP.Infrastructure.csproj" />
+    <ProjectReference Include="..\Web.Shared\Web.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #200. Last issue of milestone #17 — the agent loop is fully visible end-to-end after this lands.

Also closes the lazy [#181](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/181) tracker organically: this is the first concrete piece of shared frontend code, exactly the trigger the policy waited for.

## What landed

- **New `src/Web.Shared/` Razor class library** — Microsoft.NET.Sdk.Razor, references `Microsoft.AspNetCore.App` only. **Deliberately doesn't reference MudBlazor**; components take `CssClass`/`HeaderClass` slots so each host app re-styles with its own theme. Future-proofs against the MudBlazor reservations in ADR-0017.
- **`AgentStatusCard.razor`** — polls `GET /agent/status` (default 5s, configurable), renders last upload's `FileName` / `ParsedAt` / `SaveVersion` / `BuildVersion` / status. Empty state surfaces the "no upload yet" message + a pointer to the agent's `INSTALL.md`. Error state shows the fetch failure without crashing the page.
- **`AgentStatusDto.cs`** — wire shape mirroring the API endpoint's anonymous JSON (camelCase, nullable-friendly).
- **`_Imports.razor`** — the bare minimum so the component compiles standalone.
- **Wired into `src/Web/` Home page** — drops the card below the three existing feature tiles. Uses `IHttpClientFactory.CreateClient(nameof(PlannerApiClient))` so the card hits the same Aspire `apiservice` reference as the rest of the app, without forcing a default `HttpClient` registration.

## Design calls

- **HttpClient as Parameter, not `@inject`** — host app supplies whichever client is pointed at its API. Avoids forcing a default `HttpClient` registration in every consumer and lets each game's app route through its own typed client.
- **`[Parameter, EditorRequired]` on Http** — the analyzer warns if a host forgets to pass it. No silent NullRef at runtime.
- **Background polling via `Task.Delay` + `_cts`** — no SignalR for v1 (endpoint is in-memory cheap, polling is fine). `IDisposable` cancels the loop when the component unmounts.

## Smoke

Playwright drove `/` under AppHost. Card renders:

> **Live save**  no upload yet
> Install the agent on the machine that runs Satisfactory and point it at this server's API URL. See the agent's `INSTALL.md` for setup.

Screenshot at `test/ui-tests/agent-status-card-empty.png` (gitignored, transient).

## Test plan

- [x] `dotnet build` → 0 errors (only the pre-existing `Planner.razor` null-deref warning).
- [x] `dotnet format --verify-no-changes` → clean.
- [x] Browser smoke under AppHost — card renders cleanly, empty state shows the agent-install hint.
- [ ] CI green.

## Milestone state after merge

With this, **milestone #17 is closed** and #154 (1.0 release) unblocks. Agent ↔ API ↔ Web loop is end-to-end working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)