### PR TITLE
fix(agent): watcher disposed before any event could fire

### DIFF
--- a/src/Agent/SaveFolderWatcher.cs
+++ b/src/Agent/SaveFolderWatcher.cs
@@ -38,7 +38,7 @@ internal sealed class SaveFolderWatcher : BackgroundService
         _logger = logger;
     }
 
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var folder = _resolver.Resolve();
         var accessible = folder is not null && Directory.Exists(folder);
@@ -54,7 +54,8 @@ internal sealed class SaveFolderWatcher : BackgroundService
             // Sit idle until cancellation — the host still runs, status UI
             // can show the "not configured" state, and Win-service / systemd
             // will keep it alive until the user reconfigures + restarts.
-            return Task.Delay(Timeout.Infinite, stoppingToken);
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+            return;
         }
 
         if (!accessible)
@@ -62,15 +63,25 @@ internal sealed class SaveFolderWatcher : BackgroundService
             _logger.LogWarning(
                 "Save folder {Folder} is not accessible (does not exist or not readable). Idling.",
                 folder);
-            return Task.Delay(Timeout.Infinite, stoppingToken);
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+            return;
         }
 
         _logger.LogInformation("Watching {Folder} for *.sav changes", folder);
 
+        // IMPORTANT: must `await` the Task.Delay below, not `return` it. The
+        // watcher's lifetime is bound to this method's stack frame; a sync
+        // return disposes the watcher before any event can fire. Found on
+        // first end-to-end smoke — was the v1.0-blocker bug.
         using var watcher = new FileSystemWatcher(folder)
         {
             Filter = "*.sav",
-            IncludeSubdirectories = false,
+            // Satisfactory stores saves under SaveGames/<steam-user-id>/<save>.sav,
+            // so the watcher MUST recurse one level into the per-user folder.
+            // We watch the root (which auto-detects to %LocalAppData%/FactoryGame/Saved/SaveGames/)
+            // and let FSW recurse; rare configurations may have multiple users
+            // on one machine, which is fine — all of them upload from the same agent.
+            IncludeSubdirectories = true,
             NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
             EnableRaisingEvents = true,
         };
@@ -80,7 +91,7 @@ internal sealed class SaveFolderWatcher : BackgroundService
         watcher.Renamed += (_, e) => Enqueue(e.FullPath, stoppingToken);
         watcher.Error += (_, e) => _logger.LogError(e.GetException(), "FileSystemWatcher error");
 
-        return Task.Delay(Timeout.Infinite, stoppingToken);
+        await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
     }
 
     private void Enqueue(string fullPath, CancellationToken hostCt)


### PR DESCRIPTION
V1.0-blocker, found on the pre-tag end-to-end smoke.

## Bug

\`SaveFolderWatcher.ExecuteAsync\` returned the \`Task.Delay\` synchronously while holding the \`FileSystemWatcher\` in a \`using var\` local. Stack unwinding disposed the watcher the moment the method returned the Task — no event handler ever ran. The agent looked alive (logged "Watching ..."), but file events fired into the void.

## Fix

Make \`ExecuteAsync\` async and \`await\` the delay so the using-scope lives until cancellation.

Bonus: \`IncludeSubdirectories = true\`. Satisfactory nests saves under \`SaveGames/<steam-user-id>/<save>.sav\`; the original \`false\` would have missed them even after the disposal bug was fixed.

## Verified end-to-end

\`\`\`
agent boots, points at http://localhost:5448
$ cp Autoplay.sav .../SaveGames/<userId>/smoke-fix.sav

agent log:
  [INF] Sending HTTP request POST http://localhost:5448/agent/savegames/satisfactory
  [INF] Received HTTP response headers after 39554ms - 200
  [INF] Uploaded smoke-fix.sav -> 200

curl /agent/status:
  { "lastUpload": { "fileName": "smoke-fix.sav", "saveVersion": 59, "buildVersion": 488068, "succeeded": true, "statusCode": 200, "agentVersion": "0.4.0.0" }, "isStale": false }

curl /factory/state:
  { "isLoaded": true, "save": { "sessionName": "Beta Game", "saveVersion": 59, ... } }
\`\`\`

Real Satisfactory save (286 KB), real game metadata, real parse via the vendored SatisfactorySaveNet. Round-trip ~40s (parse-bound, same characteristics as `/factory/ingest`).

## Test plan

- [x] 4 existing Agent tests still pass.
- [x] \`dotnet format --verify-no-changes\` → clean.
- [x] Manual end-to-end smoke confirmed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)