### PR TITLE
feat(deploy): attach Homelab.Stacks sister repo as submodule (#209)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,12 @@
 	# inspection. Same skip/ignore treatment.
 	ignore = all
 	update = none
+[submodule "deploy/Homelab.Stacks.ErpForFactoryGames"]
+	path = deploy/Homelab.Stacks.ErpForFactoryGames
+	url = https://github.com/ChrisonSimtian/Homelab.Stacks.ErpForFactoryGames.git
+	# Deploy stack — off the build graph. Operators who want to drive the
+	# homelab can `git submodule update --init --checkout
+	# deploy/Homelab.Stacks.ErpForFactoryGames` on demand. Same skip/ignore
+	# posture as vendor/* so a fresh checkout doesn't show pointer drift.
+	ignore = all
+	update = none

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ src/
 test/                     # xUnit projects per layer
 build/                    # NUKE C# build scripts
 vendor/SatisfactorySaveNet # Forked .sav parser submodule
+deploy/Homelab.Stacks.ErpForFactoryGames # Compose stack submodule (off the build graph)
 docs/adr/                 # Architecture decisions
 .claude/                  # Claude Code conventions for this repo
 ```
@@ -323,6 +324,24 @@ Bump the major/minor by editing [`version.json`](version.json) — the next
 commit becomes `vX.Y.0`. Patch increments per commit automatically.
 
 `main` is protected: PRs require all four matrix checks to pass before merging.
+
+## Self-hosting
+
+The Blazor apps run on Chris's homelab as Docker containers behind a
+Cloudflare Tunnel — see [ADR-0023](docs/adr/0023-hosting-deployment-approach.md)
+for the why and [`docs/operations/deploy.md`](docs/operations/deploy.md) for
+the tag-to-deploy runbook.
+
+The compose stack lives in a sibling repo,
+[`Homelab.Stacks.ErpForFactoryGames`](https://github.com/ChrisonSimtian/Homelab.Stacks.ErpForFactoryGames),
+attached here as a submodule at `deploy/Homelab.Stacks.ErpForFactoryGames/`.
+Like the `vendor/*` submodules it's off the build graph (`update = none`,
+`ignore = all`); fetch it explicitly only when you want to operate the
+homelab:
+
+```powershell
+git submodule update --init --checkout deploy/Homelab.Stacks.ErpForFactoryGames
+```
 
 ## Backlog
 

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -15,17 +15,21 @@ ghcr.io/chrisonsimtian/erp-api     :v0.5.0  + :latest
        │  Watchtower polls every 6h, pulls :latest
        ▼
 Homelab Docker host (one of three Proxmox nodes)
-   └─ Homelab.Stacks.ErpForFactoryGames  (sibling repo)
+   └─ Homelab.Stacks.ErpForFactoryGames  (sibling repo — self-contained)
        ├─ erp-web         (Blazor Server, port 8080)
-       └─ erp-api         (Wolverine + EF Core, port 8080)
+       ├─ erp-api         (Wolverine + EF Core, port 8080)
+       └─ cloudflared     (tunnel + ingress rules live in this stack)
        │
-       │  internal HTTP via shared docker network
+       │  ingress: satisfactory.erp-for-factory.games → http://erp-web:8080
        ▼
-Cloudflared tunnel (running in Homelab.Stacks.Infrastructure)
-       │  ingress rules in cloudflare config
-       ▼
-satisfactory.erp-for-factory.games  →  http://erp-web:8080
+satisfactory.erp-for-factory.games
 ```
+
+> The ERP stack runs its own `cloudflared` container with a dedicated
+> tunnel (not the shared one in `Homelab.Stacks.Infrastructure`). Keeps
+> deploy state for ERP in one place — minor deviation from ADR-0023's
+> "reuse existing tunnel" wording; revisit if a second deviation
+> appears.
 
 The CoI app (`captain-of-industry.erp-for-factory.games`) is **not yet
 deployed** — see the game-agent milestone for what's blocking it.
@@ -54,12 +58,15 @@ deployed** — see the game-agent milestone for what's blocking it.
 
 Tracked in `Homelab.Stacks.ErpForFactoryGames`. Outline:
 
-- `compose.yml` declares two services (`erp-web`, `erp-api`),
-  references the GHCR images, joins the shared `cloudflared` network.
+- `compose.yml` declares three services (`erp-web`, `erp-api`,
+  `cloudflared`) on an internal docker network. References the GHCR
+  images by tag.
 - ApiService gets the production database connection string via env
   var or a docker secret (see ADR-0018 for the persistence picture).
-- Cloudflare Tunnel ingress rules (in the tunnel config file or
-  dashboard) route the subdomain to `http://erp-web:8080`.
+- A dedicated Cloudflare Tunnel — created once via
+  `cloudflared tunnel create erp-for-factory-games` — provides the
+  credentials JSON. Ingress rules live in `config.yml` in the sister
+  repo and route the subdomain to `http://erp-web:8080`.
 
 ## When things break
 


### PR DESCRIPTION
## Summary

- Adds `deploy/Homelab.Stacks.ErpForFactoryGames` as a submodule pointing at the sister compose-stack repo, mirroring the `vendor/*` posture (`update = none`, `ignore = all`) so it stays off the build graph.
- Adds a **Self-hosting** section to `README.md` pointing operators at [ADR-0023](docs/adr/0023-hosting-deployment-approach.md) and [`docs/operations/deploy.md`](docs/operations/deploy.md), plus a one-line entry in the project-layout block.
- Updates `docs/operations/deploy.md` to reflect the simpler deploy story: the ERP sister stack runs its own `cloudflared` container with a dedicated tunnel, rather than threading an ingress rule through `Homelab.Stacks.Infrastructure`'s tunnel. Minor deviation from ADR-0023 noted inline.

Closes part of #209 (the in-repo half). Remaining for #209: sister-repo `compose.yml` (with cloudflared service) + `config.yml` (tunnel ingress) + `stack.env` + README + LICENSE — all Chris-driven outside this repo.

## Test plan

- [ ] Fresh clone without `--recurse-submodules` still builds (`dotnet build ErpForFactoryGames.slnx`) — submodule is off the build graph.
- [ ] `git submodule status` shows the new `deploy/` entry.
- [ ] `git status` after a normal build is clean (the `ignore = all` posture hides any pointer drift in the sister repo).
- [ ] CI matrix is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)