### PR TITLE
fix(docker): include Web.Shared in erp-web Dockerfile restore

### DIFF
--- a/src/Web/Dockerfile
+++ b/src/Web/Dockerfile
@@ -19,6 +19,7 @@ RUN --mount=type=secret,id=github_token \
 # Copy nuget config + build props + every csproj into the right layout first.
 COPY nuget.config Directory.Build.props version.json ./
 COPY src/Web/Web.csproj                                                src/Web/
+COPY src/Web.Shared/Web.Shared.csproj                                  src/Web.Shared/
 COPY src/ServiceDefaults/ServiceDefaults.csproj                        src/ServiceDefaults/
 COPY src/ApiService/ApiService.csproj                                  src/ApiService/
 COPY src/ERP/Application/ERP.Application.csproj                        src/ERP/Application/


### PR DESCRIPTION
The erp-web Dockerfile copies every referenced csproj into the build layer before \`dotnet restore\` so restore is cache-stable against csproj edits only. \`Web.Shared\` was added in PR #200 (AgentStatusCard) and #213 (AgentLogsCard) but the Dockerfile wasn't updated, so its assets file was never produced and \`dotnet publish src/Web/Web.csproj\` then failed:

\`\`\`
error NETSDK1004: Assets file 'src/Web.Shared/obj/project.assets.json' not found.
\`\`\`

Surfaced when manually dispatching \`release-images.yml\` for the first time — the auto-tag CI flow uses the default \`GITHUB_TOKEN\` which can't trigger other workflows, so this Dockerfile path hadn't been exercised since #200 merged.

Tracked as task #20 ("Fix tag-trigger gap for future deploys") — that follow-up will ensure the release-images workflow actually runs on the auto-generated tags, which would have caught this earlier.

## Test plan

- [x] Branch builds locally would catch this immediately, but the workflow wasn't running.
- [ ] CI green
- [ ] Manual re-dispatch of release-images.yml after merge succeeds for both erp-web and erp-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)