### PR TITLE
feat(web): agent download card on Home + stable archive names

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -86,12 +86,20 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
 
   # ---------------------------------------------------------------------------
-  # Agent — per-RID self-contained single-file publish. Skipped on
-  # workflow_dispatch (no release to attach to); only fires on tag push.
+  # Agent — per-RID self-contained single-file publish.
+  #
+  # Runs on BOTH tag push and workflow_dispatch:
+  #   - Tag push  → attach the archive to that tag's release.
+  #   - Dispatch  → attach to the most recent existing release (so the Home
+  #                 page's `/releases/latest/download/<stable-filename>` link
+  #                 just works without waiting for the next tag).
+  #
+  # Archive filenames are STABLE (no version in the name) so the website +
+  # docs can link to a predictable URL. The release page still surfaces the
+  # version via the release name + commit metadata.
   # ---------------------------------------------------------------------------
   publish-agent:
     name: Publish agent (${{ matrix.rid }})
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write   # gh release upload
@@ -135,27 +143,46 @@ jobs:
         if: matrix.archive_ext == 'zip'
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart('v')
-          $name = "erp-agent-${{ matrix.rid }}-$version.zip"
-          Compress-Archive -Path publish/${{ matrix.rid }}/* -DestinationPath $name
+          $name = "erp-agent-${{ matrix.rid }}.zip"
+          Compress-Archive -Path publish/${{ matrix.rid }}/* -DestinationPath $name -Force
           "ARCHIVE_NAME=$name" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Pack tar.gz (Linux)
         if: matrix.archive_ext == 'tar.gz'
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          name="erp-agent-${{ matrix.rid }}-${version}.tar.gz"
+          name="erp-agent-${{ matrix.rid }}.tar.gz"
           tar -czf "$name" -C publish/${{ matrix.rid }} .
           echo "ARCHIVE_NAME=$name" >> "$GITHUB_ENV"
+
+      - name: Determine target release tag
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            # Tag push: attach to that tag's release.
+            echo "tag=${GITHUB_REF_NAME}" >>"$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch: attach to the most recent release. There has
+            # always been at least one — the `release` job in ci.yml auto-creates
+            # one on every successful main push.
+            latest="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
+            if [[ -z "$latest" ]]; then
+              echo "::error::No existing release found. Push a tag first, then re-dispatch."
+              exit 1
+            fi
+            echo "tag=${latest}" >>"$GITHUB_OUTPUT"
+          fi
 
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          # The tag push triggers the GitHub auto-release-from-tag flow; the
-          # release may or may not exist when this job lands depending on
-          # ordering. Create it if needed (idempotent), then upload.
-          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
-            || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes "See CHANGELOG / commit history. Container images on ghcr.io/${GITHUB_REPOSITORY_OWNER,,}."
-          gh release upload "${GITHUB_REF_NAME}" "${ARCHIVE_NAME}" --clobber
+          tag="${{ steps.target.outputs.tag }}"
+          # Tag push: GitHub may not have auto-created the release yet,
+          # depending on ordering. Create idempotently.
+          gh release view "$tag" >/dev/null 2>&1 \
+            || gh release create "$tag" --title "$tag" --notes "See CHANGELOG / commit history. Container images on ghcr.io/${GITHUB_REPOSITORY_OWNER,,}."
+          gh release upload "$tag" "${ARCHIVE_NAME}" --clobber

--- a/src/Web/Components/Pages/Home.razor
+++ b/src/Web/Components/Pages/Home.razor
@@ -12,7 +12,7 @@
 </MudText>
 
 <MudGrid Spacing="3">
-    <MudItem xs="12" md="4">
+    <MudItem xs="12" sm="6" lg="3">
         <MudPaper Class="fx-panel pa-4 d-flex flex-column" Elevation="0" Style="height: 100%;">
             <MudText Typo="Typo.h5" Class="card-title mb-2">
                 <span class="fx-icon-inline fx-icon-wrench" aria-hidden="true"></span> Planner
@@ -28,7 +28,7 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12" md="4">
+    <MudItem xs="12" sm="6" lg="3">
         <MudPaper Class="fx-panel pa-4 d-flex flex-column" Elevation="0" Style="height: 100%;">
             <MudText Typo="Typo.h5" Class="card-title mb-2">
                 <span class="fx-icon-inline fx-icon-gear" aria-hidden="true"></span> Factory state
@@ -44,7 +44,7 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12" md="4">
+    <MudItem xs="12" sm="6" lg="3">
         <MudPaper Class="fx-panel pa-4 d-flex flex-column" Elevation="0" Style="height: 100%;">
             <MudText Typo="Typo.h5" Class="card-title mb-2">
                 <span class="fx-icon-inline fx-icon-screwdriver" aria-hidden="true"></span> Settings
@@ -56,6 +56,33 @@
                        Href="settings" Class="align-self-start">
                 Open settings
             </MudButton>
+        </MudPaper>
+    </MudItem>
+
+    @* Agent download — runs on the user's gaming machine and shovels each
+       new save up to this server so the live-save card below shows real
+       state. ADR-0024 §7 ships the binary as a single-file self-contained
+       release. Stable filenames let us link to /releases/latest/download/...
+       without knowing the tag. *@
+    <MudItem xs="12" sm="6" lg="3">
+        <MudPaper Class="fx-panel pa-4 d-flex flex-column" Elevation="0" Style="height: 100%;">
+            <MudText Typo="Typo.h5" Class="card-title mb-2">
+                <MudIcon Icon="@Icons.Material.Filled.Download" Size="Size.Small" Class="mr-1" /> Get the agent
+            </MudText>
+            <MudText Class="flex-grow-1 mb-3">
+                Run the agent on your gaming machine to ship saves to this server automatically.
+                Single-file binary — no .NET install required.
+            </MudText>
+            <div class="d-flex flex-column" style="gap:.5em; align-items: stretch;">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                           Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/latest/download/erp-agent-win-x64.zip">
+                    Windows (x64)
+                </MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
+                           Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/latest/download/erp-agent-linux-x64.tar.gz">
+                    Linux (x64)
+                </MudButton>
+            </div>
         </MudPaper>
     </MudItem>
 </MudGrid>


### PR DESCRIPTION
## Summary

- **Home page** gets a fourth card ("Get the agent") with Windows + Linux download buttons. Grid re-flows responsively: 1 col on phone, 2 on tablet, 4 on large screens.
- **release-images.yml** now publishes agent binaries on \`workflow_dispatch\` (not just tag push), and uses stable archive names (\`erp-agent-win-x64.zip\` / \`erp-agent-linux-x64.tar.gz\`) so the Home page can link to \`/releases/latest/download/<file>\` deterministically.

The two changes together: a fresh user hits the production URL, sees the download buttons, clicks → grabs the latest agent binary without anyone hand-curating release assets.

The workflow's still gated by a manual dispatch for now (issue #20 tracks the long-term fix where auto-tag CI also triggers release-images).

## Test plan

- [x] \`dotnet build src/Web/Web.csproj\` clean locally
- [ ] CI green
- [ ] After merge: dispatch release-images.yml; both image builds + both agent binaries publish to the latest release
- [ ] Re-run \`bin/deploy.ps1\` from the sister repo; smoke confirms 200; manually click both download buttons on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)