### PR TITLE
fix(ci): release job dispatches release-images for the new tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,7 @@ jobs:
     permissions:
       contents: write    # create tags + releases
       packages: read     # per-job permissions replace workflow-level, so restate
+      actions: write     # dispatch release-images.yml (gh workflow run)
 
     steps:
       - name: Checkout (full history for NB.GV)
@@ -355,3 +356,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh Release
+
+      # ---------------------------------------------------------------------
+      # Dispatch release-images.yml against the freshly-created tag.
+      #
+      # Why we need this: build.sh Release creates the GitHub release via the
+      # API using GITHUB_TOKEN, and tags created with the default GITHUB_TOKEN
+      # do NOT trigger downstream workflows (GitHub's anti-recursion guard).
+      # So release-images.yml's `on: push: tags: v*` never fires — leaving
+      # every auto-release with zero container images and zero agent binaries.
+      #
+      # Explicit dispatch sidesteps the guard. The dispatch counts as a
+      # workflow_dispatch event, but `--ref <tag>` makes GITHUB_REF point at
+      # the tag, so release-images.yml's per-trigger logic still treats it as
+      # a tag run and attaches assets to that specific release.
+      # ---------------------------------------------------------------------
+      - name: Dispatch release-images for the new tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The release we just created is by definition the most recent.
+          tag="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
+          if [[ -z "$tag" ]]; then
+            echo "::error::No release found after build.sh Release. Aborting."
+            exit 1
+          fi
+          echo "Dispatching release-images.yml against ${tag}"
+          gh workflow run release-images.yml --ref "${tag}"


### PR DESCRIPTION
## Problem

The \`release\` job in ci.yml auto-creates a GitHub release on every main push (via \`build.sh Release\` → \`gh release create\`). The tag it creates is signed with the default \`GITHUB_TOKEN\`, which **can't trigger downstream workflows** — GitHub's anti-recursion guard.

Effect: \`release-images.yml\`'s \`on: push: tags: v*\` trigger has never actually fired on an auto-release. Every auto-release has empty assets until someone manually dispatches the workflow.

We hit this today: PR #217 merged → ci.yml created \`v0.4.40\` with no assets → \`/releases/latest/download/erp-agent-*.zip\` started returning 404 even though we'd just published binaries to \`v0.4.39\`.

## Fix

After \`build.sh Release\` finishes, dispatch \`release-images.yml\` explicitly against the just-created tag:

\`\`\`bash
tag="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
gh workflow run release-images.yml --ref \"$tag\"
\`\`\`

\`gh workflow run --ref <tag>\` makes \`GITHUB_REF\` point at the tag, so \`release-images.yml\`'s per-trigger logic still takes the tag-push branch (assets attached to that specific release, not "latest at dispatch time").

Adds \`actions: write\` to the \`release\` job permissions so \`gh\` has the scope to dispatch.

## Test plan

- [x] CI green
- [ ] After merge: confirm the next auto-release (v0.4.42 or whatever) ships with both images on GHCR + both agent binaries attached, with no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)