### PR TITLE
chore(build): bump Fallout.Common to 10.3.5; sync SatisfactorySaveNet submodule

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -7,18 +7,18 @@
     <Nullable>enable</Nullable>
     <RootNamespace></RootNamespace>
 
-    <!-- NUKE conventions: build project sits in build/, scripts at the repo root. -->
-    <NukeRootDirectory>..</NukeRootDirectory>
-    <NukeScriptDirectory>..</NukeScriptDirectory>
-    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <!-- Fallout conventions: build project sits in build/, scripts at the repo root. -->
+    <FalloutRootDirectory>..</FalloutRootDirectory>
+    <FalloutScriptDirectory>..</FalloutScriptDirectory>
+    <FalloutTelemetryVersion>1</FalloutTelemetryVersion>
 
-    <!-- Suppress noisy diagnostics common in NUKE build scripts. -->
+    <!-- Suppress noisy diagnostics common in Fallout build scripts. -->
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE0079;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Fallout is the hard-fork successor to NUKE; published to nuget.org (ADR-0021). -->
-    <PackageReference Include="Fallout.Common" Version="10.2.15" />
+    <PackageReference Include="Fallout.Common" Version="10.3.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- `build/_build.csproj`: `Fallout.Common` 10.2.15 → **10.3.5** (the first version after the `Fallout.SolutionModel` SolutionPersistence pin was fixed via the new `Fallout.VisualStudio.SolutionPersistence` package). Also renames the deprecated `<NukeRootDirectory>` / `<NukeScriptDirectory>` / `<NukeTelemetryVersion>` MSBuild props to `<Fallout*>` (silences FALLOUT001; legacy names removed in 11.0).
- `vendor/SatisfactorySaveNet`: pin 158a030 → 33723ad. The fork's main now includes [#11](https://github.com/ChrisonSimtian/SatisfactorySaveNet/pull/11) which migrates its build from `Nuke.Common` (fork's GH Packages) to `Fallout.Common` (nuget.org). Submodule stays `update=none` + `ignore=all`; ERP doesn't consume it directly, this just keeps the optional drop-in in sync.

## Test plan

- [x] `./build.sh Compile` succeeds end-to-end against Fallout 10.3.5, no FALLOUT001 warnings.
- [ ] CI green on this branch.

## Related

Migrator experience writeup: [ChrisonSimtian/Fallout#110](https://github.com/ChrisonSimtian/Fallout/discussions/110)

🤖 Generated with [Claude Code](https://claude.com/claude-code)