### PR TITLE
fix(docker): pre-create volume mount points in erp-api image

### DIFF
--- a/src/ApiService/Dockerfile
+++ b/src/ApiService/Dockerfile
@@ -39,6 +39,23 @@ RUN --mount=type=secret,id=github_token \
 # -----------------------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
 WORKDIR /app
+
+# Pre-create volume mount points with the runtime user's ownership.
+#
+# Docker initialises empty named volumes by copying the *image's* contents
+# (and permissions) at the mount point — but if the mount point doesn't
+# exist in the image, Docker creates it on the fly as root:root. The
+# container then runs as `app` (uid 1654) and SQLite refuses to open the
+# DB with "unable to open database file" because /data is root-owned.
+#
+# Mount points exposed via compose.yml:
+#   /data                          -> SQLite plans DB (ADR-0018)
+#   /agent/savegames/satisfactory  -> agent .sav uploads (#199)
+#
+# Done BEFORE `USER app` because chown needs root.
+RUN mkdir -p /data /agent/savegames/satisfactory \
+    && chown -R app:app /data /agent
+
 USER app
 
 COPY --from=build --chown=app:app /app/publish ./


### PR DESCRIPTION
## Problem

Site latency in production was 7.3 seconds TTFB instead of ~120ms. Root cause: \`erp-api\` had been in a crash-restart loop since first deploy.

The Dockerfile drops privileges to the \`app\` user (uid 1654) but doesn't create \`/data\` or \`/agent/savegames/satisfactory\` in the image. When Docker initialises empty named volumes at those paths it creates the directories as \`root:root\`, the unprivileged container can't write to them, SQLite migration crashes with \`Microsoft.Data.Sqlite.SqliteException ... SQLite Error 14: 'unable to open database file'\`, container restarts. Forever.

Downstream: every page-render mounts \`AgentStatusCard\` whose \`OnInitializedAsync\` does a Blazor-prerender-blocking HTTP call to apiservice. With apiservice dead, the call sits on the \`AddStandardResilienceHandler\` retry budget for ~7s before failing — and only then does the page render (with the agent card in error state).

## Fix

\`mkdir -p\` + \`chown\` both mount points **before** \`USER app\` in the Dockerfile. Docker's first-mount volume initialisation copies image ownership into the fresh volume → fresh volumes are writable on day one.

## Runtime mitigation already applied

The existing \`erp-db\` volume on the LXC was chowned manually:

\`\`\`bash
docker run --rm -v erp-for-factory-games_erp-db:/data alpine chown 1654:1654 /data
\`\`\`

That unblocked the site (TTFB now ~120ms). This PR makes the fix permanent so the workaround isn't needed on the next LXC rebuild / volume recreate.

## Test plan

- [ ] CI green
- [ ] After merge: the auto-dispatched release-images run (#218 wired this up yesterday) builds a fresh \`erp-api:latest\` with the fix
- [ ] Wipe the LXC volume + redeploy: confirm erp-api comes up clean without the manual chown
- [ ] TTFB stays sub-200ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)