### PR TITLE
docs(adr): 0025 — agent auth & catalogue handover model

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -186,3 +186,62 @@ jobs:
           gh release view "$tag" >/dev/null 2>&1 \
             || gh release create "$tag" --title "$tag" --notes "See CHANGELOG / commit history. Container images on ghcr.io/${GITHUB_REPOSITORY_OWNER,,}."
           gh release upload "$tag" "${ARCHIVE_NAME}" --clobber
+
+  # ---------------------------------------------------------------------------
+  # winget — bump the ErpForFactoryGames.Agent manifest in winget-pkgs.
+  #
+  # Bootstrap (first submission) is manual via `wingetcreate submit` against
+  # the templates in src/Agent/packaging/winget/. From the second release
+  # onwards this job picks it up: downloads the new zip, recomputes SHA256,
+  # opens a PR against microsoft/winget-pkgs with the bumped version.
+  #
+  # Only runs on tag push — workflow_dispatch doesn't bump the manifest
+  # because winget needs a 1:1 mapping between PackageVersion and the
+  # InstallerUrl on the release page.
+  #
+  # Needs secret WINGET_SUBMIT_TOKEN (PAT with public_repo scope) — the
+  # default GITHUB_TOKEN can't push to a fork of microsoft/winget-pkgs.
+  # ---------------------------------------------------------------------------
+  publish-winget:
+    name: Publish winget manifest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish-agent
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install wingetcreate
+        run: dotnet tool install --global Microsoft.WindowsPackageManager.WingetCreateCli
+
+      - name: Resolve package version
+        id: pkg
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          echo "version=${version}" >>"$GITHUB_OUTPUT"
+          echo "url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/erp-agent-win-x64.zip" >>"$GITHUB_OUTPUT"
+
+      - name: Submit manifest update to winget-pkgs
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "${WINGET_TOKEN}" ]]; then
+            echo "::warning::WINGET_SUBMIT_TOKEN not set — skipping winget manifest update."
+            echo "Add a PAT with public_repo scope as repo secret WINGET_SUBMIT_TOKEN to enable."
+            exit 0
+          fi
+          wingetcreate update ErpForFactoryGames.Agent \
+            --urls "${{ steps.pkg.outputs.url }}" \
+            --version "${{ steps.pkg.outputs.version }}" \
+            --submit \
+            --token "${WINGET_TOKEN}"

--- a/docs/adr/0011-catalogue-source-path-configuration.md
+++ b/docs/adr/0011-catalogue-source-path-configuration.md
@@ -1,6 +1,6 @@
 # 0011. Catalogue source path configuration
 
-- Status: Accepted
+- Status: Accepted (superseded in part by [0025](0025-agent-auth-catalogue-handover.md) for hosted deployments — server-local resolution is dev-only fallback)
 - Date: 2026-05-03
 - Deciders: Chris
 

--- a/docs/adr/0025-agent-auth-catalogue-handover.md
+++ b/docs/adr/0025-agent-auth-catalogue-handover.md
@@ -1,0 +1,388 @@
+# 0025. Agent auth & catalogue handover model
+
+- Status: Proposed
+- Date: 2026-05-24
+- Deciders: Chris
+
+## Context
+
+[ADR-0024](0024-agent-v1-shape.md) shipped the agent v1 PoC with two
+known holes flagged for a future ADR-0025: (a) the auth seam accepts
+any non-empty `X-Agent-Token`, and (b) catalogue handover from the
+player's machine to the server is unsolved. Both holes are now load-
+bearing as soon as the planner sees more than one user.
+
+[ADR-0011](0011-catalogue-source-path-configuration.md) assumed the
+catalogue (`Docs.json`) is readable from a path on the box running
+ApiService. [ADR-0023](0023-hosting-deployment-approach.md) moved
+ApiService to a homelab LXC behind Cloudflare — that box does not have
+Satisfactory installed, so the ADR-0011 path resolution silently falls
+through to "empty catalogue" for every real deployment. The agent runs
+on the player's machine where `Docs.json` actually lives, so the agent
+is the natural carrier.
+
+The shape we need to commit to before milestone #19 issues can land in
+parallel:
+
+- Who a request belongs to (player identity model).
+- How a token is issued, validated, and revoked.
+- How a player gets a token onto an installed agent without a
+  copy-paste-by-hand ritual.
+- How the catalogue gets from the player's machine to the server, and
+  how planner queries resolve "which catalogue" for a given request.
+- What a "session" is, so re-ingest and live state have a noun to
+  attach to.
+
+This ADR pins those answers. Implementation lives in #235–#239.
+
+## Decision
+
+### 1. Player aggregate, no login
+
+v2 introduces a minimal `Player` aggregate:
+
+```
+Player {
+  Id: Guid
+  DisplayName: string         // "Chris's playthrough", user-editable
+  CreatedAt: DateTimeOffset
+}
+```
+
+No login, no email, no OAuth in v2. A `Player` is created the first
+time the Web UI mints an agent token. Until real auth lands (a future
+ADR), the Web UI is gated behind a feature flag and resolves the
+"current player" from a config value (`Auth:DevPlayerId`) — every
+visitor sees the same player. This is *single-user-shaped on
+purpose*, same as ADR-0024 §5: it closes the auth hole the API needs
+without committing to an identity stack.
+
+When login lands, `Player` gets an `IdentityUserId` foreign key. The
+table doesn't need to change shape.
+
+### 2. Token shape & issuance
+
+Agent tokens are opaque secrets scoped to one `(Player, AgentInstall)`
+pair. One player can have many tokens (one per machine they install
+the agent on).
+
+```
+AgentToken {
+  Id: Guid
+  PlayerId: Guid          // FK → Player
+  Label: string           // "Chris's gaming rig", user-editable
+  TokenHash: byte[]       // argon2id, salted
+  CreatedAt: DateTimeOffset
+  LastSeenAt: DateTimeOffset?
+  RevokedAt: DateTimeOffset?
+}
+```
+
+- **Plaintext format:** `eafg_<32 url-safe-base64 bytes>`. The `eafg_`
+  prefix lets us spot a leaked token in logs and lets future format
+  bumps land cleanly (`eafg2_…`).
+- **Plaintext is surfaced once.** The mint response returns it; the
+  list endpoint never does. Server stores only the hash.
+- **Hashing:** argon2id with parameters tuned for ~50 ms on the LXC.
+  Tests assert plaintext is not recoverable from the persisted row.
+- **Revocation:** `RevokedAt` is set; row is kept for audit. Auth
+  middleware treats `RevokedAt != null` as 401.
+
+Token format is committed in this ADR — any change is a breaking
+protocol change, same constraint as the `X-Agent-Token` header name
+from ADR-0024 §5.
+
+### 3. Server-side validation
+
+The permissive `X-Agent-Token` middleware from ADR-0024 §5 is
+replaced. New middleware:
+
+1. Reads `X-Agent-Token` from the request.
+2. Hashes it, looks up the matching `AgentToken` row.
+3. On hit (and not revoked): attaches `(PlayerId, AgentTokenId)` to
+   the request context, bumps `LastSeenAt`. Status codes from
+   ADR-0024 §4 are preserved.
+4. On miss / revoked / missing: 401.
+
+Per-request `LastSeenAt` bumps go through a debounced writer (60 s
+coalesce window) so log-tail traffic doesn't hammer the DB. The
+existing `AgentStatusDto.AgentSeen` field reads from `LastSeenAt` now
+instead of an in-memory bag.
+
+The existing `X-Agent-Token` header position is preserved — agents
+that ship before this ADR's API rolls out will start receiving 401,
+but the wire shape is unchanged so a re-pair fixes them.
+
+### 4. Catalogue ownership — per player, agent-uploaded
+
+Catalogue is per-player, keyed by `(PlayerId, GameVersion, DocsHash)`.
+
+```
+PlayerCatalogue {
+  PlayerId: Guid          // FK → Player
+  Game: string            // "satisfactory" — same key as agent endpoints
+  GameVersion: string     // parsed out of Docs.json's version block
+  DocsHash: string        // sha256 of the uploaded bytes, hex
+  StorageKey: string      // blob ref (filesystem path in v2, S3 later)
+  UploadedAt: DateTimeOffset
+  PRIMARY KEY (PlayerId, Game)
+}
+```
+
+One row per `(player, game)` — re-uploads overwrite. The previous
+hash is what the agent uses to short-circuit no-op uploads (§5
+endpoint contract).
+
+**Resolver:** planner endpoints resolve catalogue from the request's
+`PlayerId`. If no row exists, the planner falls back to a server-local
+`Docs.json` (the ADR-0011 path resolution) **only if** the
+`Catalogue:AllowServerLocalFallback` config is true. That flag defaults
+to `true` in `appsettings.Development.json` and `false` in production.
+
+This partially supersedes ADR-0011: the env var / config path / auto-
+detect on the server is now a dev-only convenience. The same
+resolution logic moves to the agent (it runs on the box that actually
+has the game installed).
+
+### 5. Catalogue upload contract
+
+```
+POST {ApiBaseUrl}/agent/catalogue/satisfactory
+  X-Agent-Token: <token>
+  X-Agent-Version: <semver>
+  Content-Type: application/json     // raw Docs.json bytes
+  Body: <Docs.json>
+
+200 { gameVersion, docsHash, uploadedAt, changed: bool }
+304 (changed=false; agent sent If-None-Match: <previous-hash>)
+401 unknown/revoked token
+415 body wasn't recognisable as Docs.json (server-side shape check)
+422 catalogue parser failed; body carries exception type + first line
+```
+
+`If-None-Match` carries the last hash the agent successfully uploaded
+(persisted in `agent.json` alongside the token). On a 304 the agent
+does no further work; on a 200 the agent updates its persisted hash.
+This is the dedup guarantee #238 acceptance leans on.
+
+The agent does **not** parse Docs.json. Same principle as ADR-0024 §4
+on save uploads: ship bytes, parse server-side. Catalogue schema
+changes on a Satisfactory patch are a server-only fix.
+
+### 6. Session = active save file
+
+A *session* is the most recently watched `.sav` filename, scoped to a
+`(PlayerId, Game)`. No DB shape for sessions in v2 — it's a derived
+field on `AgentStatusDto` (`currentSaveFile`). Catalogue, save
+uploads, and re-ingest all attach to the player + game; "session"
+exists in the UI as a label, not a foreign key.
+
+If a future ADR introduces named playthroughs ("Bravo run"), this
+becomes a real aggregate. Not v2.
+
+### 7. Re-ingest — pull-based via the existing log-tail tick
+
+Re-ingest is requested by the Web UI and pulled by the agent on its
+existing 60 s log-tail interval. No new background service, no push
+channel.
+
+```
+POST {ApiBaseUrl}/players/{id}/re-ingest-catalogue
+GET  {ApiBaseUrl}/agent/poll       // agent's existing tick now returns flags
+```
+
+The poll response gains a `reIngestRequested: bool` field. When
+`true`, the agent re-runs `CatalogueUploader` regardless of its
+cached hash (forces a 200 even if Docs.json hasn't changed — useful
+when the player swapped game install paths). The server clears the
+flag when the next catalogue upload arrives.
+
+Rejected push-based options (SignalR/WebSocket) are listed under
+*Alternatives*. The 60 s lag is the documented user-visible cost.
+
+### 8. Pairing UX — two parallel paths, one validation seam
+
+Two paths, both targeted at the same `PairingService` inside the
+agent:
+
+**Path A — deep link (`erp-agent://`).**
+
+The Web UI's "Add an agent" modal shows a button:
+
+```
+erp-agent://pair?token=<plaintext>&api=<absolute-api-base>
+```
+
+Protocol-handler registration ships with the platform installers:
+
+- **Windows**: `HKCU\Software\Classes\erp-agent` written by `--install`
+  (no admin), refined by the MSI in #219.
+- **macOS**: `CFBundleURLTypes` in the .pkg's `Info.plist` (#221).
+- **Linux**: `.desktop` file with
+  `MimeType=x-scheme-handler/erp-agent` (#220).
+
+The handler invokes `erp-agent --pair <url>`. The agent parses, calls
+`GET /me` with the token to validate, writes `agent.json` atomically,
+and signals the running watcher to reload config (or starts the
+watcher if it wasn't running).
+
+**Path B — CLI wizard.**
+
+Extends #222. `erp-agent --setup` prompts for API URL, token (or
+accepts `--token <value>`), save folder override. Same
+`PairingService.Pair(apiBaseUrl, token)` validates and writes
+`agent.json`. Headless installs (servers, SSH'd boxes, "no GUI"
+users) use this path.
+
+Both paths converge on one `PairingService` so the validation +
+config-write logic has one implementation and one set of tests.
+
+### 9. New endpoints summary
+
+```
+POST   /players/{id}/agent-tokens                  // mint, returns plaintext once
+GET    /players/{id}/agent-tokens                  // list (no plaintext)
+DELETE /players/{id}/agent-tokens/{tokenId}        // revoke
+POST   /players/{id}/re-ingest-catalogue           // set flag
+POST   /agent/catalogue/satisfactory               // upload Docs.json
+GET    /agent/poll                                 // tick + flags
+GET    /me                                         // who-am-I for pair validation
+```
+
+Existing endpoints from ADR-0024 §4 keep their shape; their auth
+seam tightens per §3.
+
+## Alternatives considered
+
+**Player identity**
+
+- **Front-load login (OIDC, GitHub, magic-email).** Solid long-term,
+  but pushes v2 by weeks for a single-user-deployment we're trying to
+  unblock now. Treating the agent token as the credential closes the
+  immediate hole; login lands as its own ADR with the table-shape
+  bridge already in place (§1).
+- **Token-as-identity, no `Player` row.** Tempting (one less aggregate)
+  but breaks the moment a player wants two paired machines. The
+  `Player` row is the join point that lets multiple `AgentToken`s
+  resolve to one catalogue.
+
+**Token storage**
+
+- **Symmetric encryption at rest.** Reversible by design — wrong shape
+  for credentials. Hashing is the standard answer.
+- **Bcrypt / PBKDF2.** Both work; argon2id is the current
+  recommendation and the libsodium binding is already a transitive
+  dep via .NET 10. No reason to pick the older primitives.
+- **JWT.** Stateless validation is nice, but revocation needs a denylist
+  anyway, at which point the JWT is just a more complicated row lookup.
+  Opaque tokens with a hashed row are simpler and we already need the
+  row for `LastSeenAt`.
+
+**Catalogue handover**
+
+- **Player uploads Docs.json via the Web UI.** Works as a fallback but
+  forces re-upload after every game patch. The agent already runs on
+  the box with the file; making it the carrier is the lower-friction
+  default (per the `feedback_enduser_friction` memory).
+- **Bundle catalogue with each save upload.** Doubles the upload
+  payload for no benefit — Docs.json changes at game-version
+  granularity, saves change every few minutes.
+- **Keep ADR-0011 server-local resolution.** Doesn't work in the
+  homelab deployment. Kept as dev fallback only.
+
+**Re-ingest channel**
+
+- **SignalR / WebSocket push.** Sub-second latency, real-time UX. Adds
+  a connection-management surface (reconnect, auth, NAT) that the
+  60 s pull avoids entirely. Revisit if the lag becomes a complaint.
+- **Webhook from server to agent.** Requires the player's machine to
+  be reachable from the server. Hard NAT / firewall story for zero
+  added value over polling.
+- **Auto-trigger on detected game-version change.** Nice future
+  feature, but requires the agent to parse Docs.json (currently it
+  doesn't). Out of scope.
+
+**Pairing UX**
+
+- **Local agent web UI (`http://localhost:NNNN`).** End-user-friendliest
+  option for desktop installs. Punted for v2: deep-link covers the
+  desktop case with less platform surface (no Kestrel in the agent, no
+  port-binding story, no localhost-cert prompts). Revisit if the
+  deep-link registration proves flaky cross-platform.
+- **CLI wizard only.** Lowest implementation cost but pushes the
+  copy-paste friction onto every desktop user. Memory
+  `feedback_enduser_friction` argues against making this the only path.
+- **OAuth-style device flow.** Right shape once there's an identity
+  provider. No identity provider in v2.
+
+**Re-pair vs. token rotation**
+
+Token rotation (refresh tokens, automatic rollover) is out of scope.
+v2 expects a token to live until the user explicitly revokes it; the
+agent has no rotation logic. This keeps the auth ADR small.
+
+## Consequences
+
+**Easier**
+
+- One `PairingService` shared by deep-link and CLI paths — single
+  validation seam, single test suite.
+- Catalogue path lives where the file lives (player's machine), so
+  ADR-0011's auto-detect logic finally pays off — it's running on the
+  box that actually has Steam installed.
+- Per-player catalogue means a future "share a plan with a friend"
+  feature can ship without forcing both players onto the same game
+  version.
+- Token format prefix (`eafg_`) makes leaks searchable in any log
+  aggregator.
+- The pull-based re-ingest reuses the log-tail tick — no new
+  background service, no new auth surface.
+
+**Harder**
+
+- Protocol-handler registration is per-OS surface area. Windows is
+  the easiest (HKCU write); macOS depends on the .pkg landing (#221);
+  Linux depends on the .deb/.rpm landing (#220). Until those platform
+  installers ship, deep-link is Windows-only — Mac/Linux users use the
+  CLI wizard, which is acceptable per ADR-0024's "single-user-shaped
+  on purpose" stance.
+- The single-tenant assumption baked into existing planner endpoints
+  has to go. Every query now has a `PlayerId` filter; tests need to
+  cover the "wrong player's data" 404 path.
+- Argon2id hashes are slow on purpose. ~50 ms per pair validation is
+  fine; we don't want it on the hot path of every save upload. The
+  `LastSeenAt` debounce + the token-cache (5-minute in-memory cache
+  keyed by hash → row, evicted on revoke) keeps the hot path cheap.
+
+**Follow-up** (tracked under
+[milestone #19](https://github.com/ChrisonSimtian/ErpForFactoryGames/milestone/19))
+
+- [#235](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/235)
+  — `Player` + `AgentToken` aggregates, mint/list/revoke endpoints,
+  auth middleware swap. Per §1–§3.
+- [#236](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/236)
+  — Web UI "My Agents" page with deep-link + copy buttons. Per §8 Path A.
+- [#237](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/237)
+  — Agent `erp-agent://` handler + `PairingService` + `--setup`
+  extension. Per §8 both paths.
+- [#238](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/238)
+  — `CatalogueUploader` in the agent, `POST /agent/catalogue/satisfactory`
+  in the API, per-player resolver. Per §4–§5.
+- [#239](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/239)
+  — Re-ingest flag + Web UI button + poll-tick wiring. Per §7.
+
+A future ADR (not 0026 reserved — pick the next free number when it
+lands) introduces real login. The `Player.IdentityUserId` extension
+point is the bridge.
+
+## Explicitly out of scope
+
+- User login. v2 keeps a single "dev player" gated by feature flag.
+- Token rotation, refresh tokens, expiry.
+- Per-token scopes (read-only tokens, upload-only tokens).
+- Push-based re-ingest (SignalR/WebSocket).
+- Named sessions / playthroughs as a first-class aggregate.
+- Catalogue diffing or migration between game versions.
+- Cross-player catalogue sharing.
+- CoI catalogue upload — same wire pattern applies, but it lands with
+  the CoI agent path under its own milestone.

--- a/docs/adr/0025-agent-auth-catalogue-handover.md
+++ b/docs/adr/0025-agent-auth-catalogue-handover.md
@@ -1,6 +1,6 @@
 # 0025. Agent auth & catalogue handover model
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-05-24
 - Deciders: Chris
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,7 +31,7 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0008](0008-use-playwright-for-ui-tests.md) | Use Playwright for UI tests | Accepted |
 | [0009](0009-runtime-ingestion-of-game-catalogue.md) | Runtime ingestion of game catalogue from Docs.json | Accepted |
 | [0010](0010-game-agnostic-catalogue-contract.md) | Game-agnostic catalogue contract in the Application layer | Accepted |
-| [0011](0011-catalogue-source-path-configuration.md) | Catalogue source path configuration | Accepted |
+| [0011](0011-catalogue-source-path-configuration.md) | Catalogue source path configuration | Accepted (superseded in part by [0025](0025-agent-auth-catalogue-handover.md)) |
 | [0012](0012-live-factory-state-via-node-sidecar.md) | Live factory state ingestion via Node sidecar | Superseded by [0014](0014-pure-csharp-save-ingestion-via-fork.md) |
 | [0013](0013-map-visualiser-approach.md) | Map visualiser approach | Proposed |
 | [0014](0014-pure-csharp-save-ingestion-via-fork.md) | Pure-C# .sav ingestion via SatisfactorySaveNet fork | Accepted |
@@ -45,3 +45,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0022](0022-captain-of-industry-support.md) | Captain of Industry as the second supported game | Accepted |
 | [0023](0023-hosting-deployment-approach.md) | Hosting + deployment via homelab Docker behind Cloudflare Tunnel | Accepted |
 | [0024](0024-agent-v1-shape.md) | Game agent v1 PoC — shape, wire protocol, distribution | Accepted |
+| [0025](0025-agent-auth-catalogue-handover.md) | Agent auth & catalogue handover model | Proposed |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,4 +45,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0022](0022-captain-of-industry-support.md) | Captain of Industry as the second supported game | Accepted |
 | [0023](0023-hosting-deployment-approach.md) | Hosting + deployment via homelab Docker behind Cloudflare Tunnel | Accepted |
 | [0024](0024-agent-v1-shape.md) | Game agent v1 PoC — shape, wire protocol, distribution | Accepted |
-| [0025](0025-agent-auth-catalogue-handover.md) | Agent auth & catalogue handover model | Proposed |
+| [0025](0025-agent-auth-catalogue-handover.md) | Agent auth & catalogue handover model | Accepted |

--- a/src/Agent/INSTALL.md
+++ b/src/Agent/INSTALL.md
@@ -8,29 +8,46 @@ Single-file self-contained binary — no .NET install required.
 
 ## Windows
 
+### Recommended: winget
+
+```powershell
+winget install ErpForFactoryGames.Agent
+```
+
+Then create `%LocalAppData%\ErpForFactoryGames\agent.json` (the agent
+creates this folder on first run; or make it yourself):
+
+```json
+{
+  "Agent": {
+    "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
+    "AgentToken": "<any-non-empty-string-for-v1>"
+  }
+}
+```
+
+Open an **elevated** PowerShell and register the service:
+
+```powershell
+erp-agent --install
+```
+
+The service auto-starts at boot (delayed-auto), restarts on crash, and
+uploads new saves as they appear. Logs at `%LocalAppData%\ErpForFactoryGames\agent-logs\`.
+
+Future agent releases pick up with `winget upgrade ErpForFactoryGames.Agent`.
+
+To remove: `erp-agent --uninstall` (elevated), then `winget uninstall ErpForFactoryGames.Agent`.
+
+### Fallback: download the zip
+
+If winget isn't an option (locked-down environment, older Windows):
+
 1. Download `erp-agent-win-x64.zip` from the latest [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
 2. Extract somewhere stable, e.g. `C:\Program Files\ErpForFactoryGames\`.
-3. Edit `%LocalAppData%\ErpForFactoryGames\agent.json` (created on first
-   run; use the bundled `agent.json.example` as a template):
-
-   ```json
-   {
-     "Agent": {
-       "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
-       "AgentToken": "<any-non-empty-string-for-v1>"
-     }
-   }
-   ```
-
-4. Right-click `erp-agent.exe` → **Run as administrator**, then in a
-   terminal (still elevated):
-
-   ```powershell
-   .\erp-agent.exe --install
-   ```
-
-5. Done. The service auto-starts at boot (delayed-auto), restarts on
-   crash. Logs at `%LocalAppData%\ErpForFactoryGames\agent-logs\`.
+3. Create `agent.json` as above.
+4. Right-click `erp-agent.exe` → **Run as administrator**, then from an
+   elevated terminal: `.\erp-agent.exe --install`.
 
 To remove: `.\erp-agent.exe --uninstall` (elevated).
 

--- a/src/Agent/packaging/winget-README.md
+++ b/src/Agent/packaging/winget-README.md
@@ -4,6 +4,11 @@ Bootstrap manifest for `ErpForFactoryGames.Agent`. Lets Windows users install
 the agent with `winget install ErpForFactoryGames.Agent` and pick up new
 releases via `winget upgrade`.
 
+> This file lives outside `winget/` on purpose. `winget validate --manifest <dir>`
+> parses every file in the target directory as YAML, regardless of extension,
+> so a markdown file alongside the manifests trips the scanner on the first
+> stray `:` it sees.
+
 Today this is a **portable** manifest that wraps the release `erp-agent-win-x64.zip`.
 Winget puts `erp-agent.exe` on the user's PATH; the user runs
 `erp-agent --install` from an elevated shell to register the Windows service.

--- a/src/Agent/packaging/winget/ErpForFactoryGames.Agent.installer.yaml
+++ b/src/Agent/packaging/winget/ErpForFactoryGames.Agent.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ErpForFactoryGames.Agent
+PackageVersion: 0.4.45
+ReleaseDate: 2026-05-22
+
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: erp-agent.exe
+    PortableCommandAlias: erp-agent
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/download/v0.4.45/erp-agent-win-x64.zip
+    InstallerSha256: E28806764D851A1B0623DD31EECA30B750294D8B65F01E819CFFE7EBF6BE5715
+
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/src/Agent/packaging/winget/ErpForFactoryGames.Agent.locale.en-US.yaml
+++ b/src/Agent/packaging/winget/ErpForFactoryGames.Agent.locale.en-US.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ErpForFactoryGames.Agent
+PackageVersion: 0.4.45
+PackageLocale: en-US
+
+Publisher: ErpForFactoryGames
+PublisherUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames
+PublisherSupportUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/issues
+
+PackageName: ERP for Factory Games — Agent
+PackageUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames
+Author: ErpForFactoryGames contributors
+
+License: MIT
+LicenseUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/LICENSE
+Copyright: Copyright (c) ErpForFactoryGames contributors
+
+ShortDescription: Watches your Satisfactory save folder and uploads each new save to the ERP planner.
+Description: |-
+  The ERP for Factory Games agent is a small headless service that watches
+  the local Satisfactory save folder and uploads each new save file to the
+  hosted planner web app, so your factory's live state shows up alongside
+  your production plans.
+
+  After install, run `erp-agent --install` from an elevated shell to register
+  the Windows service. The agent then auto-starts at boot and uploads new
+  saves as you play.
+
+Moniker: erp-agent
+Tags:
+  - satisfactory
+  - factory
+  - games
+  - erp
+  - planner
+  - savegame
+  - dotnet
+
+ReleaseNotesUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/tag/v0.4.45
+
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/src/Agent/packaging/winget/ErpForFactoryGames.Agent.yaml
+++ b/src/Agent/packaging/winget/ErpForFactoryGames.Agent.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ErpForFactoryGames.Agent
+PackageVersion: 0.4.45
+DefaultLocale: en-US
+
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/src/Agent/packaging/winget/README.md
+++ b/src/Agent/packaging/winget/README.md
@@ -1,0 +1,63 @@
+# winget manifest
+
+Bootstrap manifest for `ErpForFactoryGames.Agent`. Lets Windows users install
+the agent with `winget install ErpForFactoryGames.Agent` and pick up new
+releases via `winget upgrade`.
+
+Today this is a **portable** manifest that wraps the release `erp-agent-win-x64.zip`.
+Winget puts `erp-agent.exe` on the user's PATH; the user runs
+`erp-agent --install` from an elevated shell to register the Windows service.
+When [#219](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/219)
+lands and we ship a real MSI, this manifest flips to `InstallerType: wix` and
+service registration happens at install time — the user-facing
+`winget install ...` command stays the same.
+
+## Files
+
+- `ErpForFactoryGames.Agent.installer.yaml` — installer URL, SHA256, type.
+- `ErpForFactoryGames.Agent.locale.en-US.yaml` — default-locale package metadata.
+- `ErpForFactoryGames.Agent.yaml` — version manifest (points at the locale).
+
+The three files together are a single multi-file manifest per winget's schema.
+
+## Local validation (Windows)
+
+From a Windows machine with the winget CLI installed:
+
+```powershell
+winget validate --manifest src\Agent\packaging\winget\
+winget install --manifest src\Agent\packaging\winget\
+```
+
+The second command installs the agent from these local files without
+hitting winget-pkgs — useful for end-to-end testing before submitting.
+
+## First-time submission to winget-pkgs
+
+The first submission has to be done by hand; CI takes over from the
+second release onwards.
+
+1. Update the three yaml files so `PackageVersion`, `InstallerUrl`,
+   `InstallerSha256`, and `ReleaseDate` match the release you're submitting.
+2. From Windows, with [wingetcreate](https://github.com/microsoft/winget-create) installed:
+
+   ```powershell
+   wingetcreate submit --token <gh-pat-with-public_repo-scope> src\Agent\packaging\winget\
+   ```
+
+   This forks `microsoft/winget-pkgs`, places the files at
+   `manifests/e/ErpForFactoryGames/Agent/<version>/`, and opens a PR.
+3. Wait for the winget-pkgs review (usually hours; can be a day or two).
+4. Once merged, `winget search ErpForFactoryGames` finds the package.
+
+## Subsequent releases (CI)
+
+The `publish-winget` job in `.github/workflows/release-images.yml` runs
+after every tag push, after `publish-agent` has uploaded the zip. It calls
+`wingetcreate update --submit` against this package — wingetcreate
+downloads the new zip, recomputes the SHA256, forks winget-pkgs, and
+opens a PR with the bumped version.
+
+CI needs a PAT in secret `WINGET_SUBMIT_TOKEN` with `public_repo` scope.
+The repo's default `GITHUB_TOKEN` isn't enough because the PR is opened
+against a fork outside this repository.


### PR DESCRIPTION
## Summary

- Pins the contract for milestone #19: per-player tokens (argon2id-hashed, `eafg_`-prefixed opaque secrets), agent-uploaded catalogue keyed by `(PlayerId, Game)`, pull-based re-ingest on the existing 60 s log-tail tick.
- Two parallel pairing paths share one `PairingService`: `erp-agent://` deep link (Windows HKCU, macOS `CFBundleURLTypes`, Linux `.desktop`) and the CLI wizard (`erp-agent --setup`, extending #222).
- Single-user-shaped on purpose, same stance as ADR-0024 — `Player` aggregate with no login yet; `Player.IdentityUserId` is the bridge for the future login ADR.
- Partially supersedes ADR-0011: server-local `Docs.json` becomes dev-only fallback, gated by `Catalogue:AllowServerLocalFallback`.

Closes #234. Unblocks #235, #236, #237, #238, #239.

## Test plan

- [ ] Review §1–§9 for shape errors before any implementation issue picks up.
- [ ] Confirm token format (`eafg_<32 url-safe-base64>`) and hash algorithm (argon2id, ~50 ms) are acceptable.
- [ ] Confirm pull-based re-ingest cadence (60 s) is acceptable for v2 — push channel is the documented escape hatch.
- [ ] Confirm Linux/macOS deep-link is acceptable as deferred-until-packaging (#220, #221), with CLI wizard as the cross-platform baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)