### PR TITLE
fix(agent): move Windows config + logs to %ProgramData% for service mode

### DIFF
--- a/docs/adr/0024-agent-v1-shape.md
+++ b/docs/adr/0024-agent-v1-shape.md
@@ -67,8 +67,18 @@ boundary, so swapping it later costs one Program.cs edit.
 
 Log paths (XDG / Microsoft conventions):
 
-- Windows: `%LocalAppData%/ErpForFactoryGames/agent-logs/agent-{Date}.log`
+- Windows: `%ProgramData%/ErpForFactoryGames/agent-logs/agent-{Date}.log`
 - Linux: `${XDG_STATE_HOME:-$HOME/.local/state}/ErpForFactoryGames/agent-logs/agent-{Date}.log`
+
+> **Amendment (2026-05-24, issue #241).** The Windows path was originally
+> `%LocalAppData%`. That expands differently for the LocalSystem service
+> (`C:\Windows\System32\config\systemprofile\AppData\Local\`) than for the
+> installing user, so config + logs landed somewhere the user couldn't
+> find. `%ProgramData%` (`Environment.SpecialFolder.CommonApplicationData`)
+> is shared across users, predictable for both the service and the user,
+> and the conventional Windows location for service-wide state (Docker,
+> Chocolatey, etc.). Linux paths unchanged — the systemd `--user` unit
+> runs as the user already.
 
 ### 3. Save-folder discovery — auto-detect with config override
 

--- a/src/Agent/INSTALL.md
+++ b/src/Agent/INSTALL.md
@@ -14,26 +14,38 @@ Single-file self-contained binary — no .NET install required.
 winget install ErpForFactoryGames.Agent
 ```
 
-Then create `%LocalAppData%\ErpForFactoryGames\agent.json` (the agent
-creates this folder on first run; or make it yourself):
-
-```json
-{
-  "Agent": {
-    "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
-    "AgentToken": "<any-non-empty-string-for-v1>"
-  }
-}
-```
-
 Open an **elevated** PowerShell and register the service:
 
 ```powershell
 erp-agent --install
 ```
 
+`--install` seeds `%ProgramData%\ErpForFactoryGames\agent.json` with
+your save folder pre-filled and grants your user write access to that
+file. Open it in any editor and set the API URL + token:
+
+```json
+{
+  "Agent": {
+    "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
+    "AgentToken": "<any-non-empty-string-for-v1>",
+    "SaveFolderPath": "C:\\Users\\<you>\\AppData\\Local\\FactoryGame\\Saved\\SaveGames"
+  }
+}
+```
+
+Then restart the service so the new values take effect:
+
+```powershell
+Restart-Service erp-agent
+```
+
+The service runs as LocalSystem; that's why `agent.json` lives under
+`%ProgramData%` (machine-wide) rather than `%LocalAppData%` (per-user) —
+LocalSystem and you both resolve to the same file this way.
+
 The service auto-starts at boot (delayed-auto), restarts on crash, and
-uploads new saves as they appear. Logs at `%LocalAppData%\ErpForFactoryGames\agent-logs\`.
+uploads new saves as they appear. Logs at `%ProgramData%\ErpForFactoryGames\agent-logs\`.
 
 Future agent releases pick up with `winget upgrade ErpForFactoryGames.Agent`.
 
@@ -45,9 +57,12 @@ If winget isn't an option (locked-down environment, older Windows):
 
 1. Download `erp-agent-win-x64.zip` from the latest [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
 2. Extract somewhere stable, e.g. `C:\Program Files\ErpForFactoryGames\`.
-3. Create `agent.json` as above.
-4. Right-click `erp-agent.exe` → **Run as administrator**, then from an
-   elevated terminal: `.\erp-agent.exe --install`.
+3. Right-click `erp-agent.exe` → **Run as administrator**, then from an
+   elevated terminal: `.\erp-agent.exe --install`. This seeds
+   `agent.json` under `%ProgramData%\ErpForFactoryGames\` just like the
+   winget path.
+4. Edit `%ProgramData%\ErpForFactoryGames\agent.json` to set the API URL
+   + token, then `Restart-Service erp-agent`.
 
 To remove: `.\erp-agent.exe --uninstall` (elevated).
 
@@ -143,11 +158,11 @@ honours. Set `Enabled: false` to opt out entirely.
 ## Troubleshooting
 
 - **Service installed but won't start**: check
-  `%LocalAppData%\ErpForFactoryGames\agent-logs\` for the file log, and
+  `%ProgramData%\ErpForFactoryGames\agent-logs\` for the file log, and
   the Windows Event Viewer (Application log) for service-host errors.
 - **Saves not uploading**: confirm `ApiBaseUrl` is correct and the
   server is reachable (`curl -i $ApiBaseUrl/health`). The agent logs
   every upload attempt with the response status code.
-- **First-time `agent.json` doesn't exist**: the agent creates the
-  containing folder on first run. Just create `agent.json` there
-  yourself with the snippet above; it's reloaded automatically.
+- **`agent.json` missing on Windows**: `--install` seeds it. If you
+  deleted it, re-run `erp-agent --install` (elevated) — it's idempotent
+  and won't replace an existing file.

--- a/src/Agent/Program.cs
+++ b/src/Agent/Program.cs
@@ -40,10 +40,10 @@ builder.Services.AddSystemd();
 
 // ---------------------------------------------------------------------
 // Configuration — picks up appsettings.json next to the binary plus the
-// per-user agent.json (writeable; the install flow drops the token there)
+// shared agent.json (writeable; the install flow drops the seed there)
 // plus env vars (ERP_AGENT_*). User-secrets only outside Production.
 // ---------------------------------------------------------------------
-builder.Configuration.AddJsonFile(UserConfigPath(), optional: true, reloadOnChange: true);
+builder.Configuration.AddJsonFile(ConfigPath(), optional: true, reloadOnChange: true);
 builder.Configuration.AddEnvironmentVariables(prefix: "ERP_AGENT_");
 
 builder.Services.Configure<AgentOptions>(builder.Configuration.GetSection("Agent"));
@@ -112,7 +112,7 @@ if (string.IsNullOrWhiteSpace(options.ApiBaseUrl))
     log.LogWarning(
         "Agent:ApiBaseUrl is not configured. Set it via {ConfigPath} or ERP_AGENT_ApiBaseUrl. "
         + "Uploads will fail until this is set.",
-        UserConfigPath());
+        ConfigPath());
 }
 if (string.IsNullOrWhiteSpace(options.AgentToken))
 {
@@ -141,19 +141,28 @@ static void PrintUsage()
 
         Configuration:
           appsettings.json next to the binary holds defaults.
-          agent.json under %LocalAppData%/ErpForFactoryGames/ (Windows) or
+          agent.json under %ProgramData%/ErpForFactoryGames/ (Windows) or
           $XDG_CONFIG_HOME/ErpForFactoryGames/ (Linux) is the writeable
-          per-user override — that's where you put your API URL + token.
+          override — that's where you put your API URL + token. On Windows
+          the path is machine-wide rather than per-user so the LocalSystem
+          service and the installing user agree on which file to read.
 
         See INSTALL.md next to the binary for the full first-run guide.
         """);
 }
 
 // Local helpers — file paths are OS-specific. See ADR-0024 §2.
+//
+// Windows uses %ProgramData% rather than %LocalAppData% so that the
+// LocalSystem-mode service and the installing user resolve the same
+// path. %LocalAppData% would expand to C:\Windows\System32\config\
+// systemprofile\AppData\Local\ for the service, which the user can't
+// find or edit. Linux keeps per-user XDG paths because the systemd
+// --user unit installed by --install runs as the user already.
 static string LogsDirectory()
 {
     var baseDir = OperatingSystem.IsWindows()
-        ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
         : Environment.GetEnvironmentVariable("XDG_STATE_HOME")
           ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "state");
     var dir = Path.Combine(baseDir, "ErpForFactoryGames", "agent-logs");
@@ -161,10 +170,10 @@ static string LogsDirectory()
     return dir;
 }
 
-static string UserConfigPath()
+static string ConfigPath()
 {
     var baseDir = OperatingSystem.IsWindows()
-        ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+        ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
         : Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
           ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
     var dir = Path.Combine(baseDir, "ErpForFactoryGames");

--- a/src/Agent/ServiceRegistrar.cs
+++ b/src/Agent/ServiceRegistrar.cs
@@ -94,17 +94,74 @@ internal static class ServiceRegistrar
         // Restart twice on failure, then give up. Standard service hygiene.
         await RunAsync("sc.exe", $"failure {ServiceName} reset= 86400 actions= restart/60000/restart/60000//").ConfigureAwait(false);
 
+        // Seed %ProgramData%\ErpForFactoryGames\agent.json with the installing
+        // user's save folder so the LocalSystem service has a working pointer
+        // from the first start. Idempotent — preserves an existing file.
+        var configPath = await SeedAgentJsonWindowsAsync().ConfigureAwait(false);
+
         var start = await RunAsync("sc.exe", $"start {ServiceName}").ConfigureAwait(false);
         if (start.ExitCode != 0)
         {
             Console.Error.WriteLine($"Service installed but failed to start (exit {start.ExitCode}): {start.Stderr}");
-            Console.Error.WriteLine($"Check the Windows Event Viewer or the file log at %LocalAppData%\\ErpForFactoryGames\\agent-logs\\.");
+            Console.Error.WriteLine($"Check the Windows Event Viewer or the file log at %ProgramData%\\ErpForFactoryGames\\agent-logs\\.");
             return start.ExitCode;
         }
 
         Console.Out.WriteLine($"Service '{ServiceName}' installed and started.");
-        Console.Out.WriteLine($"Configure the API URL + token at %LocalAppData%\\ErpForFactoryGames\\agent.json then restart the service.");
+        Console.Out.WriteLine($"Set the API URL + token in {configPath} then restart the service.");
         return 0;
+    }
+
+    /// <summary>
+    /// Ensures %ProgramData%\ErpForFactoryGames\agent.json exists with the
+    /// installing user's save folder pre-filled, and grants that user Modify
+    /// on the file so they can edit it without re-elevating. Returns the
+    /// resolved config path.
+    /// </summary>
+    private static async Task<string> SeedAgentJsonWindowsAsync()
+    {
+        var configDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "ErpForFactoryGames");
+        Directory.CreateDirectory(configDir);
+        var configPath = Path.Combine(configDir, "agent.json");
+
+        if (!File.Exists(configPath))
+        {
+            // Resolves to the installing user's profile because --install runs
+            // as that user (UAC keeps identity, only elevates the token).
+            var saveFolder = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "FactoryGame", "Saved", "SaveGames");
+            var saveFolderJson = saveFolder.Replace("\\", "\\\\");
+            var seed = $$"""
+                {
+                  "Agent": {
+                    "ApiBaseUrl": "",
+                    "AgentToken": "",
+                    "SaveFolderPath": "{{saveFolderJson}}"
+                  }
+                }
+                """;
+            await File.WriteAllTextAsync(configPath, seed).ConfigureAwait(false);
+            Console.Out.WriteLine($"Wrote seed config: {configPath}");
+        }
+        else
+        {
+            Console.Out.WriteLine($"Preserving existing config: {configPath}");
+        }
+
+#pragma warning disable CA1416 // Caller already gated on IsWindowsElevated().
+        var user = WindowsIdentity.GetCurrent().Name;
+#pragma warning restore CA1416
+        var grant = await RunAsync("icacls", $"\"{configPath}\" /grant \"{user}\":M").ConfigureAwait(false);
+        if (grant.ExitCode != 0)
+        {
+            Console.Error.WriteLine($"icacls grant failed (exit {grant.ExitCode}): {grant.Stderr.Trim()}");
+            Console.Error.WriteLine("Service will still work; you may need to edit agent.json from an elevated editor.");
+        }
+
+        return configPath;
     }
 
     private static async Task<int> UninstallWindowsAsync()


### PR DESCRIPTION
Closes #241.

## Summary

The agent's Windows service runs as LocalSystem, but `Program.cs` resolved config + log paths via `Environment.SpecialFolder.LocalApplicationData`, which expands to `C:\Windows\System32\config\systemprofile\AppData\Local\` for LocalSystem — not the installing user's `%LocalAppData%`. Result: the user's `agent.json` was never read and the post-install message pointed at a path neither side could agree on.

This switches both `LogsDirectory()` and `ConfigPath()` (formerly `UserConfigPath()`) to `SpecialFolder.CommonApplicationData` (`%ProgramData%`) on Windows. Linux paths are untouched — the systemd `--user` unit already runs as the user.

`--install` now seeds `%ProgramData%\ErpForFactoryGames\agent.json` with the installing user's `SaveFolderPath` so the LocalSystem service has a working save-folder pointer from the first start. The seed is idempotent (existing files preserved) and `icacls` grants the user `Modify` on `agent.json` so they can edit it without re-elevating.

## Notes

- ADR-0024 §2 amended in place. A few days old, hasn't shipped to users (winget PR #233 is held), so amending is cleaner than a superseding ADR.
- INSTALL.md Windows section rewritten to match the new flow.
- No migration for the old stale `%LocalAppData%\ErpForFactoryGames\agent.json` — pre-1.0 and only one known tester (me, who found this).
- `SaveFolderResolver` auto-detect logic is unchanged — still useful for `dotnet run` foreground mode. In service mode the override seeded by `--install` always wins, so the broken auto-detect never fires.

## Test plan

- [ ] On Windows: `erp-agent --uninstall` (elevated, to clear the v0.4.45 service), then re-run `--install` after building this branch.
- [ ] Verify `%ProgramData%\ErpForFactoryGames\agent.json` is created with `SaveFolderPath` filled in.
- [ ] Verify the installing user can edit `agent.json` without elevating (icacls grant worked).
- [ ] Set ApiBaseUrl + AgentToken, restart the service, confirm the log under `%ProgramData%\ErpForFactoryGames\agent-logs\` shows the agent watching the correct save folder with no "ApiBaseUrl not configured" warnings.
- [ ] Existing tests still pass (`dotnet test test/Agent.Tests/Agent.Tests.csproj`) — verified locally: 12/12 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)