### PR TITLE
fix(ci): switch winget publish job to standalone wingetcreate exe

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -206,20 +206,16 @@ jobs:
     name: Publish winget manifest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: publish-agent
-    runs-on: ubuntu-latest
+    # wingetcreate is Windows-only since Microsoft retired the dotnet-tool
+    # distribution. Per the upstream README's CI pattern (and the matching
+    # workflows in microsoft/edit, microsoft/PowerToys, etc.), download the
+    # standalone exe on a Windows runner.
+    runs-on: windows-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
-
-      - name: Install wingetcreate
-        run: dotnet tool install --global Microsoft.WindowsPackageManager.WingetCreateCli
 
       - name: Resolve package version
         id: pkg
@@ -232,16 +228,16 @@ jobs:
 
       - name: Submit manifest update to winget-pkgs
         env:
-          WINGET_TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
-        shell: bash
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_SUBMIT_TOKEN }}
+        shell: pwsh
         run: |
-          if [[ -z "${WINGET_TOKEN}" ]]; then
-            echo "::warning::WINGET_SUBMIT_TOKEN not set — skipping winget manifest update."
-            echo "Add a PAT with public_repo scope as repo secret WINGET_SUBMIT_TOKEN to enable."
-            exit 0
-          fi
-          wingetcreate update ErpForFactoryGames.Agent \
-            --urls "${{ steps.pkg.outputs.url }}" \
-            --version "${{ steps.pkg.outputs.version }}" \
-            --submit \
-            --token "${WINGET_TOKEN}"
+          if (-not $env:WINGET_CREATE_GITHUB_TOKEN) {
+              Write-Host "::warning::WINGET_SUBMIT_TOKEN not set — skipping winget manifest update."
+              Write-Host "Add a PAT with public_repo scope as repo secret WINGET_SUBMIT_TOKEN to enable."
+              exit 0
+          }
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update ErpForFactoryGames.Agent `
+              --urls "${{ steps.pkg.outputs.url }}" `
+              --version "${{ steps.pkg.outputs.version }}" `
+              --submit

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -207,9 +207,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: publish-agent
     # wingetcreate is Windows-only since Microsoft retired the dotnet-tool
-    # distribution. Per the upstream README's CI pattern (and the matching
-    # workflows in microsoft/edit, microsoft/PowerToys, etc.), download the
-    # standalone exe on a Windows runner.
+    # distribution. windows-latest runners have winget itself pre-installed,
+    # so we install wingetcreate the canonical way: through winget.
     runs-on: windows-latest
     permissions:
       contents: read
@@ -236,8 +235,12 @@ jobs:
               Write-Host "Add a PAT with public_repo scope as repo secret WINGET_SUBMIT_TOKEN to enable."
               exit 0
           }
-          curl.exe -JLO https://aka.ms/wingetcreate/latest
-          .\wingetcreate.exe update ErpForFactoryGames.Agent `
+          winget install wingetcreate `
+              --accept-package-agreements `
+              --accept-source-agreements `
+              --silent `
+              --disable-interactivity
+          wingetcreate update ErpForFactoryGames.Agent `
               --urls "${{ steps.pkg.outputs.url }}" `
               --version "${{ steps.pkg.outputs.version }}" `
               --submit


### PR DESCRIPTION
## Summary

Every release since v0.4.48 has failed at the `Publish winget manifest` step in `release-images.yml` with:

\`\`\`
microsoft.windowspackagemanager.wingetcreatecli is not found in NuGet feeds https://api.nuget.org/v3/index.json.
\`\`\`

Microsoft retired the `Microsoft.WindowsPackageManager.WingetCreateCli` NuGet tool. \`wingetcreate\` is now distributed as a standalone Windows-only exe — confirmed by checking nuget.org (404) and the [upstream README](https://github.com/microsoft/winget-create) which lists install paths via winget / scoop / chocolatey / standalone exe, no dotnet tool.

The release images + agent binaries are NOT affected — those matrix jobs succeed; only the upstream-winget bump fails. So this is the right kind of "fix CI" change: small, narrowly scoped, doesn't touch the runtime.

## What changes

| | Before | After |
|---|---|---|
| Runner | \`ubuntu-latest\` | \`windows-latest\` (wingetcreate is Windows-only) |
| Install | \`dotnet tool install\` (broken) | \`curl.exe -JLO https://aka.ms/wingetcreate/latest\` |
| Auth | \`--token\` arg | \`WINGET_CREATE_GITHUB_TOKEN\` env var (tool's native pickup) |
| No-token guard | bash \`[[ -z \$VAR ]]\` | pwsh \`if (-not \$env:...)\` |

Matches the pattern in [microsoft/edit's winget workflow](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml) and microsoft/PowerToys' equivalent.

## Test plan

- [ ] After merge, next release tag fires \`release-images.yml\`. \`publish-winget\` job either:
  - skips with the documented warning if \`WINGET_SUBMIT_TOKEN\` secret isn't set (current state), **or**
  - actually opens a PR against microsoft/winget-pkgs if the secret is set.
- No way to test the actual submission locally — needs a real tag push and a real PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)