### PR TITLE
feat(agent): erp-agent:// deep-link pairing + --setup wizard (#237)

### DIFF
--- a/docs/adr/0025-agent-auth-catalogue-handover.md
+++ b/docs/adr/0025-agent-auth-catalogue-handover.md
@@ -259,7 +259,7 @@ DELETE /players/{id}/agent-tokens/{tokenId}        // revoke
 POST   /players/{id}/re-ingest-catalogue           // set flag
 POST   /agent/catalogue/satisfactory               // upload Docs.json
 GET    /agent/poll                                 // tick + flags
-GET    /me                                         // who-am-I for pair validation
+GET    /api/me                                     // who-am-I for pair validation (under /api/* for Cloudflare routing per #245)
 ```
 
 Existing endpoints from ADR-0024 §4 keep their shape; their auth

--- a/src/Agent/AgentConfigWriter.cs
+++ b/src/Agent/AgentConfigWriter.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Agent;
+
+/// <summary>
+/// Atomic writer for <c>agent.json</c> (ADR-0025 §8). Reads the existing
+/// file if present, merges in the new <see cref="AgentOptions.ApiBaseUrl"/>
+/// / <see cref="AgentOptions.AgentToken"/> / save-folder values, and
+/// writes via temp-then-rename so a crash mid-write can't leave a
+/// half-written config behind.
+///
+/// <para>
+/// Preserves unknown fields. The agent config file is also touched by
+/// the install flow (<see cref="ServiceRegistrar"/>) which seeds the save
+/// folder; this writer must not clobber those keys when pairing later.
+/// </para>
+/// </summary>
+public sealed class AgentConfigWriter
+{
+    private static readonly JsonWriterOptions WriterOptions = new() { Indented = true };
+    private static readonly JsonSerializerOptions ReadOptions = new() { AllowTrailingCommas = true, ReadCommentHandling = JsonCommentHandling.Skip };
+
+    private readonly string _configPath;
+
+    public AgentConfigWriter(string configPath)
+    {
+        if (string.IsNullOrWhiteSpace(configPath)) throw new ArgumentException("configPath required", nameof(configPath));
+        _configPath = configPath;
+    }
+
+    /// <summary>
+    /// Apply the pairing values to the on-disk config. Returns the
+    /// resolved path written to. Idempotent.
+    /// </summary>
+    public async Task<string> WritePairingAsync(string apiBaseUrl, string token, string? saveFolderOverride, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(apiBaseUrl)) throw new ArgumentException("apiBaseUrl required", nameof(apiBaseUrl));
+        if (string.IsNullOrWhiteSpace(token)) throw new ArgumentException("token required", nameof(token));
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_configPath)!);
+
+        // Read existing (if any) into a JsonNode so we don't drop keys we
+        // don't know about — agent.json grows new options over time.
+        JsonObject root;
+        if (File.Exists(_configPath))
+        {
+            await using var fs = File.OpenRead(_configPath);
+            var existing = await JsonNode.ParseAsync(fs, documentOptions: new JsonDocumentOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip,
+            }, cancellationToken: ct).ConfigureAwait(false);
+            root = existing as JsonObject ?? new JsonObject();
+        }
+        else
+        {
+            root = new JsonObject();
+        }
+
+        if (root["Agent"] is not JsonObject agent)
+        {
+            agent = new JsonObject();
+            root["Agent"] = agent;
+        }
+
+        agent["ApiBaseUrl"] = apiBaseUrl.TrimEnd('/');
+        agent["AgentToken"] = token;
+        if (!string.IsNullOrWhiteSpace(saveFolderOverride))
+        {
+            agent["SaveFolderPath"] = saveFolderOverride;
+        }
+
+        var tempPath = _configPath + ".tmp";
+        await using (var fs = File.Create(tempPath))
+        await using (var writer = new Utf8JsonWriter(fs, WriterOptions))
+        {
+            root.WriteTo(writer);
+            await writer.FlushAsync(ct).ConfigureAwait(false);
+        }
+        File.Move(tempPath, _configPath, overwrite: true);
+        return _configPath;
+    }
+}

--- a/src/Agent/INSTALL.md
+++ b/src/Agent/INSTALL.md
@@ -21,24 +21,40 @@ erp-agent --install
 ```
 
 `--install` seeds `%ProgramData%\ErpForFactoryGames\agent.json` with
-your save folder pre-filled and grants your user write access to that
-file. Open it in any editor and set the API URL + token:
+your save folder pre-filled, grants your user write access to that
+file, and registers the `erp-agent://` URL protocol handler under
+`HKCU\Software\Classes\erp-agent` so the web UI's deep-link button can
+launch this binary.
 
-```json
-{
-  "Agent": {
-    "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
-    "AgentToken": "<any-non-empty-string-for-v1>",
-    "SaveFolderPath": "C:\\Users\\<you>\\AppData\\Local\\FactoryGame\\Saved\\SaveGames"
-  }
-}
-```
+### Pair the install
 
-Then restart the service so the new values take effect:
+Two ways to pair this agent to your planner account (ADR-0025 §8):
+
+**Deep link (easiest).** In the web UI, open **My Agents** → **Add an
+agent**, mint a token, then click **Open in agent**. Windows resolves
+the `erp-agent://pair?token=...&api=...` URL to this binary, which
+validates the token against `/api/me`, writes `agent.json`, and exits
+0. Then restart the service:
 
 ```powershell
 Restart-Service erp-agent
 ```
+
+**CLI wizard.** Useful for headless / server installs:
+
+```powershell
+erp-agent --setup
+```
+
+Prompts for API URL, token (copy from the web UI), and an optional
+save-folder override. Non-interactive variant for installers:
+
+```powershell
+erp-agent --setup --token eafg_... --api https://satisfactory.erp-for-factory.games
+```
+
+Either path writes the same `agent.json` — they just differ in how the
+token gets in.
 
 The service runs as LocalSystem; that's why `agent.json` lives under
 `%ProgramData%` (machine-wide) rather than `%LocalAppData%` (per-user) —
@@ -70,22 +86,40 @@ To remove: `.\erp-agent.exe --uninstall` (elevated).
 
 1. Download `erp-agent-linux-x64.tar.gz` from the [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
 2. Extract to `~/.local/bin/` (or anywhere on `$PATH`).
-3. Edit `$XDG_CONFIG_HOME/ErpForFactoryGames/agent.json` (defaults to
-   `~/.config/ErpForFactoryGames/agent.json`):
-
-   ```json
-   {
-     "Agent": {
-       "ApiBaseUrl": "https://satisfactory.erp-for-factory.games",
-       "AgentToken": "<any-non-empty-string-for-v1>"
-     }
-   }
-   ```
-
-4. Register the user-mode systemd unit (no `sudo`):
+3. Register the user-mode systemd unit (no `sudo`):
 
    ```bash
    ~/.local/bin/erp-agent --install
+   ```
+
+   This also writes a `.desktop` entry under
+   `$XDG_DATA_HOME/applications/erp-agent.desktop` and registers the
+   `erp-agent://` URL protocol handler via `xdg-mime`, so the web UI's
+   deep-link button can launch this binary on your desktop.
+
+4. Pair the install. Two options (ADR-0025 §8):
+
+   **Deep link.** In the web UI, open **My Agents** → **Add an
+   agent**, mint a token, then click **Open in agent**. Your desktop
+   resolves the `erp-agent://pair?token=...&api=...` URL to this
+   binary, which validates the token, writes `agent.json`, and exits.
+
+   **CLI wizard.** Useful for headless installs:
+
+   ```bash
+   ~/.local/bin/erp-agent --setup
+   ```
+
+   Or non-interactively:
+
+   ```bash
+   ~/.local/bin/erp-agent --setup --token eafg_... --api https://satisfactory.erp-for-factory.games
+   ```
+
+   Then restart so the new values take effect:
+
+   ```bash
+   systemctl --user restart erp-agent
    ```
 
 5. To keep the agent running after you log out:

--- a/src/Agent/PairingService.cs
+++ b/src/Agent/PairingService.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Json;
+
+namespace Agent;
+
+/// <summary>
+/// Validates a token against the planner API and writes the agent's
+/// on-disk config so the long-running service picks the values up on
+/// next start (ADR-0025 §8). Single seam shared by the
+/// <c>erp-agent --pair</c> deep-link path and the <c>erp-agent --setup</c>
+/// CLI wizard.
+/// </summary>
+public sealed class PairingService
+{
+    private readonly AgentConfigWriter _configWriter;
+    private readonly HttpClient _http;
+
+    public PairingService(AgentConfigWriter configWriter, HttpClient http)
+    {
+        _configWriter = configWriter;
+        _http = http;
+    }
+
+    /// <summary>
+    /// Validate <paramref name="token"/> against <paramref name="apiBaseUrl"/> by
+    /// calling <c>GET /api/me</c> with the token. On 200 the config is written.
+    /// </summary>
+    public async Task<PairingResult> PairAsync(
+        string apiBaseUrl,
+        string token,
+        string? saveFolderOverride = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(apiBaseUrl)) return PairingResult.Error("API base URL is required.");
+        if (string.IsNullOrWhiteSpace(token)) return PairingResult.Error("Token is required.");
+
+        if (!Uri.TryCreate(apiBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            return PairingResult.Error($"API base URL is not a well-formed absolute URI: {apiBaseUrl}");
+        }
+
+        var meUri = new Uri(baseUri, "/api/me");
+
+        MeResponse? me;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, meUri);
+            request.Headers.TryAddWithoutValidation("X-Agent-Token", token);
+
+            using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                return PairingResult.Error("Server rejected the token (401). Mint a fresh token from the web UI and try again.");
+            }
+            if (!response.IsSuccessStatusCode)
+            {
+                var detail = await SafeReadFirstLineAsync(response, ct).ConfigureAwait(false);
+                return PairingResult.Error($"Validation call to {meUri} returned {(int)response.StatusCode}: {detail ?? "(no body)"}");
+            }
+
+            me = await response.Content.ReadFromJsonAsync<MeResponse>(ct).ConfigureAwait(false);
+            if (me is null || me.PlayerId == Guid.Empty)
+            {
+                return PairingResult.Error("Server accepted the token but returned no player metadata.");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            return PairingResult.Error($"Could not reach {meUri}: {ex.Message}");
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return PairingResult.Error($"Timed out reaching {meUri}.");
+        }
+
+        var configPath = await _configWriter
+            .WritePairingAsync(apiBaseUrl, token, saveFolderOverride, ct)
+            .ConfigureAwait(false);
+
+        return PairingResult.Success(new PairedAgent(me.PlayerId, me.DisplayName, me.TokenId, configPath));
+    }
+
+    private static async Task<string?> SafeReadFirstLineAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var idx = body.IndexOf('\n');
+            return idx >= 0 ? body[..idx].Trim() : body.Trim();
+        }
+        catch { return null; }
+    }
+
+    private sealed record MeResponse(Guid PlayerId, string DisplayName, Guid TokenId);
+}
+
+public readonly record struct PairingResult(bool IsSuccess, PairedAgent? Paired, string? ErrorMessage)
+{
+    public static PairingResult Success(PairedAgent paired) => new(true, paired, null);
+    public static PairingResult Error(string message) => new(false, null, message);
+}
+
+public sealed record PairedAgent(Guid PlayerId, string DisplayName, Guid TokenId, string ConfigPath);

--- a/src/Agent/PairingUrlParser.cs
+++ b/src/Agent/PairingUrlParser.cs
@@ -1,0 +1,78 @@
+namespace Agent;
+
+/// <summary>
+/// Parses <c>erp-agent://pair?token=...&amp;api=...</c> deep-link URLs
+/// (ADR-0025 §8). Kept separate from <see cref="PairingService"/> so the
+/// URL grammar is unit-testable without touching HTTP or the filesystem.
+/// </summary>
+public static class PairingUrlParser
+{
+    public const string Scheme = "erp-agent";
+    public const string PairHost = "pair";
+
+    /// <summary>
+    /// Returns the parsed <see cref="PairingPayload"/> when
+    /// <paramref name="url"/> is a well-formed pairing deep-link.
+    /// Rejects unknown schemes/hosts, missing parameters, and empty
+    /// values — invalid input goes back as <see cref="PairingParseResult.Error"/>
+    /// with a human-readable reason.
+    /// </summary>
+    public static PairingParseResult TryParse(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return PairingParseResult.Error("Pairing URL is empty.");
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            return PairingParseResult.Error("Pairing URL is not a well-formed absolute URI.");
+        }
+
+        if (!string.Equals(parsed.Scheme, Scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return PairingParseResult.Error($"Pairing URL must use the '{Scheme}' scheme; got '{parsed.Scheme}'.");
+        }
+
+        if (!string.Equals(parsed.Host, PairHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return PairingParseResult.Error($"Pairing URL must target '{Scheme}://{PairHost}'; got host '{parsed.Host}'.");
+        }
+
+        // System.Web isn't referenced; hand-parse the query so we don't pull
+        // another dep into the agent.
+        var query = parsed.Query.TrimStart('?');
+        string? token = null;
+        string? api = null;
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var sep = pair.IndexOf('=');
+            if (sep < 0) continue;
+            var key = Uri.UnescapeDataString(pair[..sep]);
+            var value = Uri.UnescapeDataString(pair[(sep + 1)..]);
+            if (string.Equals(key, "token", StringComparison.OrdinalIgnoreCase)) token = value;
+            else if (string.Equals(key, "api", StringComparison.OrdinalIgnoreCase)) api = value;
+        }
+
+        if (string.IsNullOrWhiteSpace(token)) return PairingParseResult.Error("Pairing URL is missing the 'token' parameter.");
+        if (string.IsNullOrWhiteSpace(api)) return PairingParseResult.Error("Pairing URL is missing the 'api' parameter.");
+
+        if (!Uri.TryCreate(api, UriKind.Absolute, out var apiUri)
+            || (apiUri.Scheme != Uri.UriSchemeHttp && apiUri.Scheme != Uri.UriSchemeHttps))
+        {
+            return PairingParseResult.Error("Pairing URL 'api' must be an absolute http(s) URL.");
+        }
+
+        return PairingParseResult.Success(new PairingPayload(token, apiUri.GetLeftPart(UriPartial.Authority)));
+    }
+}
+
+/// <summary>The parameters carried by a <c>erp-agent://pair?...</c> URL.</summary>
+public readonly record struct PairingPayload(string Token, string ApiBaseUrl);
+
+/// <summary>Outcome of <see cref="PairingUrlParser.TryParse"/>.</summary>
+public readonly record struct PairingParseResult(bool IsSuccess, PairingPayload Payload, string? ErrorMessage)
+{
+    public static PairingParseResult Success(PairingPayload payload) => new(true, payload, null);
+    public static PairingParseResult Error(string message) => new(false, default, message);
+}

--- a/src/Agent/Program.cs
+++ b/src/Agent/Program.cs
@@ -7,12 +7,19 @@ using Microsoft.Extensions.Options;
 using Serilog;
 
 // ---------------------------------------------------------------------
-// CLI entry — handle --install / --uninstall / --help before any host
-// machinery boots. These flags do one thing and exit; the long-running
-// service path is the default when no flag is given.
+// CLI entry — handle --install / --uninstall / --setup / --pair / --help
+// before any host machinery boots. These flags do one thing and exit;
+// the long-running service path is the default when no flag is given.
+//
+// Pairing dispatch (ADR-0025 §8):
+//   • erp-agent --pair erp-agent://pair?token=...&api=...
+//   • erp-agent erp-agent://pair?token=...&api=...    (raw URL via protocol handler)
+//   • erp-agent --setup [--token X] [--api Y] [--save-folder Z]
+// Both paths converge on PairingService.
 // ---------------------------------------------------------------------
-foreach (var arg in args)
+for (var i = 0; i < args.Length; i++)
 {
+    var arg = args[i];
     switch (arg)
     {
         case "--install":
@@ -25,6 +32,20 @@ foreach (var arg in args)
         case "--help" or "-h":
             PrintUsage();
             return 0;
+        case "--pair":
+            {
+                var url = (i + 1 < args.Length) ? args[i + 1] : null;
+                return await RunPairAsync(url).ConfigureAwait(false);
+            }
+        case "--setup":
+            return await RunSetupAsync(args).ConfigureAwait(false);
+    }
+
+    // Protocol handler invocation: Windows / Linux pass the deep-link as
+    // the first positional argv when launching us via erp-agent://.
+    if (arg.StartsWith($"{PairingUrlParser.Scheme}://", StringComparison.OrdinalIgnoreCase))
+    {
+        return await RunPairAsync(arg).ConfigureAwait(false);
     }
 }
 
@@ -131,24 +152,114 @@ static void PrintUsage()
         erp-agent — ERP for Factory Games local-data agent.
 
         Usage:
-          erp-agent                  Run in the foreground (or as a registered
-                                     service when launched by the SCM / systemd).
-          erp-agent --install        Register as a Windows service (run elevated)
-                                     or a systemd --user unit.
-          erp-agent --uninstall      Reverse of --install.
-          erp-agent --version, -v    Print the agent version.
-          erp-agent --help, -h       This help.
+          erp-agent                       Run in the foreground (or as a registered
+                                          service when launched by the SCM / systemd).
+          erp-agent --install             Register as a Windows service (run elevated)
+                                          or a systemd --user unit. Also registers the
+                                          erp-agent:// URL protocol handler for the
+                                          deep-link pairing flow.
+          erp-agent --uninstall           Reverse of --install.
+          erp-agent --setup               Interactive first-run wizard: prompts for
+            [--token X]                     API URL, agent token, optional save-folder
+            [--api Y]                       override. Validates the token against
+            [--save-folder Z]               /api/me and writes agent.json.
+          erp-agent --pair erp-agent://pair?token=...&api=...
+                                          Non-interactive pairing: parse the deep-link,
+                                          validate the token, write agent.json. Same
+                                          path used by the URL protocol handler.
+          erp-agent erp-agent://...       Equivalent to --pair (positional invocation).
+          erp-agent --version, -v         Print the agent version.
+          erp-agent --help, -h            This help.
 
         Configuration:
           appsettings.json next to the binary holds defaults.
           agent.json under %ProgramData%/ErpForFactoryGames/ (Windows) or
           $XDG_CONFIG_HOME/ErpForFactoryGames/ (Linux) is the writeable
-          override — that's where you put your API URL + token. On Windows
+          override — that's where the API URL + token live. On Windows
           the path is machine-wide rather than per-user so the LocalSystem
           service and the installing user agree on which file to read.
 
         See INSTALL.md next to the binary for the full first-run guide.
         """);
+}
+
+static async Task<int> RunPairAsync(string? url)
+{
+    if (string.IsNullOrWhiteSpace(url))
+    {
+        Console.Error.WriteLine("--pair requires a erp-agent:// URL argument.");
+        return 2;
+    }
+
+    var parsed = PairingUrlParser.TryParse(url);
+    if (!parsed.IsSuccess)
+    {
+        Console.Error.WriteLine($"Could not parse pairing URL: {parsed.ErrorMessage}");
+        return 2;
+    }
+
+    var pairing = BuildPairingService(parsed.Payload.ApiBaseUrl);
+    Console.Out.WriteLine($"Pairing against {parsed.Payload.ApiBaseUrl}…");
+    var result = await pairing.PairAsync(parsed.Payload.ApiBaseUrl, parsed.Payload.Token).ConfigureAwait(false);
+    if (!result.IsSuccess)
+    {
+        Console.Error.WriteLine($"Pairing failed: {result.ErrorMessage}");
+        return 4;
+    }
+
+    var paired = result.Paired!;
+    Console.Out.WriteLine($"Paired as '{paired.DisplayName}' ({paired.PlayerId}).");
+    Console.Out.WriteLine($"Wrote config: {paired.ConfigPath}");
+    Console.Out.WriteLine("Restart the agent service to pick up the new values:");
+    Console.Out.WriteLine(OperatingSystem.IsWindows()
+        ? "  sc.exe stop erp-agent && sc.exe start erp-agent"
+        : "  systemctl --user restart erp-agent");
+    return 0;
+}
+
+static async Task<int> RunSetupAsync(string[] argv)
+{
+    string? token = null;
+    string? api = null;
+    string? saveFolder = null;
+    var interactive = true;
+
+    for (var i = 0; i < argv.Length; i++)
+    {
+        switch (argv[i])
+        {
+            case "--token" when i + 1 < argv.Length:
+                token = argv[++i];
+                interactive = false;
+                break;
+            case "--api" when i + 1 < argv.Length:
+                api = argv[++i];
+                break;
+            case "--save-folder" when i + 1 < argv.Length:
+                saveFolder = argv[++i];
+                break;
+        }
+    }
+
+    // Tentative API for building the HttpClient; the SetupService will
+    // re-prompt if it's null, so we use a placeholder that will be
+    // overwritten before any network call. The client just needs a
+    // BaseAddress at construction; PairingService passes the real URL.
+    var setup = new SetupService(BuildPairingService(api ?? "https://localhost"));
+    return await setup
+        .RunAsync(new SetupArgs(api, token, saveFolder, interactive))
+        .ConfigureAwait(false);
+}
+
+static PairingService BuildPairingService(string apiBaseUrlHint)
+{
+    var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+    if (Uri.TryCreate(apiBaseUrlHint, UriKind.Absolute, out var uri))
+    {
+        http.BaseAddress = uri;
+    }
+    var writer = new AgentConfigWriter(ConfigPath());
+    return new PairingService(writer, http);
 }
 
 // Local helpers — file paths are OS-specific. See ADR-0024 §2.

--- a/src/Agent/ServiceRegistrar.cs
+++ b/src/Agent/ServiceRegistrar.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+#pragma warning disable CA1416 // Each registry call is gated on OperatingSystem.IsWindows() at the call site.
+using Microsoft.Win32;
+#pragma warning restore CA1416
 
 namespace Agent;
 
@@ -107,9 +110,57 @@ internal static class ServiceRegistrar
             return start.ExitCode;
         }
 
+        // Register the erp-agent:// URL protocol handler (ADR-0025 §8) so the
+        // Web UI's "Open in agent" deep-link can launch this binary. HKCU
+        // rather than HKLM — works without admin from the user's side, even
+        // though --install itself is elevated.
+        RegisterProtocolHandlerWindows(binary);
+
         Console.Out.WriteLine($"Service '{ServiceName}' installed and started.");
-        Console.Out.WriteLine($"Set the API URL + token in {configPath} then restart the service.");
+        Console.Out.WriteLine($"Run 'erp-agent --setup' to pair this install, or pair via the web UI's deep-link.");
         return 0;
+    }
+
+    private static void RegisterProtocolHandlerWindows(string binary)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+#pragma warning disable CA1416
+        try
+        {
+            using var root = Registry.CurrentUser.CreateSubKey(@"Software\Classes\erp-agent", writable: true);
+            root.SetValue(string.Empty, "URL:ERP Agent Protocol");
+            root.SetValue("URL Protocol", string.Empty);
+
+            using var defaultIcon = root.CreateSubKey("DefaultIcon", writable: true);
+            defaultIcon.SetValue(string.Empty, $"\"{binary}\",0");
+
+            using var shellOpenCommand = root.CreateSubKey(@"shell\open\command", writable: true);
+            // "%1" is the full deep-link URL Windows passes through.
+            shellOpenCommand.SetValue(string.Empty, $"\"{binary}\" --pair \"%1\"");
+
+            Console.Out.WriteLine("Registered erp-agent:// protocol handler in HKCU.");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to register erp-agent:// protocol handler: {ex.Message}");
+            Console.Error.WriteLine("Service was installed; deep-link pairing won't work until this is fixed.");
+        }
+#pragma warning restore CA1416
+    }
+
+    private static void UnregisterProtocolHandlerWindows()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+#pragma warning disable CA1416
+        try
+        {
+            Registry.CurrentUser.DeleteSubKeyTree(@"Software\Classes\erp-agent", throwOnMissingSubKey: false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to remove erp-agent:// protocol handler: {ex.Message}");
+        }
+#pragma warning restore CA1416
     }
 
     /// <summary>
@@ -185,6 +236,8 @@ internal static class ServiceRegistrar
             return del.ExitCode;
         }
 
+        UnregisterProtocolHandlerWindows();
+
         Console.Out.WriteLine($"Service '{ServiceName}' uninstalled.");
         return 0;
     }
@@ -253,11 +306,49 @@ internal static class ServiceRegistrar
             return enable.ExitCode;
         }
 
+        // Register the erp-agent:// URL protocol handler so the Web UI's
+        // "Open in agent" button works on Linux (ADR-0025 §8). Per-user
+        // .desktop file under $XDG_DATA_HOME/applications/ + a MIME default
+        // pointing at it. No root required.
+        await RegisterProtocolHandlerLinuxAsync(binary).ConfigureAwait(false);
+
         Console.Out.WriteLine($"Unit '{ServiceName}.service' installed and started.");
-        Console.Out.WriteLine("Configure the API URL + token at $XDG_CONFIG_HOME/ErpForFactoryGames/agent.json and restart with:");
-        Console.Out.WriteLine($"  systemctl --user restart {ServiceName}");
+        Console.Out.WriteLine("Run 'erp-agent --setup' to pair this install, or pair via the web UI's deep-link.");
         Console.Out.WriteLine("To survive logout, enable user lingering: loginctl enable-linger \"$USER\"");
         return 0;
+    }
+
+    private static async Task RegisterProtocolHandlerLinuxAsync(string binary)
+    {
+        var dataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+        var appsDir = Path.Combine(dataHome, "applications");
+        Directory.CreateDirectory(appsDir);
+
+        var desktopPath = Path.Combine(appsDir, $"{ServiceName}.desktop");
+        var desktop = $"""
+            [Desktop Entry]
+            Type=Application
+            Name={DisplayName}
+            Exec={binary} --pair %u
+            Terminal=false
+            NoDisplay=true
+            MimeType=x-scheme-handler/erp-agent;
+            """;
+        await File.WriteAllTextAsync(desktopPath, desktop).ConfigureAwait(false);
+
+        // xdg-mime default registers the handler. Best-effort — if xdg-mime
+        // is absent (some minimal distros) the .desktop file still gets
+        // picked up by most DE-driven URL launchers automatically.
+        var setDefault = await RunAsync("xdg-mime", $"default {ServiceName}.desktop x-scheme-handler/erp-agent").ConfigureAwait(false);
+        if (setDefault.ExitCode != 0)
+        {
+            Console.Out.WriteLine("Wrote .desktop but xdg-mime not available; the DE may still discover the handler automatically.");
+        }
+        else
+        {
+            Console.Out.WriteLine($"Registered erp-agent:// protocol handler ({desktopPath}).");
+        }
     }
 
     private static async Task<int> UninstallSystemdUserAsync()
@@ -272,6 +363,17 @@ internal static class ServiceRegistrar
         {
             File.Delete(unitPath);
             Console.Out.WriteLine($"Removed {unitPath}");
+        }
+
+        // Remove the .desktop file too — uninstall should leave no orphan
+        // protocol-handler entries.
+        var dataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+        var desktopPath = Path.Combine(dataHome, "applications", $"{ServiceName}.desktop");
+        if (File.Exists(desktopPath))
+        {
+            File.Delete(desktopPath);
+            Console.Out.WriteLine($"Removed {desktopPath}");
         }
 
         await RunAsync("systemctl", "--user daemon-reload").ConfigureAwait(false);

--- a/src/Agent/SetupService.cs
+++ b/src/Agent/SetupService.cs
@@ -1,0 +1,100 @@
+namespace Agent;
+
+/// <summary>
+/// Interactive (and non-interactive via flags) first-run wizard for the
+/// agent (ADR-0025 §8, extends #222). Prompts for API base URL, token,
+/// and an optional save-folder override, then defers to
+/// <see cref="PairingService"/> for validation + write.
+///
+/// <para>
+/// When invoked with <c>--token &lt;value&gt;</c> the wizard runs
+/// non-interactively, so installers can chain
+/// <c>erp-agent --install &amp;&amp; erp-agent --setup --token ... --api ...</c>
+/// without user input.
+/// </para>
+/// </summary>
+public sealed class SetupService
+{
+    private readonly PairingService _pairing;
+
+    public SetupService(PairingService pairing)
+    {
+        _pairing = pairing;
+    }
+
+    public async Task<int> RunAsync(SetupArgs args, CancellationToken ct = default)
+    {
+        var apiBaseUrl = args.ApiBaseUrl ?? Prompt("API base URL", "https://satisfactory.erp-for-factory.games");
+        if (string.IsNullOrWhiteSpace(apiBaseUrl))
+        {
+            Console.Error.WriteLine("API base URL is required.");
+            return 2;
+        }
+
+        var token = args.Token ?? PromptSecret("Agent token (paste from the web UI's 'My Agents' page)");
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            Console.Error.WriteLine("Token is required.");
+            return 2;
+        }
+
+        var saveFolderOverride = args.SaveFolderPath;
+        if (saveFolderOverride is null && args.Interactive)
+        {
+            var raw = Prompt("Save folder override (blank = auto-detect)", "");
+            if (!string.IsNullOrWhiteSpace(raw)) saveFolderOverride = raw;
+        }
+
+        Console.Out.WriteLine($"Validating token against {apiBaseUrl}…");
+        var result = await _pairing.PairAsync(apiBaseUrl, token, saveFolderOverride, ct).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            Console.Error.WriteLine($"Pairing failed: {result.ErrorMessage}");
+            return 4;
+        }
+
+        var paired = result.Paired!;
+        Console.Out.WriteLine($"Paired as '{paired.DisplayName}' ({paired.PlayerId}).");
+        Console.Out.WriteLine($"Wrote config: {paired.ConfigPath}");
+        Console.Out.WriteLine("Restart the agent service to pick up the new values:");
+        Console.Out.WriteLine(OperatingSystem.IsWindows()
+            ? "  sc.exe stop erp-agent && sc.exe start erp-agent"
+            : "  systemctl --user restart erp-agent");
+        return 0;
+    }
+
+    private static string Prompt(string label, string @default)
+    {
+        if (string.IsNullOrEmpty(@default))
+        {
+            Console.Out.Write($"{label}: ");
+        }
+        else
+        {
+            Console.Out.Write($"{label} [{@default}]: ");
+        }
+        var line = Console.In.ReadLine();
+        return string.IsNullOrWhiteSpace(line) ? @default : line.Trim();
+    }
+
+    private static string PromptSecret(string label)
+    {
+        Console.Out.Write($"{label}: ");
+        // Console doesn't mask cleanly across all hosts; we trade off
+        // hidden input for portability and ask the user to paste anyway.
+        // If the terminal sends a clipboard paste the token appears in
+        // scrollback — acceptable risk for a CLI wizard, and it matches
+        // how `gh auth login` etc. behave when piped through SSH.
+        var line = Console.In.ReadLine();
+        return line?.Trim() ?? string.Empty;
+    }
+}
+
+/// <summary>Inputs to <see cref="SetupService.RunAsync"/>. All optional —
+/// missing values are prompted for unless <see cref="Interactive"/> is
+/// <c>false</c>.</summary>
+public sealed record SetupArgs(
+    string? ApiBaseUrl,
+    string? Token,
+    string? SaveFolderPath,
+    bool Interactive);

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -909,7 +909,9 @@ app.MapDelete("/players/{id:guid}/agent-tokens/{tokenId:guid}", async (
     return Results.NoContent();
 });
 
-app.MapGet("/me", async (
+// /api/me prefix per #245's routing rule — the agent reaches this through
+// the Cloudflare tunnel for pair validation, so it has to sit under /api/*.
+app.MapGet("/api/me", async (
     HttpRequest http,
     IAgentTokenAuthenticator authenticator,
     IPlayerRepository players,

--- a/test/Agent.Tests/AgentConfigWriterTests.cs
+++ b/test/Agent.Tests/AgentConfigWriterTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Agent;
+
+namespace Agent.Tests;
+
+public class AgentConfigWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _configPath;
+
+    public AgentConfigWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"agent-cfg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _configPath = Path.Combine(_tempDir, "agent.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Writes_fresh_file_when_none_exists()
+    {
+        var writer = new AgentConfigWriter(_configPath);
+
+        var resolved = await writer.WritePairingAsync("https://example.test", "eafg_abc", saveFolderOverride: null);
+
+        Assert.Equal(_configPath, resolved);
+        var node = JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!.AsObject();
+        var agent = node["Agent"]!.AsObject();
+        Assert.Equal("https://example.test", (string?)agent["ApiBaseUrl"]);
+        Assert.Equal("eafg_abc", (string?)agent["AgentToken"]);
+    }
+
+    [Fact]
+    public async Task Preserves_unknown_keys_on_merge()
+    {
+        // The install flow writes SaveFolderPath into agent.json before
+        // pairing happens — we must not clobber that, nor any future
+        // keys the user has hand-added.
+        var seed = """
+            {
+              "Agent": {
+                "ApiBaseUrl": "",
+                "AgentToken": "",
+                "SaveFolderPath": "C:\\users\\test\\sav",
+                "LogTail": { "Enabled": false }
+              },
+              "CustomSection": { "foo": "bar" }
+            }
+            """;
+        await File.WriteAllTextAsync(_configPath, seed);
+
+        var writer = new AgentConfigWriter(_configPath);
+        await writer.WritePairingAsync("https://example.test", "eafg_abc", saveFolderOverride: null);
+
+        var node = JsonNode.Parse(await File.ReadAllTextAsync(_configPath))!.AsObject();
+        var agent = node["Agent"]!.AsObject();
+        Assert.Equal("https://example.test", (string?)agent["ApiBaseUrl"]);
+        Assert.Equal("eafg_abc", (string?)agent["AgentToken"]);
+        Assert.Equal("C:\\users\\test\\sav", (string?)agent["SaveFolderPath"]);
+        Assert.False((bool)agent["LogTail"]!["Enabled"]!);
+        Assert.Equal("bar", (string?)node["CustomSection"]!["foo"]);
+    }
+
+    [Fact]
+    public async Task Trims_trailing_slash_on_api_base_url()
+    {
+        var writer = new AgentConfigWriter(_configPath);
+        await writer.WritePairingAsync("https://example.test/", "eafg_abc", saveFolderOverride: null);
+
+        var json = JsonDocument.Parse(await File.ReadAllTextAsync(_configPath));
+        Assert.Equal("https://example.test", json.RootElement.GetProperty("Agent").GetProperty("ApiBaseUrl").GetString());
+    }
+
+    [Fact]
+    public async Task Writes_via_temp_then_rename_so_partial_writes_dont_corrupt_existing()
+    {
+        // We can't easily inject a crash, but we can assert the .tmp file
+        // doesn't survive a successful write — proves the temp-then-rename
+        // path is exercised.
+        var writer = new AgentConfigWriter(_configPath);
+        await writer.WritePairingAsync("https://example.test", "eafg_abc", saveFolderOverride: null);
+
+        Assert.False(File.Exists(_configPath + ".tmp"), "Temp file should have been renamed away.");
+        Assert.True(File.Exists(_configPath));
+    }
+}

--- a/test/Agent.Tests/PairingUrlParserTests.cs
+++ b/test/Agent.Tests/PairingUrlParserTests.cs
@@ -1,0 +1,81 @@
+using Agent;
+
+namespace Agent.Tests;
+
+public class PairingUrlParserTests
+{
+    [Fact]
+    public void Parses_well_formed_url()
+    {
+        var result = PairingUrlParser.TryParse(
+            "erp-agent://pair?token=eafg_abc123&api=https%3A%2F%2Fsatisfactory.erp-for-factory.games");
+
+        Assert.True(result.IsSuccess, result.ErrorMessage);
+        Assert.Equal("eafg_abc123", result.Payload.Token);
+        Assert.Equal("https://satisfactory.erp-for-factory.games", result.Payload.ApiBaseUrl);
+    }
+
+    [Fact]
+    public void Rejects_unknown_scheme()
+    {
+        var result = PairingUrlParser.TryParse("https://pair?token=x&api=https://y");
+        Assert.False(result.IsSuccess);
+        Assert.Contains("scheme", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_unknown_host()
+    {
+        var result = PairingUrlParser.TryParse("erp-agent://wrong?token=x&api=https://y");
+        Assert.False(result.IsSuccess);
+        Assert.Contains("host", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Rejects_missing_token()
+    {
+        var result = PairingUrlParser.TryParse("erp-agent://pair?api=https://y");
+        Assert.False(result.IsSuccess);
+        Assert.Contains("token", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Rejects_missing_api()
+    {
+        var result = PairingUrlParser.TryParse("erp-agent://pair?token=x");
+        Assert.False(result.IsSuccess);
+        Assert.Contains("api", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Rejects_non_http_api()
+    {
+        var result = PairingUrlParser.TryParse(
+            "erp-agent://pair?token=eafg_abc&api=file%3A%2F%2F%2Fetc%2Fpasswd");
+        Assert.False(result.IsSuccess);
+        Assert.Contains("http", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Strips_path_and_query_from_api()
+    {
+        // The 'api' parameter should be treated as a base URL — any path or
+        // query the web UI accidentally appended must not bleed into the
+        // request URLs the agent constructs.
+        var result = PairingUrlParser.TryParse(
+            "erp-agent://pair?token=eafg_abc&api=https%3A%2F%2Fhost.example%2Fextra%3Fkey%3Dvalue");
+        Assert.True(result.IsSuccess);
+        Assert.Equal("https://host.example", result.Payload.ApiBaseUrl);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    public void Rejects_garbage(string? input)
+    {
+        var result = PairingUrlParser.TryParse(input);
+        Assert.False(result.IsSuccess);
+    }
+}

--- a/test/ApiService.Tests/PlayerTokenEndpointsTests.cs
+++ b/test/ApiService.Tests/PlayerTokenEndpointsTests.cs
@@ -73,7 +73,7 @@ public sealed class PlayerTokenEndpointsTests : IClassFixture<AgentEndpointsTest
         Assert.NotNull(payload);
 
         // The token works.
-        var meOk = new HttpRequestMessage(HttpMethod.Get, "/me");
+        var meOk = new HttpRequestMessage(HttpMethod.Get, "/api/me");
         meOk.Headers.TryAddWithoutValidation("X-Agent-Token", payload!.Plaintext);
         var meOkResponse = await client.SendAsync(meOk);
         Assert.Equal(HttpStatusCode.OK, meOkResponse.StatusCode);
@@ -84,7 +84,7 @@ public sealed class PlayerTokenEndpointsTests : IClassFixture<AgentEndpointsTest
 
         // Now the token is dead — auth pipeline must reject (the cache was
         // invalidated by the revoke endpoint).
-        var meDead = new HttpRequestMessage(HttpMethod.Get, "/me");
+        var meDead = new HttpRequestMessage(HttpMethod.Get, "/api/me");
         meDead.Headers.TryAddWithoutValidation("X-Agent-Token", payload.Plaintext);
         var meDeadResponse = await client.SendAsync(meDead);
         Assert.Equal(HttpStatusCode.Unauthorized, meDeadResponse.StatusCode);
@@ -96,7 +96,7 @@ public sealed class PlayerTokenEndpointsTests : IClassFixture<AgentEndpointsTest
         var client = _factory.CreateClient();
         var token = await _factory.MintTokenAsync(label: "/me probe");
 
-        var request = new HttpRequestMessage(HttpMethod.Get, "/me");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/me");
         request.Headers.TryAddWithoutValidation("X-Agent-Token", token);
         var response = await client.SendAsync(request);
 


### PR DESCRIPTION
## Summary

Closes #237. Both ADR-0025 §8 pairing paths land here, routed through a single `PairingService`:

```
erp-agent --pair erp-agent://pair?token=...&api=...   (deep-link)
erp-agent erp-agent://...                             (raw URL via protocol handler)
erp-agent --setup [--token X] [--api Y]               (CLI wizard, extends #222)
```

`PairingService` validates the token against `GET /api/me` **before** writing `agent.json` — failed validation never touches on-disk config. `AgentConfigWriter` merges into any existing `agent.json` so the install flow's seeded `SaveFolderPath` (and any unknown keys the user added) survive a pair operation. Atomic write via temp → rename.

## Protocol handler registration

- **Windows**: `HKCU\Software\Classes\erp-agent` written by `--install`, with `DefaultIcon` and `shell\open\command = "<binary>" --pair "%1"`. Cleaned up by `--uninstall`.
- **Linux**: `$XDG_DATA_HOME/applications/erp-agent.desktop` with `MimeType=x-scheme-handler/erp-agent`; `xdg-mime default` registers the handler. Cleaned up by `--uninstall`.
- **macOS**: deferred to #221's `.pkg` installer.

## API surface change

**`/me` moved to `/api/me`** so the Cloudflare tunnel routing rule from #245 (`/api/.* → erp-api`) can carry agent pair-validation calls. ADR-0025 §9 amended in this PR with the new path. `PlayerTokenEndpointsTests` updated.

## What this unblocks

- **#236** — the Web UI's "Open in agent" deep-link button now does something. Round-trip works: web mints token → deep-link → agent validates against `/api/me` → `agent.json` written → user restarts service → uploads start.
- **#238 / #239** — the agent's pairing context is the first piece of work that proves the auth pipeline end-to-end.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test test/Agent.Tests` — 27/27 pass (15 pre-existing + 12 new: 8 URL parser cases, 4 config writer cases including merge-preserves-unknowns + atomic-rename cleanup)
- [x] `dotnet test test/ApiService.Tests` — 24/24 pass after the `/me` → `/api/me` move
- [ ] CI: build + lint + migration drift
- [ ] Manual on Windows: install agent → mint token in web UI → click "Open in agent" → confirm `HKCU\Software\Classes\erp-agent` resolves and the agent reports `Paired as '<DevPlayer>'`
- [ ] Manual on Linux: same flow via a DE that respects `xdg-mime default`

## Deliberately out of scope

- Code signing / notarization (#223 covers).
- Automatic service restart after pairing — the wizard prints the OS-appropriate `restart` command instead. Adding `sc.exe restart erp-agent` / `systemctl --user restart erp-agent` is cheap; left out so the pairing path stays read-write-config-only and predictable.
- macOS protocol handler — needs the .pkg with `CFBundleURLTypes` (#221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)