### PR TITLE
feat(api,agent): catalogue upload — agent reads Docs.json, server stores per-player (#238)

### DIFF
--- a/docs/adr/0011-catalogue-source-path-configuration.md
+++ b/docs/adr/0011-catalogue-source-path-configuration.md
@@ -1,6 +1,6 @@
 # 0011. Catalogue source path configuration
 
-- Status: Accepted (superseded in part by [0025](0025-agent-auth-catalogue-handover.md) for hosted deployments — server-local resolution is dev-only fallback)
+- Status: Accepted (superseded in part by [0025](0025-agent-auth-catalogue-handover.md) for hosted deployments — server-local resolution is dev-only fallback; agent-side upload landed with #238)
 - Date: 2026-05-03
 - Deciders: Chris
 

--- a/src/Agent/CatalogueOptions.cs
+++ b/src/Agent/CatalogueOptions.cs
@@ -1,0 +1,28 @@
+namespace Agent;
+
+/// <summary>
+/// Where the agent finds the user's <c>Docs.json</c> to upload to the
+/// hosted planner (ADR-0025 §4-§5). Reuses the same config key
+/// (<c>Catalogue:Satisfactory:DocsPath</c>) the server-side
+/// DocsCatalogProvider used pre-#238 so existing user configs work
+/// unchanged.
+/// </summary>
+public sealed class CatalogueUploadOptions
+{
+    public const string SectionName = "Catalogue:Satisfactory";
+
+    /// <summary>
+    /// Absolute path to the user's <c>Docs.json</c> (e.g.
+    /// <c>C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs\Docs.json</c>).
+    /// Empty disables catalogue uploads — the agent logs a warning and
+    /// otherwise carries on shipping saves + log lines.
+    /// </summary>
+    public string? DocsPath { get; set; }
+
+    /// <summary>
+    /// Override via env var <c>ERP_AGENT_SATISFACTORY_DOCS_PATH</c>.
+    /// Mirrors the server-side <c>ERP_SATISFACTORY_DOCS_PATH</c> escape
+    /// hatch from ADR-0011.
+    /// </summary>
+    public const string EnvironmentVariable = "ERP_AGENT_SATISFACTORY_DOCS_PATH";
+}

--- a/src/Agent/CatalogueUploadStartup.cs
+++ b/src/Agent/CatalogueUploadStartup.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Agent;
+
+/// <summary>
+/// Hosted service that triggers <see cref="ICatalogueUploader"/> once
+/// shortly after startup (ADR-0025 §4-§5). Best-effort — failures are
+/// logged but don't block the rest of the agent's hosted services.
+///
+/// <para>
+/// On-save-event re-upload and the re-ingest poll trigger (#239) land
+/// alongside their own hosted services; this one only covers the
+/// "pair-and-then-upload-once" path so the planner has a catalogue
+/// from the first time a paired agent starts.
+/// </para>
+/// </summary>
+internal sealed class CatalogueUploadStartup : BackgroundService
+{
+    // Tiny delay so the boot logs stay readable — uploads aren't latency-
+    // critical and waiting a few seconds lets the host's startup logging
+    // flush first.
+    private static readonly TimeSpan StartDelay = TimeSpan.FromSeconds(5);
+
+    private readonly ICatalogueUploader _uploader;
+    private readonly ILogger<CatalogueUploadStartup> _logger;
+
+    public CatalogueUploadStartup(ICatalogueUploader uploader, ILogger<CatalogueUploadStartup> logger)
+    {
+        _uploader = uploader;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try { await Task.Delay(StartDelay, stoppingToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        try
+        {
+            var attempt = await _uploader.UploadAsync(stoppingToken).ConfigureAwait(false);
+            if (!attempt.Succeeded && !attempt.Skipped)
+            {
+                _logger.LogWarning("Initial catalogue upload failed: {Detail}", attempt.Detail);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Initial catalogue upload threw");
+        }
+    }
+}

--- a/src/Agent/HttpCatalogueUploader.cs
+++ b/src/Agent/HttpCatalogueUploader.cs
@@ -1,0 +1,124 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Agent;
+
+/// <summary>
+/// HTTP implementation of <see cref="ICatalogueUploader"/>. Posts the
+/// raw <c>Docs.json</c> bytes to <c>/api/agent/catalogue/satisfactory</c>;
+/// the server hashes + dedups + persists.
+/// </summary>
+internal sealed class HttpCatalogueUploader : ICatalogueUploader
+{
+    private const string UploadPath = "/api/agent/catalogue/satisfactory";
+
+    private readonly HttpClient _http;
+    private readonly AgentOptions _agentOptions;
+    private readonly CatalogueUploadOptions _catalogueOptions;
+    private readonly ILogger<HttpCatalogueUploader> _logger;
+
+    public HttpCatalogueUploader(
+        HttpClient http,
+        IOptions<AgentOptions> agentOptions,
+        IOptions<CatalogueUploadOptions> catalogueOptions,
+        ILogger<HttpCatalogueUploader> logger)
+    {
+        _http = http;
+        _agentOptions = agentOptions.Value;
+        _catalogueOptions = catalogueOptions.Value;
+        _logger = logger;
+    }
+
+    public async Task<CatalogueUploadAttempt> UploadAsync(CancellationToken ct)
+    {
+        var attemptedAt = DateTimeOffset.UtcNow;
+        var path = ResolveDocsPath();
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            _logger.LogInformation(
+                "Catalogue:Satisfactory:DocsPath is not configured — skipping catalogue upload. "
+                + "Set the path in agent.json to enable.");
+            return new CatalogueUploadAttempt(null, attemptedAt, Skipped: true,
+                Succeeded: false, StatusCode: null, DocsHash: null, SizeBytes: null,
+                Detail: "DocsPath not configured.");
+        }
+
+        if (!File.Exists(path))
+        {
+            _logger.LogWarning("Catalogue Docs.json not found at {Path}.", path);
+            return new CatalogueUploadAttempt(path, attemptedAt, Skipped: true,
+                Succeeded: false, StatusCode: null, DocsHash: null, SizeBytes: null,
+                Detail: $"Not found: {path}");
+        }
+
+        try
+        {
+            byte[] bytes;
+            await using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                             bufferSize: 64 * 1024, useAsync: true))
+            {
+                using var ms = new MemoryStream();
+                await fs.CopyToAsync(ms, ct).ConfigureAwait(false);
+                bytes = ms.ToArray();
+            }
+
+            using var content = new ByteArrayContent(bytes);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, UploadPath) { Content = content };
+            request.Headers.TryAddWithoutValidation("X-Agent-Token", _agentOptions.AgentToken);
+            request.Headers.TryAddWithoutValidation(
+                "X-Agent-Version",
+                typeof(HttpCatalogueUploader).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+
+            using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
+            {
+                _logger.LogInformation("Catalogue at {Path} matches server's stored hash (304).", path);
+                return new CatalogueUploadAttempt(path, attemptedAt, Skipped: false,
+                    Succeeded: true, StatusCode: 304, DocsHash: null, SizeBytes: bytes.Length,
+                    Detail: "No change since last upload.");
+            }
+
+            if (response.IsSuccessStatusCode)
+            {
+                var payload = await response.Content.ReadFromJsonAsync<UploadResponse>(ct).ConfigureAwait(false);
+                _logger.LogInformation(
+                    "Catalogue uploaded ({Bytes} bytes, hash {Hash}).",
+                    bytes.Length, payload?.DocsHash ?? "?");
+                return new CatalogueUploadAttempt(path, attemptedAt, Skipped: false,
+                    Succeeded: true, StatusCode: (int)response.StatusCode,
+                    DocsHash: payload?.DocsHash, SizeBytes: bytes.Length, Detail: null);
+            }
+
+            var detail = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Catalogue upload failed: {Status} {Detail}", (int)response.StatusCode, detail);
+            return new CatalogueUploadAttempt(path, attemptedAt, Skipped: false,
+                Succeeded: false, StatusCode: (int)response.StatusCode,
+                DocsHash: null, SizeBytes: bytes.Length, Detail: detail);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Catalogue upload threw");
+            return new CatalogueUploadAttempt(path, attemptedAt, Skipped: false,
+                Succeeded: false, StatusCode: null, DocsHash: null, SizeBytes: null,
+                Detail: ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    private string? ResolveDocsPath()
+    {
+        // Env var wins, matches the server-side resolution from ADR-0011.
+        var fromEnv = Environment.GetEnvironmentVariable(CatalogueUploadOptions.EnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(fromEnv)) return fromEnv;
+        return string.IsNullOrWhiteSpace(_catalogueOptions.DocsPath) ? null : _catalogueOptions.DocsPath;
+    }
+
+    private sealed record UploadResponse(string DocsHash, long SizeBytes, DateTime UploadedUtc, bool Changed);
+}

--- a/src/Agent/ICatalogueUploader.cs
+++ b/src/Agent/ICatalogueUploader.cs
@@ -1,0 +1,27 @@
+namespace Agent;
+
+/// <summary>
+/// Uploads the player's local <c>Docs.json</c> to the hosted planner
+/// (ADR-0025 §4-§5). One call per intended push; the server handles
+/// dedup via the hash on its side, so the uploader doesn't need to
+/// remember previous uploads.
+/// </summary>
+public interface ICatalogueUploader
+{
+    Task<CatalogueUploadAttempt> UploadAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Result of one upload attempt. <see cref="StatusCode"/> is 304 when
+/// the server's stored hash already matched — that's a healthy outcome,
+/// not a failure.
+/// </summary>
+public sealed record CatalogueUploadAttempt(
+    string? FilePath,
+    DateTimeOffset AttemptedAt,
+    bool Skipped,
+    bool Succeeded,
+    int? StatusCode,
+    string? DocsHash,
+    long? SizeBytes,
+    string? Detail);

--- a/src/Agent/Program.cs
+++ b/src/Agent/Program.cs
@@ -47,6 +47,8 @@ builder.Configuration.AddJsonFile(ConfigPath(), optional: true, reloadOnChange: 
 builder.Configuration.AddEnvironmentVariables(prefix: "ERP_AGENT_");
 
 builder.Services.Configure<AgentOptions>(builder.Configuration.GetSection("Agent"));
+builder.Services.Configure<CatalogueUploadOptions>(
+    builder.Configuration.GetSection(CatalogueUploadOptions.SectionName));
 
 // ---------------------------------------------------------------------
 // Logging — Serilog file sink + console, see ADR-0024 §2. App code stays
@@ -97,8 +99,21 @@ builder.Services.AddHttpClient<ILogTailUploader, HttpLogTailUploader>((sp, http)
     http.Timeout = TimeSpan.FromSeconds(30);
 });
 
+// Catalogue uploader — separate HttpClient with a longer timeout since
+// Docs.json can run 30+ MB and the LXC's upload bandwidth isn't huge.
+builder.Services.AddHttpClient<ICatalogueUploader, HttpCatalogueUploader>((sp, http) =>
+{
+    var opts = sp.GetRequiredService<IOptions<AgentOptions>>().Value;
+    if (!string.IsNullOrWhiteSpace(opts.ApiBaseUrl))
+    {
+        http.BaseAddress = new Uri(opts.ApiBaseUrl, UriKind.Absolute);
+    }
+    http.Timeout = TimeSpan.FromMinutes(5);
+});
+
 builder.Services.AddHostedService<SaveFolderWatcher>();
 builder.Services.AddHostedService<LogTailBackgroundService>();
+builder.Services.AddHostedService<CatalogueUploadStartup>();
 
 var host = builder.Build();
 

--- a/src/ApiService/CatalogueStorageOptions.cs
+++ b/src/ApiService/CatalogueStorageOptions.cs
@@ -1,0 +1,28 @@
+namespace ApiService;
+
+/// <summary>
+/// Where the catalogue blob store keeps uploaded <c>Docs.json</c> bytes
+/// (ADR-0025 §4-§5). Filesystem-backed for v2; can swap to S3 etc.
+/// without changing the <see cref="ICatalogueStorage"/> contract.
+/// </summary>
+public sealed class CatalogueStorageOptions
+{
+    public const string SectionName = "CatalogueStorage";
+
+    /// <summary>
+    /// Root directory for catalogue blobs. Each blob lands at
+    /// <c>{Root}/{playerId}/{game}/{hash}.json</c>. Defaults to
+    /// <c>%ProgramData%/ErpForFactoryGames/catalogues</c> on Windows
+    /// or <c>$XDG_DATA_HOME/ErpForFactoryGames/catalogues</c> elsewhere.
+    /// Empty falls back to the default.
+    /// </summary>
+    public string Root { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Hard ceiling on a single Docs.json upload. Vanilla Satisfactory's
+    /// is ~30 MB; modded versions can be larger. Default 200 MB — large
+    /// enough for any realistic mod load, small enough that a stuck
+    /// upload doesn't fill the LXC.
+    /// </summary>
+    public long MaxUploadBytes { get; set; } = 200L * 1024 * 1024;
+}

--- a/src/ApiService/FileSystemCatalogueStorage.cs
+++ b/src/ApiService/FileSystemCatalogueStorage.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Options;
+
+namespace ApiService;
+
+/// <summary>
+/// Filesystem-backed <see cref="ICatalogueStorage"/>. Stores each blob
+/// at <c>{Root}/{playerId}/{game}/{hash}.json</c>. Atomic writes via
+/// temp + rename so a crash mid-upload can't leave a half-written file.
+/// </summary>
+internal sealed class FileSystemCatalogueStorage : ICatalogueStorage
+{
+    private readonly string _root;
+
+    public FileSystemCatalogueStorage(IOptions<CatalogueStorageOptions> options)
+    {
+        var root = options.Value.Root;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            var baseDir = OperatingSystem.IsWindows()
+                ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
+                : Environment.GetEnvironmentVariable("XDG_DATA_HOME")
+                  ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+            root = Path.Combine(baseDir, "ErpForFactoryGames", "catalogues");
+        }
+        _root = root;
+        Directory.CreateDirectory(_root);
+    }
+
+    public async Task<string> StoreAsync(Guid playerId, string game, string docsHash, byte[] bytes, CancellationToken ct = default)
+    {
+        var key = $"{playerId}/{game}/{docsHash}.json";
+        var fullPath = ResolveFullPath(key);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+
+        if (File.Exists(fullPath))
+        {
+            // Idempotent — identical hash already on disk, nothing to do.
+            return key;
+        }
+
+        var tmp = fullPath + ".tmp";
+        await File.WriteAllBytesAsync(tmp, bytes, ct).ConfigureAwait(false);
+        File.Move(tmp, fullPath, overwrite: true);
+        return key;
+    }
+
+    public async Task<byte[]?> ReadAsync(string storageKey, CancellationToken ct = default)
+    {
+        var fullPath = ResolveFullPath(storageKey);
+        if (!File.Exists(fullPath)) return null;
+        return await File.ReadAllBytesAsync(fullPath, ct).ConfigureAwait(false);
+    }
+
+    private string ResolveFullPath(string storageKey)
+    {
+        // Defence against path traversal — the key shape is fixed by
+        // StoreAsync but ReadAsync could be called with arbitrary input.
+        var normalized = storageKey.Replace('\\', '/').TrimStart('/');
+        if (normalized.Contains("..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Storage key must not contain parent-directory segments.", nameof(storageKey));
+        }
+        return Path.Combine(_root, normalized.Replace('/', Path.DirectorySeparatorChar));
+    }
+}

--- a/src/ApiService/ICatalogueStorage.cs
+++ b/src/ApiService/ICatalogueStorage.cs
@@ -1,0 +1,22 @@
+namespace ApiService;
+
+/// <summary>
+/// Filesystem-or-other blob store for uploaded catalogue bytes
+/// (ADR-0025 §4-§5). Decoupled from the DB row so the storage backend
+/// can swap (S3, Azure Blob, etc.) without touching the
+/// <see cref="ERP.Domain.PlayerCatalogue"/> aggregate.
+/// </summary>
+public interface ICatalogueStorage
+{
+    /// <summary>
+    /// Persist <paramref name="bytes"/> under a key derived from
+    /// <paramref name="playerId"/>, <paramref name="game"/>, and the
+    /// hash of the bytes. Returns the storage key the caller should
+    /// persist on the <see cref="ERP.Domain.PlayerCatalogue"/> row.
+    /// Idempotent on re-upload of identical bytes.
+    /// </summary>
+    Task<string> StoreAsync(Guid playerId, string game, string docsHash, byte[] bytes, CancellationToken ct = default);
+
+    /// <summary>Read the bytes back. Returns null when the key isn't known.</summary>
+    Task<byte[]?> ReadAsync(string storageKey, CancellationToken ct = default);
+}

--- a/src/ApiService/Program.cs
+++ b/src/ApiService/Program.cs
@@ -50,6 +50,12 @@ builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IAgentTokenAuthenticator, AgentTokenAuthenticator>();
 builder.Services.AddHostedService<DevPlayerBootstrap>();
 
+// Catalogue storage (ADR-0025 §4-§5). Bytes land on the filesystem; the
+// PlayerCatalogue EF row carries the metadata + dedup hash.
+builder.Services.Configure<CatalogueStorageOptions>(
+    builder.Configuration.GetSection(CatalogueStorageOptions.SectionName));
+builder.Services.AddSingleton<ICatalogueStorage, FileSystemCatalogueStorage>();
+
 var app = builder.Build();
 
 // Apply pending plan-storage migrations on startup so the SQLite default Just
@@ -788,6 +794,140 @@ app.MapGet("/api/agent/logs", (IAgentLogsStore store, int? limit) =>
         }),
         totalReceived = store.TotalReceived,
         agentLastSeen = store.AgentLastSeen,
+    });
+});
+
+// ---- Catalogue upload (ADR-0025 §4-§5) ------------------------------------
+//
+//   POST /api/agent/catalogue/satisfactory — raw Docs.json body.
+//     Headers:
+//       X-Agent-Token       — validated by IAgentTokenAuthenticator.
+//       If-None-Match       — last-uploaded hash echoed by the agent so
+//                             identical re-uploads short-circuit to 304.
+//     200 { docsHash, sizeBytes, uploadedUtc, changed: true }
+//     304 (changed=false; If-None-Match matched the stored hash)
+//     401 missing/invalid token
+//     413 body exceeds MaxUploadBytes
+//     415 unexpected Content-Type (must be application/json or octet-stream)
+//
+// Bytes are kept opaque in v2 — no Docs.json parsing at upload time.
+// GameVersion parsing lands with the planner resolver swap (Phase B
+// follow-up to #238).
+// ---------------------------------------------------------------------------
+
+app.MapPost("/api/agent/catalogue/satisfactory", async (
+    HttpRequest http,
+    IAgentTokenAuthenticator authenticator,
+    IPlayerCatalogueRepository catalogues,
+    ICatalogueStorage storage,
+    Microsoft.Extensions.Options.IOptions<CatalogueStorageOptions> storageOptions,
+    TimeProvider clock,
+    ILoggerFactory loggerFactory,
+    CancellationToken ct) =>
+{
+    var log = loggerFactory.CreateLogger("CatalogueUpload");
+
+    var auth = await authenticator.AuthenticateAsync(http.Headers["X-Agent-Token"].ToString(), ct).ConfigureAwait(false);
+    if (!auth.IsAuthenticated)
+    {
+        return Results.Json(new { error = "X-Agent-Token is missing or invalid." }, statusCode: 401);
+    }
+
+    var contentType = http.ContentType?.Split(';')[0].Trim() ?? string.Empty;
+    if (!string.Equals(contentType, "application/json", StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(contentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.Json(
+            new { error = $"Content-Type must be application/json or application/octet-stream; got '{http.ContentType}'." },
+            statusCode: 415);
+    }
+
+    var maxBytes = storageOptions.Value.MaxUploadBytes;
+    if (http.ContentLength is { } len && len > maxBytes)
+    {
+        return Results.Json(
+            new { error = $"Upload exceeds MaxUploadBytes ({maxBytes})." },
+            statusCode: 413);
+    }
+
+    // Read into memory — capped by MaxUploadBytes above. We need the
+    // bytes twice (hash + storage write) and Docs.json sizes are bounded.
+    byte[] bytes;
+    using (var ms = new MemoryStream())
+    {
+        var buffer = new byte[64 * 1024];
+        int read;
+        while ((read = await http.Body.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+        {
+            if (ms.Length + read > maxBytes)
+            {
+                return Results.Json(
+                    new { error = $"Upload exceeds MaxUploadBytes ({maxBytes})." },
+                    statusCode: 413);
+            }
+            await ms.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+        }
+        bytes = ms.ToArray();
+    }
+
+    if (bytes.Length == 0)
+    {
+        return Results.Json(new { error = "Request body is empty." }, statusCode: 400);
+    }
+
+    var hashBytes = System.Security.Cryptography.SHA256.HashData(bytes);
+    var docsHash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+
+    // If-None-Match short-circuit. We compare against the stored row's
+    // current hash; a match means "nothing to do, the agent's already
+    // sent this version". Returns 304 with no body.
+    var ifNoneMatch = http.Headers.IfNoneMatch.ToString().Trim('"', ' ');
+    var existing = await catalogues.GetAsync(auth.PlayerId, PlayerCatalogue.SatisfactoryGame, ct).ConfigureAwait(false);
+    if (existing is not null && string.Equals(existing.DocsHash, docsHash, StringComparison.OrdinalIgnoreCase))
+    {
+        log.LogInformation("Catalogue upload from {PlayerId} matched existing hash {Hash}; 304.", auth.PlayerId, docsHash);
+        return Results.StatusCode(304);
+    }
+    if (existing is not null && !string.IsNullOrEmpty(ifNoneMatch)
+        && string.Equals(existing.DocsHash, ifNoneMatch, StringComparison.OrdinalIgnoreCase)
+        && string.Equals(existing.DocsHash, docsHash, StringComparison.OrdinalIgnoreCase))
+    {
+        // Defensive — covered by the check above, but keeps the
+        // If-None-Match semantics explicit if the agent and DB diverge.
+        return Results.StatusCode(304);
+    }
+
+    var storageKey = await storage.StoreAsync(auth.PlayerId.Value, PlayerCatalogue.SatisfactoryGame, docsHash, bytes, ct)
+        .ConfigureAwait(false);
+    var now = clock.GetUtcNow().UtcDateTime;
+
+    if (existing is null)
+    {
+        var row = new PlayerCatalogue(
+            auth.PlayerId,
+            PlayerCatalogue.SatisfactoryGame,
+            docsHash,
+            storageKey,
+            bytes.Length,
+            now);
+        await catalogues.AddAsync(row, ct).ConfigureAwait(false);
+    }
+    else
+    {
+        existing.ReplaceWith(docsHash, storageKey, bytes.Length, now, gameVersion: null);
+    }
+    await catalogues.SaveChangesAsync(ct).ConfigureAwait(false);
+
+    log.LogInformation(
+        "Catalogue upload from {PlayerId}: {Bytes} bytes, hash {Hash}, stored at {Key}.",
+        auth.PlayerId, bytes.Length, docsHash, storageKey);
+
+    return Results.Ok(new
+    {
+        docsHash,
+        sizeBytes = bytes.Length,
+        uploadedUtc = now,
+        changed = true,
     });
 });
 

--- a/src/ERP/Application/IPlayerCatalogueRepository.cs
+++ b/src/ERP/Application/IPlayerCatalogueRepository.cs
@@ -1,0 +1,15 @@
+using ERP.Domain;
+
+namespace ERP.Application;
+
+/// <summary>
+/// Persistence port for <see cref="PlayerCatalogue"/> rows (ADR-0025 §4).
+/// </summary>
+public interface IPlayerCatalogueRepository
+{
+    Task<PlayerCatalogue?> GetAsync(PlayerId playerId, string game, CancellationToken cancellationToken = default);
+
+    Task AddAsync(PlayerCatalogue catalogue, CancellationToken cancellationToken = default);
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/ERP/Domain/PlayerCatalogue.cs
+++ b/src/ERP/Domain/PlayerCatalogue.cs
@@ -1,0 +1,87 @@
+namespace ERP.Domain;
+
+/// <summary>
+/// The catalogue (game data dump) a <see cref="Player"/> has uploaded
+/// from their machine via the agent (ADR-0025 §4-§5). One row per
+/// <c>(PlayerId, Game)</c> — re-uploads overwrite, with the previous
+/// <see cref="DocsHash"/> being what the agent uses to short-circuit
+/// no-op uploads via <c>If-None-Match</c>.
+///
+/// <para>
+/// The catalogue bytes themselves live outside the database (filesystem
+/// blob today, possibly object storage later). <see cref="StorageKey"/>
+/// is the opaque pointer the catalogue store understands; this row is
+/// the metadata + dedup record.
+/// </para>
+/// </summary>
+public sealed class PlayerCatalogue
+{
+    public const string SatisfactoryGame = "satisfactory";
+
+    public PlayerId PlayerId { get; private set; }
+
+    /// <summary>Game adapter key — currently always <see cref="SatisfactoryGame"/>.</summary>
+    public string Game { get; private set; } = string.Empty;
+
+    /// <summary>Hex-encoded SHA-256 of the uploaded bytes. The agent
+    /// echoes this back as <c>If-None-Match</c> to skip identical re-uploads.</summary>
+    public string DocsHash { get; private set; } = string.Empty;
+
+    /// <summary>Game-version string parsed out of the catalogue bytes
+    /// at upload time. Nullable until per-game parsing lands (Phase B
+    /// of #238); the column exists so Phase B doesn't need a migration.</summary>
+    public string? GameVersion { get; private set; }
+
+    /// <summary>Opaque pointer the catalogue store knows how to resolve
+    /// to the actual bytes. Currently a filesystem-relative path.</summary>
+    public string StorageKey { get; private set; } = string.Empty;
+
+    public long SizeBytes { get; private set; }
+
+    public DateTime UploadedUtc { get; private set; }
+
+    /// <summary>Parameterless ctor for EF Core materialisation. Don't call from app code.</summary>
+    private PlayerCatalogue() { }
+
+    public PlayerCatalogue(
+        PlayerId playerId,
+        string game,
+        string docsHash,
+        string storageKey,
+        long sizeBytes,
+        DateTime uploadedUtc,
+        string? gameVersion = null)
+    {
+        if (playerId.Value == Guid.Empty) throw new ArgumentException("PlayerId must not be empty.", nameof(playerId));
+        if (string.IsNullOrWhiteSpace(game)) throw new ArgumentException("Game is required.", nameof(game));
+        if (string.IsNullOrWhiteSpace(docsHash)) throw new ArgumentException("DocsHash is required.", nameof(docsHash));
+        if (string.IsNullOrWhiteSpace(storageKey)) throw new ArgumentException("StorageKey is required.", nameof(storageKey));
+        if (sizeBytes < 0) throw new ArgumentOutOfRangeException(nameof(sizeBytes));
+
+        PlayerId = playerId;
+        Game = game;
+        DocsHash = docsHash;
+        StorageKey = storageKey;
+        SizeBytes = sizeBytes;
+        UploadedUtc = uploadedUtc;
+        GameVersion = gameVersion;
+    }
+
+    /// <summary>
+    /// Replace this row's contents with a freshly uploaded catalogue.
+    /// Idempotent at the caller — the upload endpoint checks
+    /// <see cref="DocsHash"/> before invoking this.
+    /// </summary>
+    public void ReplaceWith(string docsHash, string storageKey, long sizeBytes, DateTime uploadedUtc, string? gameVersion)
+    {
+        if (string.IsNullOrWhiteSpace(docsHash)) throw new ArgumentException("DocsHash is required.", nameof(docsHash));
+        if (string.IsNullOrWhiteSpace(storageKey)) throw new ArgumentException("StorageKey is required.", nameof(storageKey));
+        if (sizeBytes < 0) throw new ArgumentOutOfRangeException(nameof(sizeBytes));
+
+        DocsHash = docsHash;
+        StorageKey = storageKey;
+        SizeBytes = sizeBytes;
+        UploadedUtc = uploadedUtc;
+        GameVersion = gameVersion;
+    }
+}

--- a/src/ERP/Infrastructure/Persistence/Configurations/PlayerCatalogueConfiguration.cs
+++ b/src/ERP/Infrastructure/Persistence/Configurations/PlayerCatalogueConfiguration.cs
@@ -1,0 +1,48 @@
+using ERP.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ERP.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF mapping for <see cref="PlayerCatalogue"/> (ADR-0025 §4). Composite
+/// PK on <c>(PlayerId, Game)</c> — one catalogue row per player per game.
+/// Re-uploads overwrite the row; history is intentionally not retained
+/// (the StorageKey could be reused for that later if we ever want it).
+/// </summary>
+internal sealed class PlayerCatalogueConfiguration : IEntityTypeConfiguration<PlayerCatalogue>
+{
+    public void Configure(EntityTypeBuilder<PlayerCatalogue> builder)
+    {
+        builder.ToTable("PlayerCatalogues");
+
+        builder.HasKey(c => new { c.PlayerId, c.Game });
+
+        builder.Property(c => c.PlayerId)
+            .HasConversion(id => id.Value, value => new PlayerId(value))
+            .IsRequired();
+
+        builder.Property(c => c.Game)
+            .IsRequired()
+            .HasMaxLength(50);
+
+        builder.Property(c => c.DocsHash)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(c => c.GameVersion)
+            .HasMaxLength(100);
+
+        builder.Property(c => c.StorageKey)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(c => c.SizeBytes).IsRequired();
+        builder.Property(c => c.UploadedUtc).IsRequired();
+
+        builder.HasOne<Player>()
+            .WithMany()
+            .HasForeignKey(c => c.PlayerId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/ERP/Infrastructure/Persistence/Migrations/Postgres/20260524080233_AddPlayerCatalogues.Designer.cs
+++ b/src/ERP/Infrastructure/Persistence/Migrations/Postgres/20260524080233_AddPlayerCatalogues.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ERP.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ERP.Infrastructure.Persistence.Migrations.Postgres
 {
     [DbContext(typeof(PostgresPlanDbContext))]
-    partial class PostgresPlanDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524080233_AddPlayerCatalogues")]
+    partial class AddPlayerCatalogues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ERP/Infrastructure/Persistence/Migrations/Postgres/20260524080233_AddPlayerCatalogues.cs
+++ b/src/ERP/Infrastructure/Persistence/Migrations/Postgres/20260524080233_AddPlayerCatalogues.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ERP.Infrastructure.Persistence.Migrations.Postgres
+{
+    /// <inheritdoc />
+    public partial class AddPlayerCatalogues : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerCatalogues",
+                columns: table => new
+                {
+                    PlayerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Game = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    DocsHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    GameVersion = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    StorageKey = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    UploadedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerCatalogues", x => new { x.PlayerId, x.Game });
+                    table.ForeignKey(
+                        name: "FK_PlayerCatalogues_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerCatalogues");
+        }
+    }
+}

--- a/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/20260524080209_AddPlayerCatalogues.Designer.cs
+++ b/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/20260524080209_AddPlayerCatalogues.Designer.cs
@@ -3,51 +3,49 @@ using System;
 using ERP.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace ERP.Infrastructure.Persistence.Migrations.Postgres
+namespace ERP.Infrastructure.Persistence.Migrations.Sqlite
 {
-    [DbContext(typeof(PostgresPlanDbContext))]
-    partial class PostgresPlanDbContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(SqlitePlanDbContext))]
+    [Migration("20260524080209_AddPlayerCatalogues")]
+    partial class AddPlayerCatalogues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.0");
 
             modelBuilder.Entity("ERP.Domain.AgentToken", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Label")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("LastSeenUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("PlayerId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("RevokedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("TokenHash")
                         .IsRequired()
                         .HasMaxLength(32)
-                        .HasColumnType("bytea");
+                        .HasColumnType("BLOB");
 
                     b.HasKey("Id");
 
@@ -62,46 +60,46 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("ERP.Domain.FactoryAlert", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Detail")
                         .IsRequired()
                         .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("DismissedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Fix")
                         .IsRequired()
                         .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Key")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ResolvedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Severity")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Source")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -116,19 +114,19 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
                 {
                     b.Property<string>("Token")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ExpiresUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("PlanId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("RevokedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Token");
 
@@ -140,15 +138,15 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("ERP.Domain.Player", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -158,31 +156,31 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("ERP.Domain.PlayerCatalogue", b =>
                 {
                     b.Property<Guid>("PlayerId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Game")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DocsHash")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("GameVersion")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("SizeBytes")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("StorageKey")
                         .IsRequired()
                         .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UploadedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("PlayerId", "Game");
 
@@ -192,18 +190,18 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("ERP.Domain.SavedPlan", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedUtc")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -213,42 +211,42 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("TickerQ.Utilities.Entities.CronTickerEntity", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Expression")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Function")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InitIdentifier")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsSystemPaused")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
                     b.Property<byte[]>("Request")
-                        .HasColumnType("bytea");
+                        .HasColumnType("BLOB");
 
                     b.Property<int>("Retries")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
-                    b.PrimitiveCollection<int[]>("RetryIntervals")
-                        .HasColumnType("integer[]");
+                    b.PrimitiveCollection<string>("RetryIntervals")
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -264,43 +262,43 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
             modelBuilder.Entity("TickerQ.Utilities.Entities.CronTickerOccurrenceEntity<TickerQ.Utilities.Entities.CronTickerEntity>", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("CronTickerId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("ElapsedTime")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ExceptionMessage")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ExecutedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("ExecutionTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LockHolder")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("LockedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("RetryCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SkippedReason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Status")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -324,64 +322,64 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("ElapsedTime")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ExceptionMessage")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ExecutedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("ExecutionTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Function")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("InitIdentifier")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LockHolder")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("LockedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid?>("ParentId")
-                        .HasColumnType("uuid");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("Request")
-                        .HasColumnType("bytea");
+                        .HasColumnType("BLOB");
 
                     b.Property<int>("Retries")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("RetryCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
-                    b.PrimitiveCollection<int[]>("RetryIntervals")
-                        .HasColumnType("integer[]");
+                    b.PrimitiveCollection<string>("RetryIntervals")
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("RunCondition")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SkippedReason")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Status")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -430,7 +428,7 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
                             b1.Property<Guid>("SavedPlanId");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd();
+                                .ValueGeneratedOnAddOrUpdate();
 
                             b1.Property<string>("Item")
                                 .IsRequired();
@@ -453,7 +451,7 @@ namespace ERP.Infrastructure.Persistence.Migrations.Postgres
                             b1.Property<Guid>("SavedPlanId");
 
                             b1.Property<int>("__synthesizedOrdinal")
-                                .ValueGeneratedOnAdd();
+                                .ValueGeneratedOnAddOrUpdate();
 
                             b1.Property<string>("Item")
                                 .IsRequired();

--- a/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/20260524080209_AddPlayerCatalogues.cs
+++ b/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/20260524080209_AddPlayerCatalogues.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ERP.Infrastructure.Persistence.Migrations.Sqlite
+{
+    /// <inheritdoc />
+    public partial class AddPlayerCatalogues : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerCatalogues",
+                columns: table => new
+                {
+                    PlayerId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Game = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    DocsHash = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    GameVersion = table.Column<string>(type: "TEXT", maxLength: 100, nullable: true),
+                    StorageKey = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
+                    SizeBytes = table.Column<long>(type: "INTEGER", nullable: false),
+                    UploadedUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerCatalogues", x => new { x.PlayerId, x.Game });
+                    table.ForeignKey(
+                        name: "FK_PlayerCatalogues_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerCatalogues");
+        }
+    }
+}

--- a/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/SqlitePlanDbContextModelSnapshot.cs
+++ b/src/ERP/Infrastructure/Persistence/Migrations/Sqlite/SqlitePlanDbContextModelSnapshot.cs
@@ -150,6 +150,40 @@ namespace ERP.Infrastructure.Persistence.Migrations.Sqlite
                     b.ToTable("Players", (string)null);
                 });
 
+            modelBuilder.Entity("ERP.Domain.PlayerCatalogue", b =>
+                {
+                    b.Property<Guid>("PlayerId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Game")
+                        .HasMaxLength(50)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("DocsHash")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("GameVersion")
+                        .HasMaxLength(100)
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("SizeBytes")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("StorageKey")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("UploadedUtc")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("PlayerId", "Game");
+
+                    b.ToTable("PlayerCatalogues", (string)null);
+                });
+
             modelBuilder.Entity("ERP.Domain.SavedPlan", b =>
                 {
                     b.Property<Guid>("Id")
@@ -371,6 +405,15 @@ namespace ERP.Infrastructure.Persistence.Migrations.Sqlite
                     b.HasOne("ERP.Domain.SavedPlan", null)
                         .WithMany()
                         .HasForeignKey("PlanId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("ERP.Domain.PlayerCatalogue", b =>
+                {
+                    b.HasOne("ERP.Domain.Player", null)
+                        .WithMany()
+                        .HasForeignKey("PlayerId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/src/ERP/Infrastructure/Persistence/PersistenceServiceCollectionExtensions.cs
+++ b/src/ERP/Infrastructure/Persistence/PersistenceServiceCollectionExtensions.cs
@@ -100,6 +100,7 @@ public static class PersistenceServiceCollectionExtensions
         services.AddScoped<IFactoryAlertRepository, FactoryAlertRepository>();
         services.AddScoped<IPlayerRepository, PlayerRepository>();
         services.AddScoped<IAgentTokenRepository, AgentTokenRepository>();
+        services.AddScoped<IPlayerCatalogueRepository, PlayerCatalogueRepository>();
 
         // TickerQ — background job scheduler (#115, ADR-0019). Entity
         // configurations are applied explicitly in PlanDbContext.OnModelCreating

--- a/src/ERP/Infrastructure/Persistence/PlanDbContext.cs
+++ b/src/ERP/Infrastructure/Persistence/PlanDbContext.cs
@@ -38,6 +38,8 @@ public class PlanDbContext : DbContext
 
     public DbSet<AgentToken> AgentTokens => Set<AgentToken>();
 
+    public DbSet<PlayerCatalogue> PlayerCatalogues => Set<PlayerCatalogue>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(PlanDbContext).Assembly);

--- a/src/ERP/Infrastructure/Persistence/Repositories/PlayerCatalogueRepository.cs
+++ b/src/ERP/Infrastructure/Persistence/Repositories/PlayerCatalogueRepository.cs
@@ -1,0 +1,29 @@
+using ERP.Application;
+using ERP.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace ERP.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IPlayerCatalogueRepository"/> (ADR-0025 §4).
+/// </summary>
+internal sealed class PlayerCatalogueRepository : IPlayerCatalogueRepository
+{
+    private readonly PlanDbContext _db;
+
+    public PlayerCatalogueRepository(PlanDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<PlayerCatalogue?> GetAsync(PlayerId playerId, string game, CancellationToken cancellationToken = default) =>
+        _db.PlayerCatalogues.FirstOrDefaultAsync(c => c.PlayerId == playerId && c.Game == game, cancellationToken);
+
+    public async Task AddAsync(PlayerCatalogue catalogue, CancellationToken cancellationToken = default)
+    {
+        await _db.PlayerCatalogues.AddAsync(catalogue, cancellationToken);
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _db.SaveChangesAsync(cancellationToken);
+}

--- a/test/ApiService.Tests/CatalogueUploadEndpointTests.cs
+++ b/test/ApiService.Tests/CatalogueUploadEndpointTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using ERP.Domain;
+using ERP.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace ApiService.Tests;
+
+/// <summary>
+/// Integration tests for <c>POST /api/agent/catalogue/satisfactory</c>
+/// (#238, ADR-0025 §4-§5). Validates auth, content-type rejection, hash
+/// computation + dedup, and upsert semantics.
+/// </summary>
+public sealed class CatalogueUploadEndpointTests : IClassFixture<AgentEndpointsTests.AgentApiFactory>
+{
+    private readonly AgentEndpointsTests.AgentApiFactory _factory;
+
+    public CatalogueUploadEndpointTests(AgentEndpointsTests.AgentApiFactory factory) => _factory = factory;
+
+    private const string Endpoint = "/api/agent/catalogue/satisfactory";
+
+    [Fact]
+    public async Task Upload_without_token_returns_401()
+    {
+        var client = _factory.CreateClient();
+        var body = new ByteArrayContent(SampleDocsJson());
+        body.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        var response = await client.PostAsync(Endpoint, body);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Upload_with_wrong_content_type_returns_415()
+    {
+        var client = _factory.CreateClient();
+        var token = await _factory.MintTokenAsync();
+        var body = new StringContent("not docs", Encoding.UTF8, "text/plain");
+        var request = new HttpRequestMessage(HttpMethod.Post, Endpoint) { Content = body };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", token);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task First_upload_persists_row_with_correct_hash()
+    {
+        var client = _factory.CreateClient();
+        var token = await _factory.MintTokenAsync();
+        // Unique bytes per test invocation so we don't accidentally hit the
+        // 304-cached path when CatalogueUploadEndpointTests share a fixture
+        // with the rest of the API test classes.
+        var bytes = UniqueDocsJson();
+
+        var response = await PostAsync(client, token, bytes);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<UploadResponseView>();
+        Assert.NotNull(payload);
+        Assert.True(payload!.Changed);
+        Assert.Equal(bytes.Length, payload.SizeBytes);
+
+        var expectedHash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        Assert.Equal(expectedHash, payload.DocsHash);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanDbContext>();
+        var row = await db.PlayerCatalogues.AsNoTracking()
+            .SingleAsync(c => c.PlayerId == new PlayerId(_factory.DevPlayerId) && c.Game == PlayerCatalogue.SatisfactoryGame);
+        Assert.Equal(expectedHash, row.DocsHash);
+        Assert.Equal(bytes.Length, row.SizeBytes);
+    }
+
+    [Fact]
+    public async Task Re_upload_of_identical_bytes_returns_304()
+    {
+        var client = _factory.CreateClient();
+        var token = await _factory.MintTokenAsync();
+        var bytes = UniqueDocsJson();
+
+        var first = await PostAsync(client, token, bytes);
+        Assert.True(first.StatusCode is HttpStatusCode.OK or HttpStatusCode.NotModified,
+            $"First upload should be 200 OK or 304 (if state survived from a sibling test); got {first.StatusCode}");
+
+        var second = await PostAsync(client, token, bytes);
+        Assert.Equal(HttpStatusCode.NotModified, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task Re_upload_of_different_bytes_overwrites_row()
+    {
+        var client = _factory.CreateClient();
+        var token = await _factory.MintTokenAsync();
+
+        var v1 = UniqueDocsJson("v1");
+        var v2 = UniqueDocsJson("v2");
+
+        var first = await PostAsync(client, token, v1);
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        var second = await PostAsync(client, token, v2);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanDbContext>();
+        var rows = await db.PlayerCatalogues.AsNoTracking()
+            .Where(c => c.PlayerId == new PlayerId(_factory.DevPlayerId))
+            .ToListAsync();
+        // Composite PK on (PlayerId, Game) — only ever one row per player+game.
+        Assert.Single(rows);
+        var expected = Convert.ToHexString(SHA256.HashData(v2)).ToLowerInvariant();
+        Assert.Equal(expected, rows[0].DocsHash);
+    }
+
+    [Fact]
+    public async Task Empty_body_returns_400()
+    {
+        var client = _factory.CreateClient();
+        var token = await _factory.MintTokenAsync();
+        var body = new ByteArrayContent(Array.Empty<byte>());
+        body.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, Endpoint) { Content = body };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", token);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static async Task<HttpResponseMessage> PostAsync(HttpClient client, string token, byte[] bytes)
+    {
+        var body = new ByteArrayContent(bytes);
+        body.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, Endpoint) { Content = body };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", token);
+        return await client.SendAsync(request);
+    }
+
+    private static byte[] SampleDocsJson() =>
+        Encoding.UTF8.GetBytes("""{"version":"test-fixture-1.0","items":[],"buildings":[],"recipes":[]}""");
+
+    private static byte[] UniqueDocsJson(string? marker = null)
+    {
+        var tag = marker ?? Guid.NewGuid().ToString("N");
+        return Encoding.UTF8.GetBytes($$"""{"version":"test","stamp":"{{Guid.NewGuid():N}}","marker":"{{tag}}"}""");
+    }
+
+    private sealed record UploadResponseView(string DocsHash, long SizeBytes, DateTime UploadedUtc, bool Changed);
+}


### PR DESCRIPTION
## Summary

Closes #238 — **Phase A of two**. Stacked on #235/#236/#237 (all merged on main; this PR branches from current main).

> **Scope call**: this PR implements the catalogue **ingestion** path (agent uploads → server stores). It does **not** change how planner endpoints **read** catalogue — they still go through the existing server-local `DocsCatalogProvider`. The resolver swap is Phase B, a separate refactor that touches every planner endpoint and is its own PR-worth of work. Splitting keeps each piece reviewable.

## What lands

### Server side (ADR-0025 §4-§5)

- **`PlayerCatalogue` aggregate** keyed by `(PlayerId, Game)`. One row per player per game; re-uploads overwrite.
- **Dual-provider migration** `AddPlayerCatalogues`. Migration drift verified clean both providers.
- **`ICatalogueStorage` / `FileSystemCatalogueStorage`** — atomic temp+rename blob writer under `{Root}/{playerId}/{game}/{hash}.json`. Defaults to `%ProgramData%/.../catalogues` (Windows) or `$XDG_DATA_HOME/.../catalogues` (Linux).
- **`POST /api/agent/catalogue/satisfactory`** under the `/api/*` path-routing rule from #245:
  - Auth via `IAgentTokenAuthenticator` (the pipeline #235 introduced)
  - `415` unless `application/json` or `application/octet-stream`
  - `413` over `MaxUploadBytes` (default 200 MB; modded Docs.json ~30 MB)
  - `400` on empty body
  - `304` when `SHA-256(body)` matches the stored row's `DocsHash`
  - `200 { docsHash, sizeBytes, uploadedUtc, changed: true }` otherwise
- Bytes stay opaque in v2 — no `Docs.json` parsing at upload time. The `GameVersion` column exists nullable so Phase B doesn't need a migration to start populating it.

### Agent side

- **`CatalogueUploadOptions`** reuses the existing `Catalogue:Satisfactory:DocsPath` config key (same as ADR-0011's server-side resolver) so existing `appsettings.json` carries over unchanged.
- **`HttpCatalogueUploader`** — reads file, POSTs, surfaces 304 as `Skipped=false, Succeeded=true` (no change is healthy). Separate `HttpClient` with 5-min timeout.
- **`CatalogueUploadStartup` hosted service** — runs one upload ~5 s after boot. Best-effort; failures logged, don't block other hosted services. Re-ingest-poll trigger lands with #239.

### ADR-0011

Status updated: server-local `Docs.json` resolution becomes explicitly the dev-only fallback once Phase B lands.

## What this unblocks

- **#239** (re-ingest UI button) — the upload endpoint is now there to be re-triggered; #239 wires the trigger flag through the existing log-tail poll.
- **Phase B follow-up** (planner resolver swap) — refactors `DocsCatalogProvider` from a singleton with a file path into a scoped service that resolves `(PlayerId, Game) → catalogue bytes` from `ICatalogueStorage`, with the server-local fallback feature-flagged.

## Test plan

- [x] `dotnet build` clean
- [x] **30/30 ApiService tests pass** — 24 pre-existing + 6 new `CatalogueUploadEndpointTests` (auth, content-type rejection, hash correctness, identical-bytes 304, different-bytes overwrite, empty-body 400)
- [x] **12/12 Agent tests pass** — unchanged
- [x] Migration drift verified clean for both providers (`has-pending-model-changes`)
- [ ] CI: build + lint + migration drift + Postgres smoke
- [ ] Manual: spin up Aspire, point an agent's `Catalogue:Satisfactory:DocsPath` at a real `Docs.json`, confirm the agent's startup log shows the upload, check the row landed in DB and the blob landed on disk

## Deliberately out of scope (callouts for review)

- **Phase B: planner resolver swap.** Planner endpoints still resolve catalogue from the server-local path. The data is now in the DB; consuming it is the follow-up.
- **Docs.json parsing on upload.** `GameVersion` column stays nullable until parsing arrives with Phase B.
- **Agent-side dedup memory.** The agent doesn't remember the last hash it uploaded across restarts — every boot re-uploads. The server's 304 handles dedup; the wasted bandwidth is one Docs.json upload per agent restart (~30 MB). If that becomes a problem, persisting last-hash in a small state file is a trivial follow-up.
- **Server-local Docs.json deprecation.** ADR-0011 status reflects "dev-only fallback" but the planner code still uses it as the primary read path. Phase B flips that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)