### PR TITLE
feat(deploy): erp-deploy as Fallout Provision + Up targets

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,11 +31,13 @@
         "Format",
         "InstallPlaywrightBrowsers",
         "MigrationsPostgresSmoke",
+        "Provision",
         "Release",
         "Restore",
         "Test",
         "TestNoUi",
-        "TestUi"
+        "TestUi",
+        "Up"
       ]
     },
     "Verbosity": {
@@ -109,6 +111,11 @@
   "allOf": [
     {
       "properties": {
+        "CloudflareApiToken": {
+          "type": "string",
+          "description": "Cloudflare API token. Scopes: Account · Cloudflare Tunnel · Edit; Zone · DNS · Edit; Account · Account Settings · Read",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
         "Configuration": {
           "type": "string",
           "description": "Configuration to build — Debug locally, Release on CI",
@@ -116,6 +123,18 @@
             "Debug",
             "Release"
           ]
+        },
+        "DeployOutput": {
+          "type": "string",
+          "description": "Output format for Provision: text (human, default) or json"
+        },
+        "DryRun": {
+          "type": "boolean",
+          "description": "Plan changes without writing them back to Cloudflare (Provision) or the LXC (Up)"
+        },
+        "ImageTag": {
+          "type": "string",
+          "description": "Image tag for erp-web + erp-api. Default: latest"
         },
         "Solution": {
           "type": "string",

--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -39,6 +39,10 @@
   <Folder Name="/src/CaptainOfIndustry/Web/">
     <Project Path="src/CaptainOfIndustry/Web/CaptainOfIndustry.Web.csproj" />
   </Folder>
+  <Folder Name="/src/Deploy/" />
+  <Folder Name="/src/Deploy/Erp.Deploy/">
+    <Project Path="src/Deploy/Erp.Deploy/Erp.Deploy.csproj" />
+  </Folder>
   <Folder Name="/test/" />
   <Folder Name="/test/Agent.Tests/">
     <Project Path="test/Agent.Tests/Agent.Tests.csproj" />

--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -76,4 +76,8 @@
   <Folder Name="/test/Web/Web.UiTests/">
     <Project Path="test/Web/Web.UiTests/Web.UiTests.csproj" />
   </Folder>
+  <Folder Name="/test/Deploy/" />
+  <Folder Name="/test/Deploy/Erp.Deploy.Tests/">
+    <Project Path="test/Deploy/Erp.Deploy.Tests/Erp.Deploy.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+using Erp.Deploy;
+using Erp.Deploy.Configuration;
+using Erp.Deploy.Ssh;
 using Fallout.Common;
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Common.IO;
@@ -29,6 +33,32 @@ class Build : FalloutBuild
 
     [Solution(GenerateProjects = true)]
     readonly Solution Solution = null!;
+
+    // -------------------------------------------------------------------------
+    // Deploy parameters (consumed by Provision target).
+    //
+    // CloudflareApiToken: [Secret] makes Fallout prompt for it (masked) when
+    // not supplied via env var or command line, and keeps it out of logs.
+    // Locally we expect `CLOUDFLARE_API_TOKEN=$(bw get password '<vault-item>')`
+    // before ./build.sh Provision; in CI it comes from GitHub Actions secrets.
+    // -------------------------------------------------------------------------
+    [Parameter("Cloudflare API token. Scopes: Account · Cloudflare Tunnel · Edit; Zone · DNS · Edit; Account · Account Settings · Read.")]
+    [Secret]
+    readonly string CloudflareApiToken = null!;
+
+    [Parameter("Plan changes without writing them back to Cloudflare (Provision) or the LXC (Up).")]
+    readonly bool DryRun;
+
+    [Parameter("Output format for Provision: text (human, default) or json.")]
+    readonly string DeployOutput = "text";
+
+    [Parameter("Image tag for erp-web + erp-api. Default: latest.")]
+    readonly string ImageTag = "latest";
+
+    // Populated by Provision when it applies; read by Up. Empty when Provision
+    // ran in dry-run, in which case Up uses a placeholder token for its own
+    // dry-run output and refuses to proceed if asked to apply for real.
+    IReadOnlyList<TunnelOutput> _connectorTokens = Array.Empty<TunnelOutput>();
 
     GitHubActions GitHubActions => GitHubActions.Instance;
 
@@ -294,6 +324,102 @@ class Build : FalloutBuild
                 $"release create {tag} --title \"Release {tag}\" --generate-notes --target {sha}",
                 workingDirectory: RootDirectory);
             process.AssertZeroExitCode();
+        });
+
+    // -------------------------------------------------------------------------
+    // Deploy: reconcile Cloudflare tunnel + ingress + DNS for the production
+    // stack. Consumes deploy/erp-deploy.json. POC for Fallout's deploy-agent
+    // direction — same C#-as-build-script story extended from CI to CD (#263).
+    // -------------------------------------------------------------------------
+    Target Provision => _ => _
+        .Description("Reconcile Cloudflare tunnel + ingress + DNS for the deploy stack. Pass --dry-run to plan without writes.")
+        .Requires(() => CloudflareApiToken)
+        .Executes(async () =>
+        {
+            var configPath = RootDirectory / "deploy" / "erp-deploy.json";
+            if (!configPath.FileExists())
+            {
+                throw new InvalidOperationException($"Deploy config not found at {configPath}");
+            }
+
+            var json = configPath.ReadAllText();
+            var options = JsonSerializer.Deserialize<DeployOptions>(
+                json,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web))
+                ?? throw new InvalidOperationException($"Failed to parse {configPath}");
+
+            var output = string.Equals(DeployOutput, "json", StringComparison.OrdinalIgnoreCase)
+                ? OutputFormat.Json
+                : OutputFormat.Text;
+
+            var provisioner = Provisioner.Create(CloudflareApiToken);
+            var result = await provisioner.RunAsync(new ProvisionRequest(options, DryRun, output));
+
+            if (result.ExitCode != 0)
+            {
+                throw new Exception($"Provision failed with exit code {result.ExitCode}.");
+            }
+            _connectorTokens = result.Tunnels;
+            Log.Information("Provision complete ({TunnelCount} tunnel(s), DryRun={DryRun}).", result.Tunnels.Count, DryRun);
+        });
+
+    // -------------------------------------------------------------------------
+    // Up: ship the compose stack to the LXC and bring it forward.
+    //
+    // Replaces deploy.ps1 lines 117–183. Uses Renci.SshNet for SFTP + remote
+    // exec so the stack.env body is written as raw bytes — no remote shell
+    // ever re-parses the connector token line, which is the bug deploy.ps1
+    // couldn't shake.
+    //
+    // DependsOn(Provision): every Up runs the Cloudflare reconcile first so
+    // the connector token is fresh. Idempotent for both halves.
+    // -------------------------------------------------------------------------
+    Target Up => _ => _
+        .Description("Ship compose.yml + ingress.json + stack.env to the LXC and `docker compose up -d`. DependsOn(Provision).")
+        .DependsOn(Provision)
+        .Executes(() =>
+        {
+            var configPath = RootDirectory / "deploy" / "erp-deploy.json";
+            var options = JsonSerializer.Deserialize<DeployOptions>(
+                configPath.ReadAllText(),
+                new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+
+            // The compose stack lives in the sister-repo submodule.
+            var composeSource = RootDirectory / "deploy" / "Homelab.Stacks.ErpForFactoryGames";
+
+            string token;
+            if (DryRun)
+            {
+                // Provision ran in dry-run too, so there's no real token.
+                token = "<dry-run-placeholder>";
+            }
+            else
+            {
+                if (_connectorTokens.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        "No connector token from Provision — did Provision actually apply? " +
+                        "If running Up standalone (not via DependsOn), set --dry-run first to verify, " +
+                        "then full apply.");
+                }
+                // Single-tunnel today; if/when multi-tunnel lands, deploy
+                // needs to know which token to write into stack.env.
+                token = _connectorTokens[0].ConnectorToken;
+            }
+
+            var deployer = Deployer.Create();
+            var result = deployer.Run(new DeployRequest(
+                Options:          options,
+                ConnectorToken:   token,
+                ImageTag:         ImageTag,
+                ComposeSourceDir: composeSource,
+                DryRun:           DryRun));
+
+            if (result.ExitCode != 0)
+            {
+                throw new Exception($"Up failed with exit code {result.ExitCode}.");
+            }
+            Log.Information("Up complete (ImageTag={ImageTag}, DryRun={DryRun}).", ImageTag, DryRun);
         });
 
     /// <summary>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -21,4 +21,9 @@
     <PackageReference Include="Fallout.Common" Version="10.3.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Deploy library: Cloudflare reconcile + plan primitives consumed by the Provision target. -->
+    <ProjectReference Include="..\src\Deploy\Erp.Deploy\Erp.Deploy.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/deploy/erp-deploy.json
+++ b/deploy/erp-deploy.json
@@ -1,0 +1,22 @@
+{
+  "Cloudflare": {
+    "Zone": "erp-for-factory.games",
+    "Tunnels": [
+      {
+        "Name": "erp-for-factory-games",
+        "Hostnames": [
+          {
+            "Hostname": "satisfactory.erp-for-factory.games",
+            "Service": "http://erp-web:8080"
+          }
+        ],
+        "Catchall": "http_status:404"
+      }
+    ]
+  },
+  "Remote": {
+    "Host": "10.10.107.175",
+    "User": "chris",
+    "StackDir": "/home/chris/stacks/erp"
+  }
+}

--- a/src/Deploy/Erp.Deploy/Cloudflare/CloudflareApiException.cs
+++ b/src/Deploy/Erp.Deploy/Cloudflare/CloudflareApiException.cs
@@ -1,0 +1,24 @@
+namespace Erp.Deploy.Cloudflare;
+
+public sealed class CloudflareApiException : Exception
+{
+    public string Method { get; }
+    public string Path { get; }
+    public int? HttpStatus { get; }
+    public IReadOnlyList<(int Code, string Message)> ApiErrors { get; }
+
+    public CloudflareApiException(
+        string method,
+        string path,
+        int? httpStatus,
+        IReadOnlyList<(int, string)> apiErrors,
+        string message,
+        Exception? inner = null)
+        : base(message, inner)
+    {
+        Method = method;
+        Path = path;
+        HttpStatus = httpStatus;
+        ApiErrors = apiErrors;
+    }
+}

--- a/src/Deploy/Erp.Deploy/Cloudflare/CloudflareClient.cs
+++ b/src/Deploy/Erp.Deploy/Cloudflare/CloudflareClient.cs
@@ -1,0 +1,142 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Web;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Deploy.Cloudflare;
+
+// Thin typed client over Cloudflare's v4 REST API. Seven endpoints, all the
+// ones provision.ps1 hits. Bearer-token auth via ICloudflareTokenSource so the
+// token never gets baked into options/config and dependent code can mock it.
+public sealed class CloudflareClient
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _http;
+    private readonly ILogger<CloudflareClient> _log;
+    private readonly ICloudflareTokenSource _tokenSource;
+
+    public CloudflareClient(HttpClient http, ICloudflareTokenSource tokenSource, ILogger<CloudflareClient> log)
+    {
+        _http = http;
+        _tokenSource = tokenSource;
+        _log = log;
+        if (_http.BaseAddress is null)
+        {
+            _http.BaseAddress = new Uri("https://api.cloudflare.com/client/v4/");
+        }
+    }
+
+    public async Task<IReadOnlyList<CfAccount>> ListAccountsAsync(CancellationToken ct = default)
+        => await GetListAsync<CfAccount>("accounts", ct);
+
+    public async Task<IReadOnlyList<CfZone>> FindZoneByNameAsync(string name, CancellationToken ct = default)
+        => await GetListAsync<CfZone>($"zones?name={HttpUtility.UrlEncode(name)}", ct);
+
+    public async Task<IReadOnlyList<CfTunnel>> FindTunnelByNameAsync(string accountId, string name, CancellationToken ct = default)
+        => await GetListAsync<CfTunnel>(
+            $"accounts/{accountId}/cfd_tunnel?name={HttpUtility.UrlEncode(name)}&is_deleted=false",
+            ct);
+
+    public async Task<CfTunnel> CreateTunnelAsync(string accountId, string name, string tunnelSecret, CancellationToken ct = default)
+    {
+        var body = new CfTunnelCreateBody { Name = name, TunnelSecret = tunnelSecret, ConfigSrc = "cloudflare" };
+        return await PostAsync<CfTunnelCreateBody, CfTunnel>($"accounts/{accountId}/cfd_tunnel", body, ct);
+    }
+
+    // Cloudflare returns the connector token as a bare JSON string in the `result` field.
+    public async Task<string> GetTunnelConnectorTokenAsync(string accountId, string tunnelId, CancellationToken ct = default)
+        => await GetAsync<string>($"accounts/{accountId}/cfd_tunnel/{tunnelId}/token", ct);
+
+    public async Task<CfIngressConfig?> GetTunnelConfigurationAsync(string accountId, string tunnelId, CancellationToken ct = default)
+    {
+        try
+        {
+            return await GetAsync<CfIngressConfig>($"accounts/{accountId}/cfd_tunnel/{tunnelId}/configurations", ct);
+        }
+        catch (CloudflareApiException ex) when (ex.HttpStatus == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task PutTunnelConfigurationAsync(string accountId, string tunnelId, CfIngressConfig config, CancellationToken ct = default)
+        => await PutAsync<CfIngressConfig, object>($"accounts/{accountId}/cfd_tunnel/{tunnelId}/configurations", config, ct);
+
+    public async Task<IReadOnlyList<CfDnsRecord>> FindDnsRecordsAsync(string zoneId, string name, string type, CancellationToken ct = default)
+        => await GetListAsync<CfDnsRecord>(
+            $"zones/{zoneId}/dns_records?name={HttpUtility.UrlEncode(name)}&type={HttpUtility.UrlEncode(type)}",
+            ct);
+
+    public async Task<CfDnsRecord> CreateCnameAsync(string zoneId, string name, string content, bool proxied, int ttl, CancellationToken ct = default)
+    {
+        var body = new CfDnsRecordUpsertBody { Type = "CNAME", Name = name, Content = content, Proxied = proxied, Ttl = ttl };
+        return await PostAsync<CfDnsRecordUpsertBody, CfDnsRecord>($"zones/{zoneId}/dns_records", body, ct);
+    }
+
+    public async Task<CfDnsRecord> UpdateCnameAsync(string zoneId, string recordId, string name, string content, bool proxied, int ttl, CancellationToken ct = default)
+    {
+        var body = new CfDnsRecordUpsertBody { Type = "CNAME", Name = name, Content = content, Proxied = proxied, Ttl = ttl };
+        return await PutAsync<CfDnsRecordUpsertBody, CfDnsRecord>($"zones/{zoneId}/dns_records/{recordId}", body, ct);
+    }
+
+    // ----- Verb helpers --------------------------------------------------
+
+    private Task<T> GetAsync<T>(string path, CancellationToken ct) => SendAsync<object, T>(HttpMethod.Get, path, null, ct);
+    private Task<TOut> PostAsync<TIn, TOut>(string path, TIn body, CancellationToken ct) => SendAsync<TIn, TOut>(HttpMethod.Post, path, body, ct);
+    private Task<TOut> PutAsync<TIn, TOut>(string path, TIn body, CancellationToken ct) => SendAsync<TIn, TOut>(HttpMethod.Put, path, body, ct);
+
+    private async Task<IReadOnlyList<T>> GetListAsync<T>(string path, CancellationToken ct)
+    {
+        var list = await SendAsync<object, List<T>>(HttpMethod.Get, path, null, ct);
+        return list ?? new List<T>();
+    }
+
+    private async Task<TOut> SendAsync<TIn, TOut>(HttpMethod method, string path, TIn? body, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _tokenSource.GetToken());
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (body is not null && method != HttpMethod.Get)
+        {
+            req.Content = JsonContent.Create(body, options: Json);
+        }
+
+        _log.LogDebug("cf {Method} {Path}", method.Method, path);
+
+        using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+        var status = (int)resp.StatusCode;
+        var raw = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new CloudflareApiException(method.Method, path, status, Array.Empty<(int, string)>(), $"empty response body (HTTP {status})");
+        }
+
+        CfEnvelope<TOut>? env;
+        try
+        {
+            env = JsonSerializer.Deserialize<CfEnvelope<TOut>>(raw, Json);
+        }
+        catch (JsonException jex)
+        {
+            throw new CloudflareApiException(method.Method, path, status, Array.Empty<(int, string)>(),
+                $"non-JSON response (HTTP {status}): {Truncate(raw, 200)}", jex);
+        }
+
+        if (env is null || !env.Success)
+        {
+            var errs = (env?.Errors ?? new List<CfMessage>())
+                .Select(e => (e.Code, e.Message))
+                .ToList();
+            throw new CloudflareApiException(method.Method, path, status, errs,
+                $"Cloudflare API {method.Method} {path} failed (HTTP {status}): " +
+                (errs.Count > 0 ? string.Join("; ", errs.Select(e => $"[{e.Code}] {e.Message}")) : "no error details"));
+        }
+
+        return env.Result!;
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max] + "…";
+}

--- a/src/Deploy/Erp.Deploy/Cloudflare/CloudflareModels.cs
+++ b/src/Deploy/Erp.Deploy/Cloudflare/CloudflareModels.cs
@@ -1,0 +1,89 @@
+using System.Text.Json.Serialization;
+
+namespace Erp.Deploy.Cloudflare;
+
+// Cloudflare's API wraps every response in { success, errors, messages, result }.
+// We project `result` into a typed `T` and surface success/errors at the boundary.
+
+internal sealed class CfEnvelope<T>
+{
+    [JsonPropertyName("success")] public bool Success { get; set; }
+    [JsonPropertyName("errors")]  public List<CfMessage>? Errors { get; set; }
+    [JsonPropertyName("messages")]public List<CfMessage>? Messages { get; set; }
+    [JsonPropertyName("result")]  public T? Result { get; set; }
+}
+
+internal sealed class CfMessage
+{
+    [JsonPropertyName("code")]    public int Code { get; set; }
+    [JsonPropertyName("message")] public string Message { get; set; } = string.Empty;
+}
+
+public sealed class CfAccount
+{
+    [JsonPropertyName("id")]   public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+}
+
+public sealed class CfZone
+{
+    [JsonPropertyName("id")]   public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+}
+
+public sealed class CfTunnel
+{
+    [JsonPropertyName("id")]         public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")]       public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("config_src")] public string? ConfigSrc { get; set; }
+    [JsonPropertyName("deleted_at")] public DateTimeOffset? DeletedAt { get; set; }
+}
+
+internal sealed class CfTunnelCreateBody
+{
+    [JsonPropertyName("name")]          public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("tunnel_secret")] public string TunnelSecret { get; set; } = string.Empty;
+    [JsonPropertyName("config_src")]    public string ConfigSrc { get; set; } = "cloudflare";
+}
+
+public sealed class CfIngressConfig
+{
+    [JsonPropertyName("config")] public CfIngressInner Config { get; set; } = new();
+}
+
+public sealed class CfIngressInner
+{
+    [JsonPropertyName("ingress")] public List<CfIngressRule> Ingress { get; set; } = new();
+}
+
+public sealed class CfIngressRule
+{
+    [JsonPropertyName("hostname")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Hostname { get; set; }
+
+    [JsonPropertyName("path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Path { get; set; }
+
+    [JsonPropertyName("service")] public string Service { get; set; } = string.Empty;
+}
+
+public sealed class CfDnsRecord
+{
+    [JsonPropertyName("id")]      public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("type")]    public string Type { get; set; } = string.Empty;
+    [JsonPropertyName("name")]    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("proxied")] public bool Proxied { get; set; }
+    [JsonPropertyName("ttl")]     public int Ttl { get; set; }
+}
+
+internal sealed class CfDnsRecordUpsertBody
+{
+    [JsonPropertyName("type")]    public string Type { get; set; } = "CNAME";
+    [JsonPropertyName("name")]    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("proxied")] public bool Proxied { get; set; } = true;
+    [JsonPropertyName("ttl")]     public int Ttl { get; set; } = 1;
+}

--- a/src/Deploy/Erp.Deploy/Cloudflare/CloudflareModels.cs
+++ b/src/Deploy/Erp.Deploy/Cloudflare/CloudflareModels.cs
@@ -8,42 +8,42 @@ namespace Erp.Deploy.Cloudflare;
 internal sealed class CfEnvelope<T>
 {
     [JsonPropertyName("success")] public bool Success { get; set; }
-    [JsonPropertyName("errors")]  public List<CfMessage>? Errors { get; set; }
-    [JsonPropertyName("messages")]public List<CfMessage>? Messages { get; set; }
-    [JsonPropertyName("result")]  public T? Result { get; set; }
+    [JsonPropertyName("errors")] public List<CfMessage>? Errors { get; set; }
+    [JsonPropertyName("messages")] public List<CfMessage>? Messages { get; set; }
+    [JsonPropertyName("result")] public T? Result { get; set; }
 }
 
 internal sealed class CfMessage
 {
-    [JsonPropertyName("code")]    public int Code { get; set; }
+    [JsonPropertyName("code")] public int Code { get; set; }
     [JsonPropertyName("message")] public string Message { get; set; } = string.Empty;
 }
 
 public sealed class CfAccount
 {
-    [JsonPropertyName("id")]   public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
 }
 
 public sealed class CfZone
 {
-    [JsonPropertyName("id")]   public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
 }
 
 public sealed class CfTunnel
 {
-    [JsonPropertyName("id")]         public string Id { get; set; } = string.Empty;
-    [JsonPropertyName("name")]       public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("config_src")] public string? ConfigSrc { get; set; }
     [JsonPropertyName("deleted_at")] public DateTimeOffset? DeletedAt { get; set; }
 }
 
 internal sealed class CfTunnelCreateBody
 {
-    [JsonPropertyName("name")]          public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("tunnel_secret")] public string TunnelSecret { get; set; } = string.Empty;
-    [JsonPropertyName("config_src")]    public string ConfigSrc { get; set; } = "cloudflare";
+    [JsonPropertyName("config_src")] public string ConfigSrc { get; set; } = "cloudflare";
 }
 
 public sealed class CfIngressConfig
@@ -71,19 +71,19 @@ public sealed class CfIngressRule
 
 public sealed class CfDnsRecord
 {
-    [JsonPropertyName("id")]      public string Id { get; set; } = string.Empty;
-    [JsonPropertyName("type")]    public string Type { get; set; } = string.Empty;
-    [JsonPropertyName("name")]    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("type")] public string Type { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
     [JsonPropertyName("proxied")] public bool Proxied { get; set; }
-    [JsonPropertyName("ttl")]     public int Ttl { get; set; }
+    [JsonPropertyName("ttl")] public int Ttl { get; set; }
 }
 
 internal sealed class CfDnsRecordUpsertBody
 {
-    [JsonPropertyName("type")]    public string Type { get; set; } = "CNAME";
-    [JsonPropertyName("name")]    public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("type")] public string Type { get; set; } = "CNAME";
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
     [JsonPropertyName("proxied")] public bool Proxied { get; set; } = true;
-    [JsonPropertyName("ttl")]     public int Ttl { get; set; } = 1;
+    [JsonPropertyName("ttl")] public int Ttl { get; set; } = 1;
 }

--- a/src/Deploy/Erp.Deploy/Cloudflare/ICloudflareTokenSource.cs
+++ b/src/Deploy/Erp.Deploy/Cloudflare/ICloudflareTokenSource.cs
@@ -1,0 +1,25 @@
+namespace Erp.Deploy.Cloudflare;
+
+// Source of the Cloudflare API bearer token. The library doesn't care where
+// the secret came from — env var, prompt, Bitwarden, GitHub Actions secret —
+// just that the caller can produce one.
+public interface ICloudflareTokenSource
+{
+    string GetToken();
+}
+
+public sealed class InlineCloudflareTokenSource : ICloudflareTokenSource
+{
+    private readonly string _token;
+
+    public InlineCloudflareTokenSource(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException("Cloudflare API token must be a non-empty string.", nameof(token));
+        }
+        _token = token;
+    }
+
+    public string GetToken() => _token;
+}

--- a/src/Deploy/Erp.Deploy/Configuration/DeployOptions.cs
+++ b/src/Deploy/Erp.Deploy/Configuration/DeployOptions.cs
@@ -1,0 +1,41 @@
+namespace Erp.Deploy.Configuration;
+
+public sealed class DeployOptions
+{
+    public CloudflareOptions Cloudflare { get; init; } = new();
+    public RemoteOptions Remote { get; init; } = new();
+}
+
+public sealed class CloudflareOptions
+{
+    public string Zone { get; init; } = string.Empty;
+    public List<TunnelSpec> Tunnels { get; init; } = new();
+}
+
+public sealed class TunnelSpec
+{
+    public string Name { get; init; } = string.Empty;
+    public List<HostnameSpec> Hostnames { get; init; } = new();
+    public string Catchall { get; init; } = "http_status:404";
+}
+
+public sealed class HostnameSpec
+{
+    public string Hostname { get; init; } = string.Empty;
+    public string Service { get; init; } = string.Empty;
+}
+
+public sealed class RemoteOptions
+{
+    // Host is the SSH config alias OR a raw hostname. SshConnectionResolver
+    // shells out to `ssh -G <Host>` and picks up Hostname/Port/User/IdentityFile
+    // from ~/.ssh/config. Explicit values below override what ssh -G resolves.
+    public string Host { get; init; } = "erp-lxc";
+
+    // Optional overrides. When null/0, the value resolved from `ssh -G` wins.
+    public int? Port { get; init; }
+    public string? User { get; init; }
+    public string? IdentityFile { get; init; }
+
+    public string StackDir { get; init; } = "/home/chris/stacks/erp";
+}

--- a/src/Deploy/Erp.Deploy/Deployer.cs
+++ b/src/Deploy/Erp.Deploy/Deployer.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using Erp.Deploy.Configuration;
+using Erp.Deploy.Ssh;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+
+namespace Erp.Deploy;
+
+public sealed record DeployRequest(
+    DeployOptions Options,
+    string ConnectorToken,
+    string ImageTag,
+    string ComposeSourceDir,
+    bool DryRun);
+
+public sealed record DeployResult(int ExitCode);
+
+// Owns the SSH/SFTP half of the deploy.
+//
+// What it replaces (deploy.ps1, lines 117–148):
+//   - ssh "$user@$host" "mkdir -p '$remoteDir'"           → SftpClient mkdir-p
+//   - scp compose.yml + ingress.json                       → SftpClient.UploadFile (binary-safe)
+//   - cat > stack.env && chmod 600                         → SftpClient.UploadFile + ChangePermissions (THE BUG FIX)
+//   - ssh "$user@$host" "docker compose pull && up -d"     → SshClient.RunCommand
+//
+// The stack.env step is the original failure mode. PowerShell piped a string
+// body through ssh, where the remote shell re-parsed it, mangling lines that
+// contained `$`, double-quotes, or newlines depending on terminal/locale.
+// SFTP writes the bytes directly to the remote filesystem — no shell parses
+// the content. Quoting goes from a multi-layered nightmare to a non-issue.
+public sealed class Deployer
+{
+    private readonly SshConnectionResolver _resolver;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<Deployer> _log;
+
+    public Deployer(SshConnectionResolver resolver, ILoggerFactory? loggerFactory = null)
+    {
+        _resolver = resolver;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _log = _loggerFactory.CreateLogger<Deployer>();
+    }
+
+    public static Deployer Create(ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
+        return new Deployer(
+            new SshConnectionResolver(loggerFactory.CreateLogger<SshConnectionResolver>()),
+            loggerFactory);
+    }
+
+    public DeployResult Run(DeployRequest req)
+    {
+        var remote = req.Options.Remote;
+        var conn = _resolver.Resolve(remote);
+        var stackEnv = BuildStackEnv(req.ConnectorToken, req.ImageTag);
+        var uploads = BuildUploads(req.ComposeSourceDir, remote.StackDir, stackEnv);
+
+        // Pre-flight: complain about missing source files before touching SSH.
+        foreach (var u in uploads)
+        {
+            // Length 0 is suspicious for compose.yml/ingress.json; stack.env
+            // is fine to be small but never zero — we always write at least
+            // TUNNEL_TOKEN=… and ERP_IMAGE_TAG=…
+            if (u.Size == 0)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[red]Refusing to upload empty file:[/] {u.RemotePath}");
+                return new DeployResult(2);
+            }
+        }
+
+        if (req.DryRun)
+        {
+            RenderPlan(conn, uploads, remote.StackDir, redact: true);
+            return new DeployResult(0);
+        }
+
+        RenderPlan(conn, uploads, remote.StackDir, redact: true);
+
+        AnsiConsole.MarkupLine("[cyan]→[/] connecting + uploading");
+        using var deployer = SshDeployer.Connect(conn, _loggerFactory.CreateLogger<SshDeployer>());
+        deployer.UploadFiles(uploads, remote.StackDir);
+
+        var commands = new[]
+        {
+            $"cd '{remote.StackDir}' && docker compose --env-file stack.env pull",
+            $"cd '{remote.StackDir}' && docker compose --env-file stack.env up -d",
+            $"docker ps --filter name=erp- --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'",
+        };
+
+        foreach (var cmd in commands)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[green]→ remote[/] {cmd}");
+            var r = deployer.Run(cmd, TimeSpan.FromMinutes(5));
+            if (!string.IsNullOrWhiteSpace(r.StdOut))
+            {
+                AnsiConsole.WriteLine(r.StdOut.TrimEnd());
+            }
+            if (r.ExitStatus != 0)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[red]remote command failed[/] (exit={r.ExitStatus}): {r.StdErr.TrimEnd()}");
+                return new DeployResult(r.ExitStatus);
+            }
+        }
+
+        AnsiConsole.MarkupLine("[green]✓[/] deploy complete");
+        return new DeployResult(0);
+    }
+
+    private static byte[] BuildStackEnv(string connectorToken, string imageTag)
+    {
+        // Match the existing PS-written shape so the compose file's env-var
+        // references (TUNNEL_TOKEN, ERP_IMAGE_TAG) keep working unchanged.
+        var sb = new StringBuilder();
+        sb.Append("TUNNEL_TOKEN=").Append(connectorToken).Append('\n');
+        sb.Append("ERP_IMAGE_TAG=").Append(imageTag).Append('\n');
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static IReadOnlyList<RemoteFileUpload> BuildUploads(string sourceDir, string stackDir, byte[] stackEnv)
+    {
+        var composeYml = Path.Combine(sourceDir, "compose.yml");
+        var ingressJson = Path.Combine(sourceDir, "ingress.json");
+
+        if (!File.Exists(composeYml) || !File.Exists(ingressJson))
+        {
+            // The submodule isn't checked out. Tell the user how to fix it.
+            throw new FileNotFoundException(
+                $"Compose stack source not found under {sourceDir}. " +
+                "If you haven't initialised the submodule yet: " +
+                "`git submodule update --init --checkout deploy/Homelab.Stacks.ErpForFactoryGames`");
+        }
+
+        // Renci.SshNet's ChangePermissions takes the octal digits as a decimal
+        // integer (not the actual POSIX bitfield) — i.e. pass 644, not 0b110_100_100.
+        // Their validator does Math.DivRem(mode, 1000) and checks each digit ∈ [0,7].
+        const short Mode644 = 644;
+        const short Mode600 = 600;
+        return new List<RemoteFileUpload>
+        {
+            new($"{stackDir}/compose.yml",  File.ReadAllBytes(composeYml),  Mode644),
+            new($"{stackDir}/ingress.json", File.ReadAllBytes(ingressJson), Mode644),
+            // stack.env is 0600 — it carries the cloudflared connector secret.
+            new($"{stackDir}/stack.env",    stackEnv,                       Mode600),
+        };
+    }
+
+    private static void RenderPlan(
+        ResolvedSshConnection conn,
+        IReadOnlyList<RemoteFileUpload> uploads,
+        string stackDir,
+        bool redact)
+    {
+        var t = new Table().Border(TableBorder.Rounded);
+        t.AddColumn("Target");
+        t.AddColumn("Detail");
+        t.AddRow("connect", Markup.Escape(conn.Display));
+        t.AddRow("stackDir", Markup.Escape(stackDir));
+        foreach (var u in uploads)
+        {
+            var preview = u.RemotePath.EndsWith("stack.env") && redact
+                ? "(redacted — contains TUNNEL_TOKEN)"
+                : $"{u.Size} bytes, mode 0{u.Mode}";
+            t.AddRow("upload " + Markup.Escape(Path.GetFileName(u.RemotePath)), Markup.Escape(preview));
+        }
+        t.AddRow("compose", "pull + up -d (--env-file stack.env)");
+        AnsiConsole.Write(t);
+    }
+}

--- a/src/Deploy/Erp.Deploy/Deployer.cs
+++ b/src/Deploy/Erp.Deploy/Deployer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Erp.Deploy.Configuration;
 using Erp.Deploy.Ssh;
 using Microsoft.Extensions.Logging;
@@ -54,7 +53,7 @@ public sealed class Deployer
     {
         var remote = req.Options.Remote;
         var conn = _resolver.Resolve(remote);
-        var stackEnv = BuildStackEnv(req.ConnectorToken, req.ImageTag);
+        var stackEnv = StackEnvBuilder.Build(req.ConnectorToken, req.ImageTag);
         var uploads = BuildUploads(req.ComposeSourceDir, remote.StackDir, stackEnv);
 
         // Pre-flight: complain about missing source files before touching SSH.
@@ -106,16 +105,6 @@ public sealed class Deployer
 
         AnsiConsole.MarkupLine("[green]✓[/] deploy complete");
         return new DeployResult(0);
-    }
-
-    private static byte[] BuildStackEnv(string connectorToken, string imageTag)
-    {
-        // Match the existing PS-written shape so the compose file's env-var
-        // references (TUNNEL_TOKEN, ERP_IMAGE_TAG) keep working unchanged.
-        var sb = new StringBuilder();
-        sb.Append("TUNNEL_TOKEN=").Append(connectorToken).Append('\n');
-        sb.Append("ERP_IMAGE_TAG=").Append(imageTag).Append('\n');
-        return Encoding.UTF8.GetBytes(sb.ToString());
     }
 
     private static IReadOnlyList<RemoteFileUpload> BuildUploads(string sourceDir, string stackDir, byte[] stackEnv)

--- a/src/Deploy/Erp.Deploy/Erp.Deploy.csproj
+++ b/src/Deploy/Erp.Deploy/Erp.Deploy.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Erp.Deploy</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.51.1" />
+    <!-- Managed SSH + SFTP. Sidesteps the remote-shell heredoc quoting that broke deploy.ps1. -->
+    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Deploy/Erp.Deploy/Provisioner.cs
+++ b/src/Deploy/Erp.Deploy/Provisioner.cs
@@ -1,0 +1,189 @@
+using Erp.Deploy.Cloudflare;
+using Erp.Deploy.Configuration;
+using Erp.Deploy.Reconcile;
+using Erp.Deploy.Reconcile.Cloudflare;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console;
+
+namespace Erp.Deploy;
+
+public sealed record ProvisionRequest(
+    DeployOptions Options,
+    bool DryRun,
+    OutputFormat Output);
+
+public enum OutputFormat
+{
+    Text,
+    Json,
+}
+
+public sealed record TunnelOutput(string Name, string Id, string ConnectorToken);
+
+public sealed record ProvisionResult(
+    int ExitCode,
+    IReadOnlyList<ResourcePlan> Plans,
+    IReadOnlyList<TunnelOutput> Tunnels);
+
+// Mirrors what ProvisionCommand.ExecuteAsync did in the old Spectre CLI, minus
+// the framework. Pure logic over a CloudflareClient + reconcilers; emits to
+// AnsiConsole for the human path and returns the result for the caller to
+// optionally serialize.
+public sealed class Provisioner
+{
+    private readonly CloudflareClient _cf;
+    private readonly TunnelReconciler _tunnels;
+    private readonly DnsRecordReconciler _dns;
+    private readonly IngressReconciler _ingress;
+    private readonly ILogger<Provisioner> _log;
+
+    public Provisioner(
+        CloudflareClient cf,
+        TunnelReconciler tunnels,
+        DnsRecordReconciler dns,
+        IngressReconciler ingress,
+        ILogger<Provisioner>? log = null)
+    {
+        _cf = cf;
+        _tunnels = tunnels;
+        _dns = dns;
+        _ingress = ingress;
+        _log = log ?? NullLogger<Provisioner>.Instance;
+    }
+
+    // Convenience constructor for the Fallout build target — wires up its own
+    // graph from a token string and a DeployOptions POCO.
+    public static Provisioner Create(string cloudflareApiToken, ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
+        var http = new HttpClient();
+        var tokens = new InlineCloudflareTokenSource(cloudflareApiToken);
+        var cf = new CloudflareClient(http, tokens, loggerFactory.CreateLogger<CloudflareClient>());
+        return new Provisioner(
+            cf,
+            new TunnelReconciler(cf, loggerFactory.CreateLogger<TunnelReconciler>()),
+            new DnsRecordReconciler(cf, loggerFactory.CreateLogger<DnsRecordReconciler>()),
+            new IngressReconciler(cf, loggerFactory.CreateLogger<IngressReconciler>()),
+            loggerFactory.CreateLogger<Provisioner>());
+    }
+
+    public async Task<ProvisionResult> RunAsync(ProvisionRequest req, CancellationToken ct = default)
+    {
+        var deploy = req.Options;
+        var human = req.Output == OutputFormat.Text;
+        if (deploy.Cloudflare.Tunnels.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[red]Cloudflare.Tunnels is empty — nothing to provision.[/]");
+            return new ProvisionResult(2, Array.Empty<ResourcePlan>(), Array.Empty<TunnelOutput>());
+        }
+
+        // 1. Discover account + zone.
+        if (human) AnsiConsole.MarkupLine("[cyan]→[/] discovering account + zone");
+        var accounts = await _cf.ListAccountsAsync(ct);
+        if (accounts.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[red]Cloudflare token has access to zero accounts. Check token scopes.[/]");
+            return new ProvisionResult(2, Array.Empty<ResourcePlan>(), Array.Empty<TunnelOutput>());
+        }
+        if (accounts.Count > 1 && human)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[yellow]warning:[/] token sees {accounts.Count} accounts; using first ({accounts[0].Name}).");
+        }
+        var accountId = accounts[0].Id;
+
+        var zones = await _cf.FindZoneByNameAsync(deploy.Cloudflare.Zone, ct);
+        if (zones.Count == 0)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[red]zone '{deploy.Cloudflare.Zone}' not found.[/]");
+            return new ProvisionResult(2, Array.Empty<ResourcePlan>(), Array.Empty<TunnelOutput>());
+        }
+        var zoneId = zones[0].Id;
+        _log.LogDebug("account={AccountId} zone={ZoneId}", accountId, zoneId);
+
+        // 2. Build plan list.
+        var plans = new List<ResourcePlan>();
+        var tunnelResults = new List<TunnelReconcileResult>();
+        foreach (var spec in deploy.Cloudflare.Tunnels)
+        {
+            var tr = await _tunnels.PlanAsync(accountId, spec.Name, ct);
+            tunnelResults.Add(tr);
+            plans.Add(tr.Plan);
+
+            // Deferred id provider — reads tr.Id at the time the closure is
+            // called. Apply rebinds the entry below post-create so DNS/ingress
+            // closures see the real id.
+            Func<string> idProvider = () => tr.Id;
+
+            plans.Add(await _ingress.PlanAsync(accountId, idProvider, tr.WillCreate, spec, ct));
+            foreach (var h in spec.Hostnames)
+            {
+                plans.Add(await _dns.PlanCnameAsync(zoneId, h.Hostname, idProvider, tr.WillCreate, ct));
+            }
+        }
+
+        // 3. Render plan.
+        if (human)
+        {
+            PlanRenderer.RenderHuman(plans);
+        }
+
+        // 4. Dry-run exits here.
+        if (req.DryRun)
+        {
+            if (!human)
+            {
+                AnsiConsole.WriteLine(PlanRenderer.RenderJson(plans, new { dry_run = true }));
+            }
+            return new ProvisionResult(0, plans, Array.Empty<TunnelOutput>());
+        }
+
+        // 5. Apply.
+        foreach (var plan in plans)
+        {
+            if (plan.Apply is null) continue;
+            if (human)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[green]→ applying[/] {plan.Resource} {plan.Identity} ({plan.Action})");
+            }
+            await plan.Apply(ct);
+
+            // Post-tunnel-create: refresh the id so DNS/ingress closures resolve.
+            if (plan.Resource == "Tunnel" && plan.Action == PlanAction.Create)
+            {
+                var refreshed = await _cf.FindTunnelByNameAsync(accountId, plan.Identity, ct);
+                if (refreshed.Count == 0)
+                {
+                    AnsiConsole.MarkupLineInterpolated($"[red]post-create lookup failed for tunnel {plan.Identity}.[/]");
+                    return new ProvisionResult(1, plans, Array.Empty<TunnelOutput>());
+                }
+                var idx = tunnelResults.FindIndex(t => t.Name == plan.Identity);
+                if (idx >= 0)
+                {
+                    tunnelResults[idx] = tunnelResults[idx] with { Id = refreshed[0].Id, WillCreate = false };
+                }
+            }
+        }
+
+        // 6. Pull connector tokens.
+        var tokens = new List<TunnelOutput>();
+        foreach (var tr in tunnelResults)
+        {
+            var token = await tr.ConnectorTokenAsync(ct);
+            tokens.Add(new TunnelOutput(tr.Name, tr.Id, token));
+        }
+
+        if (human)
+        {
+            AnsiConsole.MarkupLineInterpolated($"[green]✓[/] provision complete ({tokens.Count} tunnel(s)).");
+        }
+        else
+        {
+            AnsiConsole.WriteLine(PlanRenderer.RenderJson(plans, new
+            {
+                tunnels = tokens.Select(t => new { tunnel = t.Name, tunnel_id = t.Id, connector_token = t.ConnectorToken })
+            }));
+        }
+        return new ProvisionResult(0, plans, tokens);
+    }
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/DnsRecordReconciler.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/DnsRecordReconciler.cs
@@ -1,0 +1,92 @@
+using Erp.Deploy.Cloudflare;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Deploy.Reconcile.Cloudflare;
+
+public sealed class DnsRecordReconciler
+{
+    private const bool DesiredProxied = true;
+    private const int DesiredTtl = 1; // 1 = auto
+
+    private readonly CloudflareClient _cf;
+    private readonly ILogger<DnsRecordReconciler> _log;
+
+    public DnsRecordReconciler(CloudflareClient cf, ILogger<DnsRecordReconciler> log)
+    {
+        _cf = cf;
+        _log = log;
+    }
+
+    // tunnelIdProvider is a closure because in dry-run with a not-yet-created
+    // tunnel we still want to plan the DNS record using a placeholder target,
+    // and in apply mode we resolve the real id after the tunnel create.
+    public async Task<ResourcePlan> PlanCnameAsync(
+        string zoneId,
+        string hostname,
+        Func<string> tunnelIdProvider,
+        bool tunnelWillBeCreated,
+        CancellationToken ct)
+    {
+        string TargetFor() => $"{tunnelIdProvider()}.cfargotunnel.com";
+
+        var existing = (await _cf.FindDnsRecordsAsync(zoneId, hostname, "CNAME", ct)).FirstOrDefault();
+
+        if (existing is null)
+        {
+            var displayTarget = tunnelWillBeCreated ? "<pending>.cfargotunnel.com" : TargetFor();
+            return ResourcePlan.Create(
+                "DNS",
+                $"CNAME {hostname}",
+                new[]
+                {
+                    FieldChange.Diff("content", null, displayTarget),
+                    FieldChange.Diff("proxied", null, DesiredProxied.ToString()),
+                    FieldChange.Diff("ttl", null, DesiredTtl.ToString()),
+                },
+                apply: async c =>
+                {
+                    var rec = await _cf.CreateCnameAsync(zoneId, hostname, TargetFor(), DesiredProxied, DesiredTtl, c);
+                    _log.LogInformation("Created CNAME {Host} → {Target} ({Id})", hostname, rec.Content, rec.Id);
+                });
+        }
+
+        // Update path — diff each mutable field.
+        var desiredContent = tunnelWillBeCreated ? "<pending>.cfargotunnel.com" : TargetFor();
+        var changes = new List<FieldChange>
+        {
+            FieldChange.Diff("content", existing.Content, desiredContent) with { IsChange = !ContentMatches(existing.Content, desiredContent, tunnelWillBeCreated) },
+            existing.Proxied == DesiredProxied
+                ? FieldChange.Same("proxied", existing.Proxied.ToString())
+                : FieldChange.Diff("proxied", existing.Proxied.ToString(), DesiredProxied.ToString()),
+            existing.Ttl == DesiredTtl
+                ? FieldChange.Same("ttl", existing.Ttl.ToString())
+                : FieldChange.Diff("ttl", existing.Ttl.ToString(), DesiredTtl.ToString()),
+        };
+
+        if (changes.All(c => !c.IsChange))
+        {
+            return ResourcePlan.NoOp(
+                "DNS",
+                $"CNAME {hostname}",
+                changes,
+                note: $"id={existing.Id}");
+        }
+
+        var recordId = existing.Id;
+        return ResourcePlan.Update(
+            "DNS",
+            $"CNAME {hostname}",
+            changes,
+            apply: async c =>
+            {
+                var rec = await _cf.UpdateCnameAsync(zoneId, recordId, hostname, TargetFor(), DesiredProxied, DesiredTtl, c);
+                _log.LogInformation("Updated CNAME {Host} → {Target} ({Id})", hostname, rec.Content, rec.Id);
+            },
+            note: $"id={existing.Id}");
+    }
+
+    // When the tunnel will be created, the desired target string is a placeholder
+    // — we can't compare to existing content meaningfully, so always treat as change.
+    private static bool ContentMatches(string existing, string desired, bool tunnelWillBeCreated)
+        => !tunnelWillBeCreated && string.Equals(existing, desired, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/IngressReconciler.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/IngressReconciler.cs
@@ -1,0 +1,118 @@
+using Erp.Deploy.Cloudflare;
+using Erp.Deploy.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Deploy.Reconcile.Cloudflare;
+
+public sealed class IngressReconciler
+{
+    private readonly CloudflareClient _cf;
+    private readonly ILogger<IngressReconciler> _log;
+
+    public IngressReconciler(CloudflareClient cf, ILogger<IngressReconciler> log)
+    {
+        _cf = cf;
+        _log = log;
+    }
+
+    public async Task<ResourcePlan> PlanAsync(
+        string accountId,
+        Func<string> tunnelIdProvider,
+        bool tunnelWillBeCreated,
+        TunnelSpec spec,
+        CancellationToken ct)
+    {
+        var target = BuildTarget(spec);
+
+        // Skip the GET when the tunnel is brand-new — there's no current config
+        // to diff against.
+        CfIngressConfig? current = null;
+        if (!tunnelWillBeCreated)
+        {
+            current = await _cf.GetTunnelConfigurationAsync(accountId, tunnelIdProvider(), ct);
+        }
+
+        var currentRules = current?.Config.Ingress ?? new List<CfIngressRule>();
+        var changes = DiffRules(currentRules, target.Config.Ingress);
+
+        if (!tunnelWillBeCreated && changes.All(c => !c.IsChange))
+        {
+            return ResourcePlan.NoOp(
+                "Ingress",
+                spec.Name,
+                changes,
+                note: $"{target.Config.Ingress.Count} rules, all unchanged");
+        }
+
+        return ResourcePlan.Update(
+            "Ingress",
+            spec.Name,
+            changes,
+            apply: async c =>
+            {
+                await _cf.PutTunnelConfigurationAsync(accountId, tunnelIdProvider(), target, c);
+                _log.LogInformation("Applied ingress config for tunnel {Name} ({Count} rules)", spec.Name, target.Config.Ingress.Count);
+            },
+            note: $"{target.Config.Ingress.Count} rules");
+    }
+
+    private static CfIngressConfig BuildTarget(TunnelSpec spec)
+    {
+        var rules = new List<CfIngressRule>();
+        foreach (var h in spec.Hostnames)
+        {
+            rules.Add(new CfIngressRule { Hostname = h.Hostname, Service = h.Service });
+        }
+        // Catch-all MUST be last. Cloudflare evaluates top-down.
+        rules.Add(new CfIngressRule { Service = spec.Catchall });
+        return new CfIngressConfig { Config = new CfIngressInner { Ingress = rules } };
+    }
+
+    // Positional diff — position matters because Cloudflare evaluates top-down.
+    // Comparison key inside a rule is (hostname, path, service).
+    private static List<FieldChange> DiffRules(IReadOnlyList<CfIngressRule> current, IReadOnlyList<CfIngressRule> target)
+    {
+        var max = Math.Max(current.Count, target.Count);
+        var changes = new List<FieldChange>(max);
+        for (var i = 0; i < max; i++)
+        {
+            var c = i < current.Count ? current[i] : null;
+            var t = i < target.Count ? target[i] : null;
+            var name = $"[{i}]";
+
+            if (c is null)
+            {
+                changes.Add(FieldChange.Diff(name, null, Format(t!)));
+            }
+            else if (t is null)
+            {
+                changes.Add(FieldChange.Diff(name, Format(c), null));
+            }
+            else if (RulesEqual(c, t))
+            {
+                changes.Add(FieldChange.Same(name, Format(t)));
+            }
+            else
+            {
+                changes.Add(FieldChange.Diff(name, Format(c), Format(t)));
+            }
+        }
+        return changes;
+    }
+
+    private static bool RulesEqual(CfIngressRule a, CfIngressRule b)
+        => string.Equals(a.Hostname ?? "", b.Hostname ?? "", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(a.Path ?? "", b.Path ?? "", StringComparison.Ordinal)
+        && string.Equals(a.Service, b.Service, StringComparison.Ordinal);
+
+    private static string Format(CfIngressRule r)
+    {
+        if (string.IsNullOrEmpty(r.Hostname))
+        {
+            return $"* → {r.Service}";
+        }
+        return string.IsNullOrEmpty(r.Path)
+            ? $"{r.Hostname} → {r.Service}"
+            : $"{r.Hostname}{r.Path} → {r.Service}";
+    }
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/TunnelReconcileResult.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/TunnelReconcileResult.cs
@@ -1,0 +1,11 @@
+namespace Erp.Deploy.Reconcile.Cloudflare;
+
+// Output of TunnelReconciler. The Id is what every downstream resource keys
+// off (DNS CNAME target, ingress PUT path). ConnectorTokenAsync fetches the
+// token lazily — we don't want to GET it in dry-run mode.
+public sealed record TunnelReconcileResult(
+    string Name,
+    string Id,
+    bool WillCreate,
+    ResourcePlan Plan,
+    Func<CancellationToken, Task<string>> ConnectorTokenAsync);

--- a/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/TunnelReconciler.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/Cloudflare/TunnelReconciler.cs
@@ -1,0 +1,79 @@
+using System.Security.Cryptography;
+using Erp.Deploy.Cloudflare;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Deploy.Reconcile.Cloudflare;
+
+public sealed class TunnelReconciler
+{
+    private readonly CloudflareClient _cf;
+    private readonly ILogger<TunnelReconciler> _log;
+
+    public TunnelReconciler(CloudflareClient cf, ILogger<TunnelReconciler> log)
+    {
+        _cf = cf;
+        _log = log;
+    }
+
+    public async Task<TunnelReconcileResult> PlanAsync(string accountId, string tunnelName, CancellationToken ct)
+    {
+        var existing = await _cf.FindTunnelByNameAsync(accountId, tunnelName, ct);
+        if (existing.Count > 0)
+        {
+            var t = existing[0];
+            _log.LogInformation("Tunnel {Name} already exists ({Id})", tunnelName, t.Id);
+            return new TunnelReconcileResult(
+                Name: t.Name,
+                Id: t.Id,
+                WillCreate: false,
+                Plan: ResourcePlan.NoOp(
+                    "Tunnel",
+                    t.Name,
+                    new[] { FieldChange.Same("id", t.Id) },
+                    note: "found existing tunnel"),
+                ConnectorTokenAsync: c => _cf.GetTunnelConnectorTokenAsync(accountId, t.Id, c));
+        }
+
+        // No tunnel — plan a create. The actual create happens in Apply so that
+        // dry-run can read this plan without producing side-effects.
+        string? createdId = null;
+
+        return new TunnelReconcileResult(
+            Name: tunnelName,
+            Id: "<pending>",
+            WillCreate: true,
+            Plan: ResourcePlan.Create(
+                "Tunnel",
+                tunnelName,
+                new[]
+                {
+                    FieldChange.Diff("name", null, tunnelName),
+                    FieldChange.Diff("config_src", null, "cloudflare"),
+                },
+                apply: async c =>
+                {
+                    var secret = GenerateTunnelSecret();
+                    var created = await _cf.CreateTunnelAsync(accountId, tunnelName, secret, c);
+                    createdId = created.Id;
+                    _log.LogInformation("Created tunnel {Name} ({Id})", tunnelName, created.Id);
+                },
+                note: "tunnel_secret generated at apply-time"),
+            ConnectorTokenAsync: async c =>
+            {
+                if (createdId is null)
+                {
+                    throw new InvalidOperationException("Cannot fetch connector token before tunnel create is applied.");
+                }
+                return await _cf.GetTunnelConnectorTokenAsync(accountId, createdId, c);
+            });
+    }
+
+    private static string GenerateTunnelSecret()
+    {
+        // 32 random bytes, base64-encoded. Token-based connectors don't use
+        // this value but the create endpoint demands it as a required field.
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/FieldChange.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/FieldChange.cs
@@ -1,0 +1,10 @@
+namespace Erp.Deploy.Reconcile;
+
+// A single field's before → after diff. IsChange = false means we looked at
+// the field and it was the same (we still emit it so the operator can see
+// what we considered, not just what we'd touch).
+public sealed record FieldChange(string Name, string? Before, string? After, bool IsChange)
+{
+    public static FieldChange Same(string name, string? value) => new(name, value, value, false);
+    public static FieldChange Diff(string name, string? before, string? after) => new(name, before, after, true);
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/PlanAction.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/PlanAction.cs
@@ -1,0 +1,8 @@
+namespace Erp.Deploy.Reconcile;
+
+public enum PlanAction
+{
+    NoOp,
+    Create,
+    Update,
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/PlanRenderer.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/PlanRenderer.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Spectre.Console;
+
+namespace Erp.Deploy.Reconcile;
+
+public static class PlanRenderer
+{
+    public static void RenderHuman(IReadOnlyList<ResourcePlan> plans)
+    {
+        if (plans.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim](no plans)[/]");
+            return;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded).Expand();
+        table.AddColumn("Resource");
+        table.AddColumn("Identity");
+        table.AddColumn("Action");
+        table.AddColumn("Diff");
+
+        foreach (var p in plans)
+        {
+            var actionMarkup = p.Action switch
+            {
+                PlanAction.Create => "[green]+ CREATE[/]",
+                PlanAction.Update => "[yellow]~ UPDATE[/]",
+                PlanAction.NoOp   => "[dim]  no-op[/]",
+                _ => p.Action.ToString(),
+            };
+            table.AddRow(
+                Markup.Escape(p.Resource),
+                Markup.Escape(p.Identity),
+                actionMarkup,
+                RenderChanges(p.Changes, p.Note));
+        }
+        AnsiConsole.Write(table);
+    }
+
+    public static string RenderJson(IReadOnlyList<ResourcePlan> plans, object? extra = null)
+    {
+        var doc = new
+        {
+            plans = plans.Select(p => new
+            {
+                resource = p.Resource,
+                identity = p.Identity,
+                action = p.Action.ToString().ToLowerInvariant(),
+                note = p.Note,
+                changes = p.Changes.Select(c => new
+                {
+                    field = c.Name,
+                    before = c.Before,
+                    after = c.After,
+                    changed = c.IsChange,
+                }),
+            }),
+            extra,
+        };
+        return JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string RenderChanges(IReadOnlyList<FieldChange> changes, string? note)
+    {
+        if (changes.Count == 0 && string.IsNullOrEmpty(note))
+        {
+            return "[dim]—[/]";
+        }
+        var lines = new List<string>();
+        foreach (var c in changes)
+        {
+            var before = c.Before is null ? "[dim]∅[/]" : Markup.Escape(c.Before);
+            var after  = c.After  is null ? "[dim]∅[/]" : Markup.Escape(c.After);
+            if (c.IsChange)
+            {
+                lines.Add($"[yellow]{Markup.Escape(c.Name)}[/]: {before} → [bold]{after}[/]");
+            }
+            else
+            {
+                lines.Add($"[dim]{Markup.Escape(c.Name)}: {before} (unchanged)[/]");
+            }
+        }
+        if (!string.IsNullOrEmpty(note))
+        {
+            lines.Add($"[italic dim]{Markup.Escape(note)}[/]");
+        }
+        return string.Join("\n", lines);
+    }
+}

--- a/src/Deploy/Erp.Deploy/Reconcile/PlanRenderer.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/PlanRenderer.cs
@@ -25,7 +25,7 @@ public static class PlanRenderer
             {
                 PlanAction.Create => "[green]+ CREATE[/]",
                 PlanAction.Update => "[yellow]~ UPDATE[/]",
-                PlanAction.NoOp   => "[dim]  no-op[/]",
+                PlanAction.NoOp => "[dim]  no-op[/]",
                 _ => p.Action.ToString(),
             };
             table.AddRow(
@@ -70,7 +70,7 @@ public static class PlanRenderer
         foreach (var c in changes)
         {
             var before = c.Before is null ? "[dim]∅[/]" : Markup.Escape(c.Before);
-            var after  = c.After  is null ? "[dim]∅[/]" : Markup.Escape(c.After);
+            var after = c.After is null ? "[dim]∅[/]" : Markup.Escape(c.After);
             if (c.IsChange)
             {
                 lines.Add($"[yellow]{Markup.Escape(c.Name)}[/]: {before} → [bold]{after}[/]");

--- a/src/Deploy/Erp.Deploy/Reconcile/ResourcePlan.cs
+++ b/src/Deploy/Erp.Deploy/Reconcile/ResourcePlan.cs
@@ -1,0 +1,22 @@
+namespace Erp.Deploy.Reconcile;
+
+// One reconcile plan for one resource. Resource = human kind ("Tunnel", "DNS").
+// Identity = the human label ("erp-for-factory-games", "satisfactory.erp-for-factory.games").
+// Apply is the closure that performs the mutation when not in dry-run.
+public sealed record ResourcePlan(
+    string Resource,
+    string Identity,
+    PlanAction Action,
+    IReadOnlyList<FieldChange> Changes,
+    Func<CancellationToken, Task>? Apply,
+    string? Note = null)
+{
+    public static ResourcePlan NoOp(string resource, string identity, IReadOnlyList<FieldChange> changes, string? note = null)
+        => new(resource, identity, PlanAction.NoOp, changes, Apply: null, Note: note);
+
+    public static ResourcePlan Create(string resource, string identity, IReadOnlyList<FieldChange> changes, Func<CancellationToken, Task> apply, string? note = null)
+        => new(resource, identity, PlanAction.Create, changes, apply, note);
+
+    public static ResourcePlan Update(string resource, string identity, IReadOnlyList<FieldChange> changes, Func<CancellationToken, Task> apply, string? note = null)
+        => new(resource, identity, PlanAction.Update, changes, apply, note);
+}

--- a/src/Deploy/Erp.Deploy/Ssh/RemoteFileUpload.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/RemoteFileUpload.cs
@@ -1,0 +1,9 @@
+namespace Erp.Deploy.Ssh;
+
+// Describes a single file to push to the remote stack directory.
+// Mode is a POSIX octal (e.g. 0o644). Body is the in-memory bytes; for files
+// read off disk, the caller fills Body from File.ReadAllBytes.
+public sealed record RemoteFileUpload(string RemotePath, byte[] Body, short Mode)
+{
+    public int Size => Body.Length;
+}

--- a/src/Deploy/Erp.Deploy/Ssh/ResolvedSshConnection.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/ResolvedSshConnection.cs
@@ -1,0 +1,22 @@
+namespace Erp.Deploy.Ssh;
+
+public sealed record ResolvedSshConnection(
+    string Host,
+    int Port,
+    string User,
+    IReadOnlyList<string> IdentityFiles)
+{
+    public string Display
+    {
+        get
+        {
+            var keys = IdentityFiles.Count switch
+            {
+                0 => "(no keys)",
+                1 => IdentityFiles[0],
+                _ => $"{IdentityFiles[0]} (+{IdentityFiles.Count - 1} more)",
+            };
+            return $"{User}@{Host}:{Port} (key={keys})";
+        }
+    }
+}

--- a/src/Deploy/Erp.Deploy/Ssh/SshConnectionResolver.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/SshConnectionResolver.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics;
+using Erp.Deploy.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Erp.Deploy.Ssh;
+
+// Resolves an SSH config alias (or raw hostname) into a concrete connection
+// tuple by shelling out to `ssh -G <host>`. Honours ~/.ssh/config so the
+// existing alias-driven UX (`ssh erp-lxc`) keeps working.
+//
+// IdentityFile handling: ssh -G emits every candidate identityfile OpenSSH
+// would try — explicit `IdentityFile` directives first, then the default
+// ~/.ssh/id_* set. We keep all that exist on disk and hand them all to
+// Renci.SshNet, which tries them in order at auth time. Same behaviour as
+// OpenSSH itself: first key that authenticates wins.
+//
+// Explicit values on RemoteOptions take precedence; missing ones fall through
+// to whatever `ssh -G` resolves.
+public sealed class SshConnectionResolver
+{
+    private static readonly string[] DefaultIdentityCandidates =
+    {
+        "~/.ssh/id_ed25519",
+        "~/.ssh/id_ecdsa",
+        "~/.ssh/id_rsa",
+    };
+
+    private readonly ILogger<SshConnectionResolver> _log;
+
+    public SshConnectionResolver(ILogger<SshConnectionResolver>? log = null)
+    {
+        _log = log ?? NullLogger<SshConnectionResolver>.Instance;
+    }
+
+    public ResolvedSshConnection Resolve(RemoteOptions opts)
+    {
+        var fromSshG = TrySshDashG(opts.Host);
+
+        var host = fromSshG?.Host ?? opts.Host;
+        var port = opts.Port ?? fromSshG?.Port ?? 22;
+        var user = opts.User ?? fromSshG?.User ?? Environment.UserName;
+
+        // If the user explicitly named a key, use just that one (and fail loud
+        // if it doesn't exist — they asked for it specifically). Otherwise
+        // take everything ssh -G suggested, fall back to the default set,
+        // dedupe, expand ~/, keep only those that exist on disk.
+        IReadOnlyList<string> keys;
+        if (opts.IdentityFile is { Length: > 0 } explicitKey)
+        {
+            var expanded = ExpandHome(explicitKey);
+            if (!File.Exists(expanded))
+            {
+                throw new FileNotFoundException(
+                    $"Remote.IdentityFile points to a file that doesn't exist: {expanded}", expanded);
+            }
+            keys = new[] { expanded };
+        }
+        else
+        {
+            var candidates = (fromSshG?.IdentityFiles ?? Array.Empty<string>())
+                .Concat(DefaultIdentityCandidates)
+                .Select(ExpandHome)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            keys = candidates.Where(File.Exists).ToList();
+
+            if (keys.Count == 0)
+            {
+                throw new FileNotFoundException(
+                    "No usable SSH identity file found. Tried: " + string.Join(", ", candidates) + ". " +
+                    "Set Remote.IdentityFile in deploy/erp-deploy.json, or generate a key with `ssh-keygen -t ed25519`.");
+            }
+        }
+
+        return new ResolvedSshConnection(host, port, user, keys);
+    }
+
+    private record SshGOutput(string Host, int Port, string User, IReadOnlyList<string> IdentityFiles);
+
+    private SshGOutput? TrySshDashG(string aliasOrHost)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "ssh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-G");
+        psi.ArgumentList.Add(aliasOrHost);
+
+        try
+        {
+            using var p = Process.Start(psi)!;
+            var stdout = p.StandardOutput.ReadToEnd();
+            p.WaitForExit(5_000);
+            if (p.ExitCode != 0)
+            {
+                _log.LogDebug("ssh -G {Alias} exited {ExitCode}; falling back.", aliasOrHost, p.ExitCode);
+                return null;
+            }
+
+            string? host = null, user = null;
+            int port = 22;
+            var identityFiles = new List<string>();
+            foreach (var line in stdout.Split('\n'))
+            {
+                var parts = line.TrimEnd('\r').Split(' ', 2);
+                if (parts.Length != 2) continue;
+                switch (parts[0])
+                {
+                    case "hostname": host = parts[1]; break;
+                    case "user": user = parts[1]; break;
+                    case "port": int.TryParse(parts[1], out port); break;
+                    case "identityfile": identityFiles.Add(parts[1]); break;
+                }
+            }
+            if (host is null || user is null) return null;
+            return new SshGOutput(host, port, user, identityFiles);
+        }
+        catch (Exception ex)
+        {
+            _log.LogDebug(ex, "ssh -G probe failed; falling back to literal host.");
+            return null;
+        }
+    }
+
+    private static string ExpandHome(string path)
+    {
+        if (path.StartsWith("~/"))
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..]);
+        }
+        return path;
+    }
+}

--- a/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
@@ -74,6 +74,13 @@ public sealed class SshDeployer : IDisposable
         foreach (var f in files)
         {
             _log.LogInformation("SFTP write {Path} ({Bytes} bytes, mode {Mode:o})", f.RemotePath, f.Size, f.Mode);
+
+            // UploadFile(canOverride:true) still EACCES's if the existing file
+            // lacks owner-write. Pre-chmod 0644 so a stuck remote mode can't
+            // wedge subsequent deploys.
+            try { _sftp.ChangePermissions(f.RemotePath, 644); }
+            catch (Renci.SshNet.Common.SftpPathNotFoundException) { /* new file */ }
+
             using var stream = new MemoryStream(f.Body);
             _sftp.UploadFile(stream, f.RemotePath, canOverride: true);
             _sftp.ChangePermissions(f.RemotePath, f.Mode);

--- a/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
@@ -122,6 +122,6 @@ public sealed class SshDeployer : IDisposable
     public void Dispose()
     {
         try { _sftp.Disconnect(); _sftp.Dispose(); } catch { /* best effort */ }
-        try { _ssh.Disconnect();  _ssh.Dispose();  } catch { /* best effort */ }
+        try { _ssh.Disconnect(); _ssh.Dispose(); } catch { /* best effort */ }
     }
 }

--- a/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
+++ b/src/Deploy/Erp.Deploy/Ssh/SshDeployer.cs
@@ -1,0 +1,120 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Renci.SshNet;
+
+namespace Erp.Deploy.Ssh;
+
+public sealed record RemoteCommandResult(string Command, int ExitStatus, string StdOut, string StdErr);
+
+// SFTP + remote-exec wrapper over Renci.SshNet. Two operations matter:
+//
+//   1. UploadFiles — pushes byte arrays to remote paths and chmods them.
+//      This is the bug fix the whole CLI was started for: writes are
+//      transport-layer SFTP, never re-parsed by a remote shell, so a
+//      stack.env line like `FOO="ab $c\nd"` lands byte-for-byte intact.
+//
+//   2. Run — runs one shell-compound command. The remote shell still parses
+//      the command body itself, so callers must build commands carefully;
+//      we don't accept user input here.
+public sealed class SshDeployer : IDisposable
+{
+    private readonly SshClient _ssh;
+    private readonly SftpClient _sftp;
+    private readonly ResolvedSshConnection _conn;
+    private readonly ILogger<SshDeployer> _log;
+
+    private SshDeployer(SshClient ssh, SftpClient sftp, ResolvedSshConnection conn, ILogger<SshDeployer> log)
+    {
+        _ssh = ssh;
+        _sftp = sftp;
+        _conn = conn;
+        _log = log;
+    }
+
+    public static SshDeployer Connect(ResolvedSshConnection conn, ILogger<SshDeployer>? log = null)
+    {
+        log ??= NullLogger<SshDeployer>.Instance;
+
+        if (conn.IdentityFiles.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No SSH identity files available — SshConnectionResolver should have caught this.");
+        }
+
+        // Load every surviving key and feed them all to one auth method.
+        // Renci.SshNet tries them in order at handshake time, same as OpenSSH.
+        var keyFiles = conn.IdentityFiles.Select(p => new PrivateKeyFile(p)).ToArray();
+        var auth = new PrivateKeyAuthenticationMethod(conn.User, keyFiles);
+        var info = new ConnectionInfo(conn.Host, conn.Port, conn.User, auth);
+
+        var ssh = new SshClient(info);
+        ssh.HostKeyReceived += (_, e) =>
+        {
+            // TODO Phase 3: verify against ~/.ssh/known_hosts. For v1 accept
+            // any key and surface the fingerprint so the operator can sanity-
+            // check it against what `ssh-keyscan` reports.
+            var fp = string.Join(":", e.FingerPrintSHA256);
+            log.LogInformation("SSH host key SHA256: {Fingerprint}", fp);
+            e.CanTrust = true;
+        };
+
+        ssh.Connect();
+        log.LogInformation("SSH connected: {Display}", conn.Display);
+
+        var sftp = new SftpClient(info);
+        sftp.Connect();
+
+        return new SshDeployer(ssh, sftp, conn, log);
+    }
+
+    public void UploadFiles(IReadOnlyList<RemoteFileUpload> files, string stackDir)
+    {
+        EnsureDir(stackDir);
+        foreach (var f in files)
+        {
+            _log.LogInformation("SFTP write {Path} ({Bytes} bytes, mode {Mode:o})", f.RemotePath, f.Size, f.Mode);
+            using var stream = new MemoryStream(f.Body);
+            _sftp.UploadFile(stream, f.RemotePath, canOverride: true);
+            _sftp.ChangePermissions(f.RemotePath, f.Mode);
+        }
+    }
+
+    public RemoteCommandResult Run(string command, TimeSpan? timeout = null)
+    {
+        using var cmd = _ssh.CreateCommand(command);
+        if (timeout is not null) cmd.CommandTimeout = timeout.Value;
+        _log.LogInformation("ssh exec: {Command}", command);
+
+        var stdout = cmd.Execute();
+        // ExitStatus is int? — null means SSH didn't report one. Treat as -1.
+        var result = new RemoteCommandResult(command, cmd.ExitStatus ?? -1, stdout, cmd.Error);
+        if (result.ExitStatus != 0)
+        {
+            _log.LogWarning("ssh exit={ExitStatus}: {Stderr}", result.ExitStatus, result.StdErr.TrimEnd());
+        }
+        return result;
+    }
+
+    private void EnsureDir(string remotePath)
+    {
+        // mkdir -p, but issued over SSH exec so we don't need to walk the path
+        // tree component-by-component over SFTP.
+        var r = Run($"mkdir -p {Quote(remotePath)}");
+        if (r.ExitStatus != 0)
+        {
+            throw new InvalidOperationException(
+                $"mkdir -p {remotePath} failed ({r.ExitStatus}): {r.StdErr.TrimEnd()}");
+        }
+    }
+
+    // Single-quote-wrap, escaping any embedded single quote with '\'' (POSIX safe).
+    // Used for paths we construct ourselves — not for user input.
+    private static string Quote(string s) => "'" + s.Replace("'", "'\\''") + "'";
+
+    public void Dispose()
+    {
+        try { _sftp.Disconnect(); _sftp.Dispose(); } catch { /* best effort */ }
+        try { _ssh.Disconnect();  _ssh.Dispose();  } catch { /* best effort */ }
+    }
+}

--- a/src/Deploy/Erp.Deploy/StackEnvBuilder.cs
+++ b/src/Deploy/Erp.Deploy/StackEnvBuilder.cs
@@ -1,0 +1,21 @@
+using System.Text;
+
+namespace Erp.Deploy;
+
+// Renders the docker-compose env-file (stack.env) as raw UTF-8 bytes.
+//
+// Why a dedicated builder: the previous PowerShell deploy mangled bodies
+// that contained `$`, quotes, or newlines because the remote shell re-parsed
+// the string when ssh piped it in. The new SFTP path writes bytes byte-for-
+// byte over the wire, so the only place mangling could still happen is here.
+// Isolating the byte production makes it trivially testable in isolation.
+public static class StackEnvBuilder
+{
+    public static byte[] Build(string connectorToken, string imageTag)
+    {
+        var sb = new StringBuilder();
+        sb.Append("TUNNEL_TOKEN=").Append(connectorToken).Append('\n');
+        sb.Append("ERP_IMAGE_TAG=").Append(imageTag).Append('\n');
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+}

--- a/test/Deploy/Erp.Deploy.Tests/Erp.Deploy.Tests.csproj
+++ b/test/Deploy/Erp.Deploy.Tests/Erp.Deploy.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Erp.Deploy.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Deploy\Erp.Deploy\Erp.Deploy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Deploy/Erp.Deploy.Tests/StackEnvBuilderTests.cs
+++ b/test/Deploy/Erp.Deploy.Tests/StackEnvBuilderTests.cs
@@ -1,0 +1,64 @@
+using System.Text;
+using Erp.Deploy;
+
+namespace Erp.Deploy.Tests;
+
+// Pins the bug that motivated moving deploy off PowerShell: hostile bytes in
+// the connector token used to get re-parsed by a remote shell (heredoc / scp).
+// The new SFTP path writes bytes verbatim, so the only place we could still
+// mangle is StackEnvBuilder. Any regression there fails this test.
+public class StackEnvBuilderTests
+{
+    [Fact]
+    public void Plain_token_round_trips_with_expected_layout()
+    {
+        var bytes = StackEnvBuilder.Build("abc123", "v1.2.3");
+
+        var text = Encoding.UTF8.GetString(bytes);
+        Assert.Equal("TUNNEL_TOKEN=abc123\nERP_IMAGE_TAG=v1.2.3\n", text);
+    }
+
+    [Theory]
+    [InlineData("$dollar")]                         // would interpolate in a shell
+    [InlineData("\"double-quoted\"")]               // breaks `cat > foo` heredocs
+    [InlineData("'single-quoted'")]                 // breaks ssh "cmd" outer-quoting
+    [InlineData("back`tick`")]                      // command-substitution trap
+    [InlineData("path\\with\\backslashes")]
+    [InlineData("a;b|c&d>e<f(g)h{i}j[k]")]          // grab-bag of shell metachars
+    [InlineData("contains\nliteral\nnewlines")]     // would split into bogus env lines after re-parse
+    [InlineData("trailing\\")]
+    [InlineData("$(whoami)")]                       // would execute under shell expansion
+    [InlineData("ünïcödé-token-Ω")]                 // multibyte UTF-8
+    public void Hostile_token_lands_verbatim_in_bytes(string hostile)
+    {
+        var bytes = StackEnvBuilder.Build(hostile, "v1.0.0");
+        var text = Encoding.UTF8.GetString(bytes);
+
+        // The whole point: the token sits between `TUNNEL_TOKEN=` and `\n`
+        // exactly as supplied. No quoting added, no metachars escaped, no
+        // newlines collapsed. The compose env-file consumer is responsible
+        // for whatever interpretation it wants — our job is byte-fidelity.
+        Assert.Equal($"TUNNEL_TOKEN={hostile}\nERP_IMAGE_TAG=v1.0.0\n", text);
+    }
+
+    [Fact]
+    public void Hostile_image_tag_also_round_trips()
+    {
+        // ImageTag is operator-controlled but treat it the same way — any
+        // future caller passing a tag with metachars should still get bytes
+        // through unmolested.
+        var bytes = StackEnvBuilder.Build("token", "tag-with-$weird\"chars");
+        var text = Encoding.UTF8.GetString(bytes);
+        Assert.Equal("TUNNEL_TOKEN=token\nERP_IMAGE_TAG=tag-with-$weird\"chars\n", text);
+    }
+
+    [Fact]
+    public void Output_is_utf8_no_bom()
+    {
+        var bytes = StackEnvBuilder.Build("token", "tag");
+
+        // BOM would corrupt the first env-var key (`﻿TUNNEL_TOKEN`).
+        Assert.NotEqual(0xEF, bytes[0]);
+        Assert.Equal((byte)'T', bytes[0]);
+    }
+}


### PR DESCRIPTION
Closes #263.

## Summary

- New `src/Deploy/Erp.Deploy/` library: typed `CloudflareClient`, reconcile primitives (`ResourcePlan`, `FieldChange`, `PlanAction`, `PlanRenderer`), `TunnelReconciler` / `DnsRecordReconciler` / `IngressReconciler`, `Provisioner` orchestrator.
- Managed SSH/SFTP deploy path via Renci.SshNet — `SshConnectionResolver`, `SshDeployer`, `Deployer`. Sidesteps the heredoc/scp/quoting issues that bit the old `deploy.ps1` (the `stack.env` content is written byte-for-byte over SFTP, never re-parsed by a remote shell).
- `Provision` + `Up` targets in `build/Build.cs`, with `[Secret] CloudflareApiToken` and `[Parameter] DryRun`. Secrets ergonomics flow through Fallout's parameter machinery — `CLOUDFLARE_API_TOKEN=$(bw get …) ./build.sh Provision` works locally; CI sets the same env var from GitHub secrets.
- `deploy/erp-deploy.json` — single source of truth for zone / tunnels / hostnames / remote host.
- Self-healing pre-chmod in `SshDeployer.UploadFiles` so a stuck remote mode (file lacking owner-write) doesn't wedge subsequent deploys.
- Phase 3 hostile-string round-trip pin: `StackEnvBuilder` extracted from `Deployer.BuildStackEnv`, covered by parameterised tests for `$`, quotes, backticks, embedded newlines, command-substitution syntax, and multibyte UTF-8.

## Why Fallout, not a standalone CLI

Dogfoods Fallout (ADR-0021) as CD as well as CI — same C#-as-build-script story, no separate binary, no separate config language, same `./build.sh <Target>` muscle memory.

## Coverage vs. #263 acceptance

- [x] `./build.sh Provision --dry-run` against live Cloudflare renders the plan.
- [x] `./build.sh Up` performs a full deploy from a clean checkout; `https://satisfactory.erp-for-factory.games` serves the app. Verified end-to-end against `10.10.107.175` on 2026-05-28; all three containers (`erp-cloudflared`, `erp-web`, `erp-api`) report healthy.
- [x] Re-run of `Up` after a previous deploy succeeds (validates the self-healing chmod).
- [x] Hostile-string round-trip test pins the regression that motivated the move off PowerShell.
- [ ] `deploy/Homelab.Stacks.ErpForFactoryGames/bin/*.ps1` deletion + docs update — follow-up.
- [ ] `Doctor` target — follow-up.

## Out of scope

- Deletion of the old `.ps1` scripts and `docs/operations/deploy.md` rewrite — keeping in this PR scope only the new code + the test that pins the original bug.
- `Doctor` target — separate PR.
- Replacing `deploy/bootstrap-lxc.sh` / `harden-ssh.sh` (different lifecycle).

## Test plan

- [x] `./build.sh Provision --dry-run` against live Cloudflare account renders the plan.
- [x] `./build.sh Up` performs a full deploy from a clean checkout.
- [x] Re-run of `Up` after a previous deploy succeeds.
- [x] `dotnet test test/Deploy/Erp.Deploy.Tests` — 13/13 pass locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)