### PR TITLE
chore: secret-scan + dev-scratch hygiene

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,29 @@
+name: Secret scan (gitleaks)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so push-to-main scans cover the new commits, not just HEAD.
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ test/ui-tests/
 *.db-shm
 *.db-wal
 
+# Planner scratch snapshot (Steam ID + local save path inside) — dev-only
+factory_state.json
+
 
 *.lscache

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,6 +25,16 @@ Assumes:
 - **Unprivileged** with `nesting=1` and `keyctl=1` Features enabled
   (Proxmox UI → LXC → Options → Features).
 - An SSH alias `erp-lxc` configured in `~/.ssh/config` on the dev box.
+  This is also what `deploy/erp-deploy.json` references, so `./build.sh Up`
+  and `./build.sh Provision` go through the same alias. A minimal stanza:
+
+  ```
+  Host erp-lxc
+      HostName <your-lxc-ip>
+      User chris
+      IdentityFile ~/.ssh/id_ed25519
+  ```
+
 - Your SSH public key already pasted into `/root/.ssh/authorized_keys`
   on the LXC (one-time, via the Proxmox console).
 

--- a/deploy/erp-deploy.json
+++ b/deploy/erp-deploy.json
@@ -15,7 +15,7 @@
     ]
   },
   "Remote": {
-    "Host": "10.10.107.175",
+    "Host": "erp-lxc",
     "User": "chris",
     "StackDir": "/home/chris/stacks/erp"
   }


### PR DESCRIPTION
## Summary

Three small repo-hygiene fixes after the post-merge secret audit on #265.

- **Gitleaks workflow** alongside GitHub's built-in Secret Scanning (already enabled + push protection on). Any push or PR that introduces a string matching one of the ~150 default detectors fails CI.
- **`deploy/erp-deploy.json` Host: \`10.10.107.175\` → \`erp-lxc\`.** The committed config now references the SSH-config alias the README already requires (line 27), so the homelab IP no longer ships in the public repo. Code-side already supports this — `RemoteOptions.Host` accepts an alias OR a raw hostname (resolves via \`ssh -G\`).
- **Gitignore \`factory_state.json\`.** Planner scratch snapshot — carries a Steam ID and a local save path, never meant to be committed.

## Test plan

- [ ] Gitleaks CI job passes on the first run. If it trips on a known-safe pattern (e.g. the winget \`InstallerSha256\`), follow up with a \`.gitleaks.toml\` allowlist.
- [ ] Confirm \`./build.sh Up\` still resolves the deploy target through \`erp-lxc\` after this merge (no behaviour change expected — the alias path was already supported and documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)