### PR TITLE
feat(0026): Phase 5c4 — Erp.Presentation.Web.Auth scaffold

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -29,6 +29,9 @@
   <Folder Name="/src/Presentation/Web/Erp.Presentation.Web.Common/">
     <Project Path="src/Presentation/Web/Erp.Presentation.Web.Common/Erp.Presentation.Web.Common.csproj" />
   </Folder>
+  <Folder Name="/src/Presentation/Web/Erp.Presentation.Web.Auth/">
+    <Project Path="src/Presentation/Web/Erp.Presentation.Web.Auth/Erp.Presentation.Web.Auth.csproj" />
+  </Folder>
   <Folder Name="/src/Presentation/Web/Satisfactory.Presentation.Web/">
     <Project Path="src/Presentation/Web/Satisfactory.Presentation.Web/Satisfactory.Presentation.Web.csproj" />
   </Folder>

--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -39,4 +39,14 @@ builder.AddProject<Projects.CaptainOfIndustry_Presentation_Web>("coi-webfrontend
     .WithExternalHttpEndpoints()
     .WithHttpHealthCheck("/health");
 
+// Central auth web frontend (ADR-0026 phase 5c4) — the identity punch-out the
+// game frontends redirect to for sign-in + account/agent management. Talks to
+// auth-api; deploys behind auth.erp-for-factory.games (CNAME wired in 5c5).
+// Scaffold only for now: no OAuth flow, no live Auth-API calls yet.
+builder.AddProject<Projects.Erp_Presentation_Web_Auth>("auth-webfrontend")
+    .WithExternalHttpEndpoints()
+    .WithHttpHealthCheck("/health")
+    .WithReference(authApi)
+    .WaitFor(authApi);
+
 builder.Build().Run();

--- a/src/Hosting/Erp.Hosting.AppHost/Erp.Hosting.AppHost.csproj
+++ b/src/Hosting/Erp.Hosting.AppHost/Erp.Hosting.AppHost.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\Presentation\Api\Satisfactory.Presentation.Api\Satisfactory.Presentation.Api.csproj" />
     <ProjectReference Include="..\..\Presentation\Api\Erp.Presentation.Api.Auth\Erp.Presentation.Api.Auth.csproj" />
     <ProjectReference Include="..\..\Presentation\Api\CaptainOfIndustry.Presentation.Api\CaptainOfIndustry.Presentation.Api.csproj" />
+    <ProjectReference Include="..\..\Presentation\Web\Erp.Presentation.Web.Auth\Erp.Presentation.Web.Auth.csproj" />
     <ProjectReference Include="..\..\Presentation\Web\Satisfactory.Presentation.Web\Satisfactory.Presentation.Web.csproj" />
     <ProjectReference Include="..\..\Presentation\Web\CaptainOfIndustry.Presentation.Web\CaptainOfIndustry.Presentation.Web.csproj" />
   </ItemGroup>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/App.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/App.razor
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <ImportMap />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes @rendermode="InteractiveServer" />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+</body>
+
+</html>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Layout/MainLayout.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Layout/MainLayout.razor
@@ -1,0 +1,25 @@
+@inherits LayoutComponentBase
+
+<MudThemeProvider Theme="_theme" IsDarkMode="true" />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudText Typo="Typo.h6">ERP for Factory Games — Account</MudText>
+        <MudSpacer />
+        <MudLink Href="/" Color="Color.Inherit" Class="mx-2">Sign in</MudLink>
+        <MudLink Href="account" Color="Color.Inherit" Class="mx-2">Account</MudLink>
+        <MudLink Href="agents" Color="Color.Inherit" Class="mx-2">Agents</MudLink>
+    </MudAppBar>
+    <MudMainContent>
+        <MudContainer MaxWidth="MaxWidth.Small" Class="mt-6">
+            @Body
+        </MudContainer>
+    </MudMainContent>
+</MudLayout>
+
+@code {
+    private readonly MudTheme _theme = new();
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Account.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Account.razor
@@ -1,0 +1,22 @@
+@page "/account"
+
+<PageTitle>ERP — Account</PageTitle>
+
+<h1>Account</h1>
+
+<MudText Class="mb-4">
+    Profile and identity settings for your ERP for Factory Games player. Today the
+    player is provisioned automatically in development (<code>DevPlayerBootstrap</code>
+    on the Auth API); this page becomes the surface for editing display name,
+    linked providers, and account deletion once sign-in ships.
+</MudText>
+
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Scaffold only — no editable fields yet. Account data is owned by the Auth API
+    (<code>auth-api</code>) per ADR-0026.
+</MudAlert>
+
+<MudPaper Class="pa-4" Elevation="0" Outlined="true">
+    <MudText Typo="Typo.subtitle2" Class="mb-2">Linked providers</MudText>
+    <MudText Typo="Typo.body2">None — provider linking arrives with the OAuth phase.</MudText>
+</MudPaper>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Agents.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Agents.razor
@@ -1,0 +1,18 @@
+@page "/agents"
+
+<PageTitle>ERP — Agents</PageTitle>
+
+<h1>Agents</h1>
+
+<MudText Class="mb-4">
+    Pair and manage the desktop agents that upload your save files and game
+    catalogues. Agent tokens are owned by the Auth API (<code>auth-api</code>) and
+    shared across every game planner — one set of agents per player, not per game.
+</MudText>
+
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Scaffold only. The full "My Agents" management UI moves here from the
+    Satisfactory frontend's <code>/settings/agents</code> page in a follow-up
+    (see #260), and the token format switches to JWT in
+    <MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/docs/adr/0027-jwt-hmac-cross-api-auth.md">ADR-0027</MudLink> / phase 5c3 (#279).
+</MudAlert>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Error.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Error.razor
@@ -1,0 +1,25 @@
+@page "/Error"
+@using System.Diagnostics
+
+<PageTitle>Error</PageTitle>
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@RequestId</code>
+    </p>
+}
+
+@code{
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Home.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Home.razor
@@ -1,0 +1,30 @@
+@page "/"
+
+<PageTitle>ERP — Sign in</PageTitle>
+
+<h1>Sign in</h1>
+
+<MudText Class="mb-4">
+    Single account across every ERP for Factory Games planner. This is the central
+    identity punch-out — game frontends
+    (<MudLink Href="https://satisfactory.erp-for-factory.games">Satisfactory</MudLink>,
+    <MudLink Href="https://coi.erp-for-factory.games">Captain of Industry</MudLink>)
+    redirect here to sign in and manage their account, per
+    <MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/docs/adr/0026-onion-layered-src-with-product-split.md">ADR-0026</MudLink>.
+</MudText>
+
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Scaffold only. Provider sign-in (Google, Microsoft, Apple, Steam) and the
+    OAuth flow land in a later phase — this project carves out the slot they
+    wire into without touching the game frontends.
+</MudAlert>
+
+<MudPaper Class="pa-4" Elevation="0" Outlined="true">
+    <MudText Typo="Typo.subtitle2" Class="mb-3">Sign in with</MudText>
+    <MudStack Spacing="2">
+        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Google — coming soon</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Microsoft — coming soon</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Apple — coming soon</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Steam — coming soon</MudButton>
+    </MudStack>
+</MudPaper>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Routes.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/_Imports.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/_Imports.razor
@@ -1,0 +1,11 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using MudBlazor
+@using Erp.Presentation.Web.Auth
+@using Erp.Presentation.Web.Auth.Components

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Erp.Presentation.Web.Auth.csproj
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Erp.Presentation.Web.Auth.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Erp.Presentation.Web.Auth</RootNamespace>
+    <AssemblyName>Erp.Presentation.Web.Auth</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Hosting\Erp.Hosting.ServiceDefaults\Erp.Hosting.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Erp.Presentation.Web.Common\Erp.Presentation.Web.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
@@ -1,0 +1,50 @@
+using Erp.Hosting.ServiceDefaults;
+using Erp.Presentation.Web.Auth.Components;
+using MudBlazor.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add service defaults & Aspire client integrations.
+builder.AddServiceDefaults();
+
+builder.Services.AddMudServices();
+
+// Add services to the container.
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddOutputCache();
+
+// The auth web frontend talks to the central Auth API for player + agent-token
+// operations. Service discovery resolves "auth-api" via Aspire in dev and the
+// container name in production. No typed client yet — the scaffold has no live
+// calls; that arrives when the OAuth flow + agent-management UI land here.
+builder.Services.AddHttpClient("auth-api", client =>
+{
+    // "https+http://" prefers HTTPS over HTTP — see https://aka.ms/dotnet/sdschemes
+    client.BaseAddress = new("https+http://auth-api");
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAntiforgery();
+
+app.UseOutputCache();
+
+app.MapStaticAssets();
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.MapDefaultEndpoints();
+
+app.Run();

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Properties/launchSettings.json
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5460",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7570;http://localhost:5460",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.Development.json
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.json
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/wwwroot/app.css
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/wwwroot/app.css
@@ -1,0 +1,13 @@
+html, body {
+    height: 100%;
+    margin: 0;
+}
+
+h1 {
+    font-weight: 300;
+}
+
+code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.9em;
+}


### PR DESCRIPTION
Closes #280. ADR-0026 phase 5c4.

New Blazor Server project that punches out the user-identity UI from the game-specific web frontends, so future OAuth providers (Google/Microsoft/Apple/Steam) and the JWT work ([ADR-0027](docs/adr/0027-jwt-hmac-cross-api-auth.md) / #279) wire here without touching Satisfactory or CoI.

## What landed

- **`src/Presentation/Web/Erp.Presentation.Web.Auth`** — Blazor Server, references `Erp.Hosting.ServiceDefaults` + `Erp.Presentation.Web.Common`, MudBlazor UI. Mirrors the CoI/Sat web project shape.
- **Placeholder pages**: sign-in (`/`), account stub (`/account`), agents stub (`/agents`) — each clearly marked scaffold-only with pointers to the follow-up work.
- **`auth-api` HttpClient** wired via Aspire service discovery (no live calls yet).
- **AppHost**: orchestrates as `auth-webfrontend` with `.WithReference(authApi).WaitFor(authApi)`, external HTTP endpoints, `/health` check.
- Registered in `ErpForFactoryGames.slnx`; dev ports 5460/7570.

## Verification

- `dotnet build` of the new project and the AppHost: 0 errors (warnings all pre-existing — vuln advisories, NU1608, the Planner.razor nullable).
- UI test fixture only waits on `webfrontend`, so the extra resource doesn't perturb it. The new frontend touches no DB → no migration race.

## Out of scope (tracked elsewhere)

- OAuth provider integration — its own ADR + issue.
- Migrating the live `/settings/agents` UI from Satisfactory.Web — #260.
- CNAME (`auth.erp-for-factory.games`) + compose + CI image rollout — #281 (phase 5c5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)