### PR TITLE
feat(0026): Phase 5c5 (scaffold) — CoI API health check + launchSettings

### DIFF
--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -13,9 +13,13 @@ var apiService = builder.AddProject<Projects.Satisfactory_Presentation_Api>("api
     .WithHttpHealthCheck("/health")
     .WaitFor(authApi);
 
-// Captain of Industry API (scaffold) — same shape as the Satisfactory binary,
-// no real surface yet. Phase 5c5 wires its planner endpoints + health check.
-var coiApi = builder.AddProject<Projects.CaptainOfIndustry_Presentation_Api>("coi-api");
+// Captain of Industry API (scaffold) — same shape as the Satisfactory binary.
+// Health-checkable now (launchSettings + WithHttpHealthCheck), but still has no
+// real planner surface: CoI.Web reads its catalogue in-process. The planner
+// endpoints + operational rollout (CNAME, compose, CI image) are deferred to
+// the full phase-5c5 work (#281); this just makes the binary symmetric.
+var coiApi = builder.AddProject<Projects.CaptainOfIndustry_Presentation_Api>("coi-api")
+    .WithHttpHealthCheck("/health");
 
 // ---- Optional Postgres for plan storage (ADR-0018) -------------------------
 // SQLite is the default and needs no orchestration. Uncomment the block below

--- a/src/Presentation/Api/CaptainOfIndustry.Presentation.Api/Properties/launchSettings.json
+++ b/src/Presentation/Api/CaptainOfIndustry.Presentation.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5470",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7571;http://localhost:5470",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Partial / scaffold-only step toward #281 (ADR-0026 phase 5c5). **Does not** close #281 — the operational rollout is deliberately left untouched.

Per direction: 5c5 is a minimum-effort scaffold for now, not a rollout. This makes the CoI API binary symmetric with `auth-api` and `apiservice` so it boots health-checkable under the AppHost, without implying a deployment that doesn't exist.

## What landed

- `Properties/launchSettings.json` for `CaptainOfIndustry.Presentation.Api` (ports 5470/7571) — lets Aspire resolve an http endpoint for the health probe (the same gap the Auth API hit in #277).
- AppHost: `coi-api` gains `.WithHttpHealthCheck("/health")`.

## Explicitly deferred to the full #281 work

- CoI planner endpoints (CoI.Web still reads its catalogue in-process).
- `deploy/erp-deploy.json` hostnames + cloudflared CNAMEs.
- Sister-repo compose services (`erp-auth-api`, `erp-coi-api`, `erp-coi-web`).
- `release-images.yml` CI matrix entries.

Half-wiring any of those would imply a rollout that hasn't happened.

## Verification

- AppHost build: 0 errors. `/health` is mapped unconditionally in `ServiceDefaults`, so the probe is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)