### PR TITLE
refactor(0026): Phase 7 (part 2a) — split Agent.Tests per src

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -72,8 +72,11 @@
     <Project Path="tools/Erp.Deploy/Erp.Deploy.csproj" />
   </Folder>
   <Folder Name="/test/" />
-  <Folder Name="/test/Agent.Tests/">
-    <Project Path="test/Agent.Tests/Agent.Tests.csproj" />
+  <Folder Name="/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/">
+    <Project Path="test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/Erp.Presentation.Agent.Common.Tests.csproj" />
+  </Folder>
+  <Folder Name="/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/">
+    <Project Path="test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/Satisfactory.Presentation.Agent.Tests.csproj" />
   </Folder>
   <Folder Name="/test/ApiService.Tests/" />
   <Folder Name="/test/Application/" />

--- a/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/AgentConfigWriterTests.cs
+++ b/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/AgentConfigWriterTests.cs
@@ -1,9 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Erp.Presentation.Agent.Common;
-using Satisfactory.Presentation.Agent;
 
-namespace Agent.Tests;
+namespace Erp.Presentation.Agent.Common.Tests;
 
 public class AgentConfigWriterTests : IDisposable
 {

--- a/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/Erp.Presentation.Agent.Common.Tests.csproj
+++ b/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/Erp.Presentation.Agent.Common.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <RootNamespace>Agent.Tests</RootNamespace>
+    <RootNamespace>Erp.Presentation.Agent.Common.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,8 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Presentation\Agent\Erp.Presentation.Agent.Common\Erp.Presentation.Agent.Common.csproj" />
-    <ProjectReference Include="..\..\src\Presentation\Agent\Satisfactory.Presentation.Agent\Satisfactory.Presentation.Agent.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Presentation\Agent\Erp.Presentation.Agent.Common\Erp.Presentation.Agent.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/LogTailReaderTests.cs
+++ b/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/LogTailReaderTests.cs
@@ -1,7 +1,6 @@
 using Erp.Presentation.Agent.Common;
-using Satisfactory.Presentation.Agent;
 
-namespace Agent.Tests;
+namespace Erp.Presentation.Agent.Common.Tests;
 
 public class LogTailReaderTests : IDisposable
 {

--- a/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/PairingUrlParserTests.cs
+++ b/test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests/PairingUrlParserTests.cs
@@ -1,7 +1,6 @@
 using Erp.Presentation.Agent.Common;
-using Satisfactory.Presentation.Agent;
 
-namespace Agent.Tests;
+namespace Erp.Presentation.Agent.Common.Tests;
 
 public class PairingUrlParserTests
 {

--- a/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/Satisfactory.Presentation.Agent.Tests.csproj
+++ b/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/Satisfactory.Presentation.Agent.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Satisfactory.Presentation.Agent.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Presentation\Agent\Satisfactory.Presentation.Agent\Satisfactory.Presentation.Agent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/SaveFolderResolverTests.cs
+++ b/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/SaveFolderResolverTests.cs
@@ -2,7 +2,7 @@ using Erp.Presentation.Agent.Common;
 using Satisfactory.Presentation.Agent;
 using Microsoft.Extensions.Options;
 
-namespace Agent.Tests;
+namespace Satisfactory.Presentation.Agent.Tests;
 
 public class SaveFolderResolverTests : IDisposable
 {


### PR DESCRIPTION
Part 2a of #282 (ADR-0026 phase 7). Mirrors the 5b src-side Agent split.

`test/Agent.Tests` divided to match the two src projects it covered:

| Tests | New project | References |
|---|---|---|
| AgentConfigWriterTests, LogTailReaderTests, PairingUrlParserTests | `test/Presentation/Agent/Erp.Presentation.Agent.Common.Tests` | `Erp.Presentation.Agent.Common` |
| SaveFolderResolverTests | `test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests` | `Satisfactory.Presentation.Agent` |

- Namespaces `Agent.Tests` → the two new ones; dropped the now-vestigial `using Satisfactory.Presentation.Agent;` from the Common tests (verified none reference a Satisfactory-only type).
- slnx updated.
- Verified: 23 Common + 4 Satisfactory = 27 tests pass (matches the original count).

## Note: ApiService split is separate (part 2b)

While scoping this I found `ApiService.Tests` was silently dropped from the solution during the 5c1/5c2 API refactor — so #276/#277 merged green without those 14 integration tests running. They currently fail with a `FOREIGN KEY constraint failed`: the fixtures' DI-minted `AgentToken` references a dev-Player row that no longer exists, because `DevPlayerBootstrap` moved to the Auth API in 5c2. That's a fixture fix + re-add, not a mechanical move — tracked for its own PR per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)