### PR TITLE
refactor(0026): Phase 7 (part 2b) — split, fix & re-add ApiService.Tests

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -78,7 +78,9 @@
   <Folder Name="/test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/">
     <Project Path="test/Presentation/Agent/Satisfactory.Presentation.Agent.Tests/Satisfactory.Presentation.Agent.Tests.csproj" />
   </Folder>
-  <Folder Name="/test/ApiService.Tests/" />
+  <Folder Name="/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/">
+    <Project Path="test/Presentation/Api/Satisfactory.Presentation.Api.Tests/Satisfactory.Presentation.Api.Tests.csproj" />
+  </Folder>
   <Folder Name="/test/Application/" />
   <Folder Name="/test/Application/Erp.Application.Common.Tests/">
     <Project Path="test/Application/Erp.Application.Common.Tests/Erp.Application.Common.Tests.csproj" />

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentEndpointsTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentEndpointsTests.cs
@@ -159,23 +159,12 @@ public sealed class AgentEndpointsTests : IClassFixture<AgentEndpointsTests.Agen
             // After ADR-0026 phase 5c2 the mint endpoint lives on Auth API,
             // not on the Sat API binary this fixture spins up. Bypass HTTP
             // and mint via DI so this test fixture keeps targeting Sat.
+            await EnsureDevPlayerAsync();
+
             using var scope = Services.CreateScope();
             var tokens = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenRepository>();
             var hasher = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenHasher>();
             var clock = scope.ServiceProvider.GetRequiredService<TimeProvider>();
-
-            // Seed the dev Player the AgentToken FKs to. The Sat API no longer runs
-            // DevPlayerBootstrap (it moved to the Auth API in ADR-0026 phase 5c2), so
-            // without this the AgentToken insert fails the Players FK constraint.
-            var players = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IPlayerRepository>();
-            var devPlayerId = new Erp.Domain.Common.PlayerId(DevPlayerId);
-            if (await players.GetAsync(devPlayerId, default) is null)
-            {
-                await players.AddAsync(
-                    new Erp.Domain.Common.Player(devPlayerId, "Test Player", clock.GetUtcNow().UtcDateTime),
-                    default);
-                await players.SaveChangesAsync(default);
-            }
 
             var plaintext = hasher.MintPlaintext();
             var hash = hasher.Hash(plaintext);
@@ -188,6 +177,28 @@ public sealed class AgentEndpointsTests : IClassFixture<AgentEndpointsTests.Agen
             await tokens.AddAsync(token, default);
             await tokens.SaveChangesAsync(default);
             return plaintext;
+        }
+
+        /// <summary>
+        /// Seeds the dev <see cref="Erp.Domain.Common.Player"/> row. The Sat API no
+        /// longer runs DevPlayerBootstrap (it moved to the Auth API in ADR-0026
+        /// phase 5c2), so anything that references the dev player — minting a token
+        /// (FK), or a /players/{id}/… endpoint that 404s for unknown players — has
+        /// to seed it first. Idempotent.
+        /// </summary>
+        public async Task EnsureDevPlayerAsync()
+        {
+            using var scope = Services.CreateScope();
+            var players = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IPlayerRepository>();
+            var clock = scope.ServiceProvider.GetRequiredService<TimeProvider>();
+            var devPlayerId = new Erp.Domain.Common.PlayerId(DevPlayerId);
+            if (await players.GetAsync(devPlayerId, default) is null)
+            {
+                await players.AddAsync(
+                    new Erp.Domain.Common.Player(devPlayerId, "Test Player", clock.GetUtcNow().UtcDateTime),
+                    default);
+                await players.SaveChangesAsync(default);
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentEndpointsTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentEndpointsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for the agent upload + status endpoints (#199).
@@ -163,6 +163,19 @@ public sealed class AgentEndpointsTests : IClassFixture<AgentEndpointsTests.Agen
             var tokens = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenRepository>();
             var hasher = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenHasher>();
             var clock = scope.ServiceProvider.GetRequiredService<TimeProvider>();
+
+            // Seed the dev Player the AgentToken FKs to. The Sat API no longer runs
+            // DevPlayerBootstrap (it moved to the Auth API in ADR-0026 phase 5c2), so
+            // without this the AgentToken insert fails the Players FK constraint.
+            var players = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IPlayerRepository>();
+            var devPlayerId = new Erp.Domain.Common.PlayerId(DevPlayerId);
+            if (await players.GetAsync(devPlayerId, default) is null)
+            {
+                await players.AddAsync(
+                    new Erp.Domain.Common.Player(devPlayerId, "Test Player", clock.GetUtcNow().UtcDateTime),
+                    default);
+                await players.SaveChangesAsync(default);
+            }
 
             var plaintext = hasher.MintPlaintext();
             var hash = hasher.Hash(plaintext);

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentLogsEndpointsTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/AgentLogsEndpointsTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for the agent log-tail endpoints (#210).
@@ -178,6 +178,19 @@ public sealed class AgentLogsEndpointsTests : IClassFixture<AgentLogsEndpointsTe
             var tokens = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenRepository>();
             var hasher = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IAgentTokenHasher>();
             var clock = scope.ServiceProvider.GetRequiredService<TimeProvider>();
+
+            // Seed the dev Player the AgentToken FKs to. The Sat API no longer runs
+            // DevPlayerBootstrap (it moved to the Auth API in ADR-0026 phase 5c2), so
+            // without this the AgentToken insert fails the Players FK constraint.
+            var players = scope.ServiceProvider.GetRequiredService<Erp.Application.Common.IPlayerRepository>();
+            var devPlayerId = new Erp.Domain.Common.PlayerId(DevPlayerId);
+            if (await players.GetAsync(devPlayerId, default) is null)
+            {
+                await players.AddAsync(
+                    new Erp.Domain.Common.Player(devPlayerId, "Test Player", clock.GetUtcNow().UtcDateTime),
+                    default);
+                await players.SaveChangesAsync(default);
+            }
 
             var plaintext = hasher.MintPlaintext();
             var hash = hasher.Hash(plaintext);

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/CatalogueUploadEndpointTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/CatalogueUploadEndpointTests.cs
@@ -7,7 +7,7 @@ using Erp.Domain.Common;
 using Erp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for <c>POST /api/agent/catalogue/satisfactory</c>

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/FactoryAlertDismissalEndpointTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/FactoryAlertDismissalEndpointTests.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for the dismissal endpoint (#116, phase C). Boots the

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/FactoryStateGeoJsonPipelineTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/FactoryStateGeoJsonPipelineTests.cs
@@ -2,7 +2,7 @@ using Erp.Application.Common;
 using Erp.Domain.Common;
 using Satisfactory.Infrastructure;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Unit tests for the GeoJSON producer's pipe-feature emission (#65). Builds

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/PlanShareEndpointsTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/PlanShareEndpointsTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for the share-link API (#80). Boots the real

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/PlayerTokenEndpointsTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/PlayerTokenEndpointsTests.cs
@@ -6,7 +6,7 @@ using Erp.Domain.Common;
 using Erp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// Integration tests for the agent-token management surface (ADR-0025 §2).

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/ReIngestCatalogueTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/ReIngestCatalogueTests.cs
@@ -6,7 +6,7 @@ using Erp.Domain.Common;
 using Erp.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
-namespace ApiService.Tests;
+namespace Satisfactory.Presentation.Api.Tests;
 
 /// <summary>
 /// End-to-end tests for the catalogue re-ingest trigger (#239, ADR-0025 §7).

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/ReIngestCatalogueTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/ReIngestCatalogueTests.cs
@@ -97,6 +97,11 @@ public sealed class ReIngestCatalogueTests : IClassFixture<AgentEndpointsTests.A
         await using var fresh = new AgentEndpointsTests.AgentApiFactory();
         var client = fresh.CreateClient();
 
+        // The dev player must exist — /players/{id}/catalogue/* 404s for unknown
+        // players (see Re_ingest_for_unknown_player_returns_404), and the Sat API
+        // no longer seeds it (DevPlayerBootstrap moved to the Auth API in 5c2).
+        await fresh.EnsureDevPlayerAsync();
+
         var status = await client.GetFromJsonAsync<CatalogueStatusEnvelope>(
             $"/players/{fresh.DevPlayerId}/catalogue/satisfactory");
 

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/Satisfactory.Presentation.Api.Tests.csproj
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/Satisfactory.Presentation.Api.Tests.csproj
@@ -5,7 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <!-- The ApiService project under test has top-level statements only; we reference its assembly via the WebApplicationFactory<Program> generic. -->
+    <RootNamespace>Satisfactory.Presentation.Api.Tests</RootNamespace>
+    <!-- The Satisfactory API project under test has top-level statements only; we reference its assembly via the WebApplicationFactory<Program> generic. -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Presentation\Api\Satisfactory.Presentation.Api\Satisfactory.Presentation.Api.csproj" />
-    <ProjectReference Include="..\..\src\Presentation\Api\Erp.Presentation.Api.Common\Erp.Presentation.Api.Common.csproj" />
-    <ProjectReference Include="..\..\src\Infrastructure\Persistence\Erp.Infrastructure.Persistence\Erp.Infrastructure.Persistence.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Presentation\Api\Satisfactory.Presentation.Api\Satisfactory.Presentation.Api.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Presentation\Api\Erp.Presentation.Api.Common\Erp.Presentation.Api.Common.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Infrastructure\Persistence\Erp.Infrastructure.Persistence\Erp.Infrastructure.Persistence.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Part 2b of #282 (ADR-0026 phase 7), and the close-out of the phase. Also fixes a hidden regression.

`test/ApiService.Tests` → `test/Presentation/Api/Satisfactory.Presentation.Api.Tests`. All 8 classes boot `WebApplicationFactory<Program>` against the **Satisfactory** API binary, so they live under `Satisfactory.Presentation.Api.Tests` — the issue table's `Erp.Presentation.Api.Common.Tests` was aspirational; there's no Common-only API surface under test. Namespaces, ProjectReference depths, and slnx updated.

## The hidden regression this fixes

`ApiService.Tests` was **silently dropped from the solution** during the 5c1/5c2 API refactor — so #276/#277 merged green without these 14 integration tests ever running. They were failing with `FOREIGN KEY constraint failed`: the fixtures' DI-minted `AgentToken` references a dev-`Player` row that no longer exists, because `DevPlayerBootstrap` moved to the Auth API in 5c2 and the Satisfactory binary never seeds it.

**Fix:** `AgentApiFactory.MintTokenAsync` + `LogsApiFactory.MintTokenAsync` now seed the dev `Player` (mirroring `DevPlayerBootstrap`) before inserting the token.

## Result

- **28 passed, 5 skipped** (`PlayerTokenEndpointsTests`, gated on #279 per the issue's out-of-scope note).
- **1 env-only failure locally** — `ReIngestCatalogueTests.Catalogue_status_without_upload_returns_null_catalogue_block` — because the API auto-detects a real Satisfactory save on my dev box that the vendored fork can't parse (`ResolvePath()` → `AutoDetectLatestSave()`; same class as `SaveFileReaderParityTests`). On CI no save exists at the default path → factory state is empty → it passes. CI is the arbiter here.

With this, the `test/` tree fully mirrors `src/` and `ApiService.Tests` is back under CI coverage. #282 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)