### PR TITLE
feat(0027): Phase 5c3 — JWT/HMAC agent-token auth across Auth + game APIs

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -55,6 +55,16 @@ class Build : FalloutBuild
     [Parameter("Image tag for erp-web + erp-api. Default: latest.")]
     readonly string ImageTag = "latest";
 
+    // Shared HMAC key the Auth API signs agent JWTs with and the game APIs
+    // verify against (ADR-0027 / 5c3). [Secret] → Fallout prompts masked when
+    // not supplied via env (AUTH_JWT_SIGNING_KEY) / CI secret. Baked into
+    // stack.env as Auth__JwtSigningKey on every API container. Empty is allowed
+    // (the APIs fall back to their dev key + log a warning) but production
+    // deployments must set a real ≥256-bit secret.
+    [Parameter("Shared HMAC-SHA256 key for agent JWTs (ADR-0027). Set a ≥256-bit secret in production.")]
+    [Secret]
+    readonly string AuthJwtSigningKey = "";
+
     // Populated by Provision when it applies; read by Up. Empty when Provision
     // ran in dry-run, in which case Up uses a placeholder token for its own
     // dry-run output and refuses to proceed if asked to apply for real.
@@ -413,7 +423,8 @@ class Build : FalloutBuild
                 ConnectorToken:   token,
                 ImageTag:         ImageTag,
                 ComposeSourceDir: composeSource,
-                DryRun:           DryRun));
+                DryRun:           DryRun,
+                JwtSigningKey:    AuthJwtSigningKey));
 
             if (result.ExitCode != 0)
             {

--- a/docs/adr/0027-jwt-hmac-cross-api-auth.md
+++ b/docs/adr/0027-jwt-hmac-cross-api-auth.md
@@ -1,8 +1,19 @@
 # 27. JWT/HMAC-signed agent tokens across Auth + game APIs
 
-- Status: Proposed
+- Status: Accepted (implemented in phase 5c3, #279)
 - Date: 2026-05-28
 - Deciders: Chris
+
+> **Implementation note (5c3).** The JWT rides the existing `X-Agent-Token`
+> header as an opaque string rather than `Authorization: Bearer`, so no agent
+> change was needed (a JWT is just a longer token). Game APIs therefore verify
+> it inside the existing `IAgentTokenAuthenticator` seam (a
+> `HybridAgentTokenAuthenticator` that tries JWT-via-`JsonWebTokenHandler`
+> first, then the legacy hash-DB path) instead of ASP.NET `JwtBearer`
+> middleware — same HS256 verification, fits the established wire protocol.
+> CoI API auth wiring lands with its endpoints in 5c5; the agent re-pair
+> banner + `token-format=jwt` deeplink param + operator docs are deferred
+> follow-ups (the agent already works unchanged).
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,4 +47,4 @@ ADRs are numbered sequentially starting at `0001`. The filename is
 | [0024](0024-agent-v1-shape.md) | Game agent v1 PoC — shape, wire protocol, distribution | Accepted |
 | [0025](0025-agent-auth-catalogue-handover.md) | Agent auth & catalogue handover model | Accepted |
 | [0026](0026-onion-layered-src-with-product-split.md) | Onion-layered `src/` with per-game product split | Accepted (supersedes namespace-refactor clause of [0020](0020-rebrand-to-erp-for-factory-games.md); reaffirms [0004](0004-use-onion-architecture.md)) |
-| [0027](0027-jwt-hmac-cross-api-auth.md) | JWT/HMAC-signed agent tokens across Auth + game APIs | Proposed (partial supersession of [0025](0025-agent-auth-catalogue-handover.md) §3) |
+| [0027](0027-jwt-hmac-cross-api-auth.md) | JWT/HMAC-signed agent tokens across Auth + game APIs | Accepted (implemented 5c3; partial supersession of [0025](0025-agent-auth-catalogue-handover.md) §3) |

--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -1,15 +1,24 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Shared HMAC signing key for agent JWTs (ADR-0027 / 5c3). The Auth API mints
+// with it; the game APIs verify locally with the same value (no DB hit). In
+// prod this is a Fallout [Secret] baked into stack.env on every API container;
+// here we inject one fixed dev key so all binaries agree under `dotnet run`.
+// NOT a production secret — overridden by Auth__JwtSigningKey from stack.env.
+const string devJwtSigningKey = "erp-for-factory-games-local-apphost-hs256-dev-key-0123456789ab";
+
 // Auth API owns player + agent-token aggregate per ADR-0026. Phase 5c2
-// landed the /players/* + /api/me endpoints + DevPlayerBootstrap here.
+// landed the /players/* + /api/me endpoints + DevPlayerBootstrap here; 5c3
+// added JWT minting (it signs with the shared key above).
 var authApi = builder.AddProject<Projects.Erp_Presentation_Api_Auth>("auth-api")
+    .WithEnvironment("Auth__JwtSigningKey", devJwtSigningKey)
     .WithHttpHealthCheck("/health");
 
 // Sat API waits for Auth to be healthy first — both binaries hit the same
 // SQLite file via EF migrations at startup; concurrent migrate races would
-// lock the DB. Phase 5c3 splits the DbContext so each binary owns its own
-// schema and the ordering goes away.
+// lock the DB. It verifies agent JWTs locally with the same shared key.
 var apiService = builder.AddProject<Projects.Satisfactory_Presentation_Api>("apiservice")
+    .WithEnvironment("Auth__JwtSigningKey", devJwtSigningKey)
     .WithHttpHealthCheck("/health")
     .WaitFor(authApi);
 

--- a/src/Presentation/Api/Erp.Presentation.Api.Auth/Program.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Auth/Program.cs
@@ -19,12 +19,9 @@ builder.AddServiceDefaults();
 builder.Services.AddErpInfrastructure(builder.Configuration);
 builder.Services.AddErpPersistence(builder.Configuration);
 
-// AgentTokenAuthenticator + DevPlayerBootstrap (the auth-side scope).
-builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection(AuthOptions.SectionName));
-builder.Services.Configure<AgentTokenAuthenticatorOptions>(
-    builder.Configuration.GetSection(AgentTokenAuthenticatorOptions.SectionName));
-builder.Services.AddMemoryCache();
-builder.Services.AddSingleton<IAgentTokenAuthenticator, AgentTokenAuthenticator>();
+// Agent-token auth pipeline (ADR-0027 / 5c3): hybrid JWT-or-legacy
+// authenticator + the AgentTokenJwt signer the mint endpoint uses.
+builder.Services.AddAgentTokenAuth(builder.Configuration);
 builder.Services.AddHostedService<DevPlayerBootstrap>();
 
 // ICurrentPlayer + ICatalogueStorage are needed transitively by
@@ -106,6 +103,7 @@ app.MapPost("/players/{id:guid}/agent-tokens", async (
     IPlayerRepository players,
     IAgentTokenRepository tokens,
     IAgentTokenHasher hasher,
+    AgentTokenJwt jwtSigner,
     TimeProvider clock,
     CancellationToken ct) =>
 {
@@ -117,21 +115,26 @@ app.MapPost("/players/{id:guid}/agent-tokens", async (
         ? $"Agent {DateTime.UtcNow:yyyy-MM-dd}"
         : request!.Label!.Trim();
 
-    var plaintext = hasher.MintPlaintext();
-    var hash = hasher.Hash(plaintext);
+    // ADR-0027: mint a JWT carrying sub=playerId, jti=tokenId. The AgentToken
+    // row still exists for revocation + audit (and the legacy hybrid path);
+    // its hash column holds the hash of the JWT so the row stays consistent,
+    // but game APIs verify the JWT by signature, not by that hash.
+    var now = clock.GetUtcNow().UtcDateTime;
+    var tokenId = AgentTokenId.New();
+    var jwt = jwtSigner.Sign(playerId, tokenId, now);
     var token = new AgentToken(
-        AgentTokenId.New(),
+        tokenId,
         playerId,
         label,
-        hash,
-        clock.GetUtcNow().UtcDateTime);
+        hasher.Hash(jwt),
+        now);
     await tokens.AddAsync(token, ct).ConfigureAwait(false);
     await tokens.SaveChangesAsync(ct).ConfigureAwait(false);
 
     return Results.Json(new
     {
         id = token.Id.Value,
-        plaintext,
+        plaintext = jwt,
         label = token.Label,
         createdUtc = token.CreatedUtc,
     }, statusCode: 201);

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/AgentTokenAuthExtensions.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/AgentTokenAuthExtensions.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Erp.Presentation.Api.Common;
+
+/// <summary>
+/// Registers the agent-token auth pipeline shared by the Auth API and every
+/// game API (ADR-0027 / phase 5c3): the hybrid JWT-or-legacy authenticator,
+/// the JWT signer/verifier, and the options they bind.
+/// </summary>
+public static class AgentTokenAuthExtensions
+{
+    /// <summary>
+    /// Wires <see cref="IAgentTokenAuthenticator"/> as the
+    /// <see cref="HybridAgentTokenAuthenticator"/> (JWT verified locally, with a
+    /// legacy <c>eafg_*</c> DB fallback) plus the <see cref="AgentTokenJwt"/>
+    /// signer/verifier. Idempotent for the options binds.
+    /// </summary>
+    public static IServiceCollection AddAgentTokenAuth(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<AuthOptions>(configuration.GetSection(AuthOptions.SectionName));
+        services.Configure<AgentTokenAuthenticatorOptions>(
+            configuration.GetSection(AgentTokenAuthenticatorOptions.SectionName));
+        services.AddMemoryCache();
+
+        // JWT signer/verifier — shared HMAC key from Auth:JwtSigningKey.
+        services.AddSingleton<AgentTokenJwt>();
+
+        // Legacy hash-DB authenticator as a concrete singleton; the hybrid
+        // wraps it for the eafg_* fallback during the deprecation window.
+        services.AddSingleton<AgentTokenAuthenticator>();
+        services.AddSingleton<IAgentTokenAuthenticator, HybridAgentTokenAuthenticator>();
+
+        return services;
+    }
+}

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/AgentTokenJwt.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/AgentTokenJwt.cs
@@ -1,0 +1,120 @@
+using System.Text;
+using Erp.Domain.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Erp.Presentation.Api.Common;
+
+/// <summary>
+/// Mints + verifies HMAC-SHA256 (HS256) agent JWTs per ADR-0027.
+///
+/// <para>
+/// The Auth API <see cref="Sign"/>s a token on mint; game APIs
+/// <see cref="ValidateAsync"/> it locally with the same shared key — no DB
+/// round-trip, which is the architectural point of phase 5c3 (game APIs stop
+/// reaching into the Auth API's <c>AgentTokens</c> table per request).
+/// </para>
+///
+/// <para>
+/// Claims (ADR-0027 §1): <c>sub</c> = player id, <c>jti</c> = AgentToken id
+/// (for revocation/audit), <c>iat</c>/<c>nbf</c>/<c>exp</c>, <c>iss</c>,
+/// <c>aud</c>. The token rides the existing <c>X-Agent-Token</c> header as an
+/// opaque string, so no agent change is needed — a JWT is just a longer token.
+/// </para>
+/// </summary>
+public sealed class AgentTokenJwt
+{
+    private static readonly JsonWebTokenHandler Handler = new();
+
+    private readonly SymmetricSecurityKey _key;
+    private readonly SigningCredentials _signing;
+    private readonly string _issuer;
+    private readonly string _audience;
+    private readonly TimeSpan _lifetime;
+    private readonly ILogger<AgentTokenJwt> _logger;
+
+    public AgentTokenJwt(IOptions<AuthOptions> options, ILogger<AgentTokenJwt> logger)
+    {
+        var opts = options.Value;
+        _logger = logger;
+
+        if (string.IsNullOrWhiteSpace(opts.JwtSigningKey))
+        {
+            _logger.LogWarning(
+                "Auth:JwtSigningKey is empty — using the dev fallback signing key. " +
+                "This is fine for local dev/tests but MUST be set in production (stack.env).");
+        }
+
+        _key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(opts.EffectiveJwtSigningKey));
+        _signing = new SigningCredentials(_key, SecurityAlgorithms.HmacSha256);
+        _issuer = opts.JwtIssuer;
+        _audience = opts.JwtAudience;
+        _lifetime = TimeSpan.FromDays(Math.Max(1, opts.JwtLifetimeDays));
+    }
+
+    /// <summary>
+    /// Sign a JWT for the given player + AgentToken id. <paramref name="nowUtc"/>
+    /// is the issued-at; expiry is <c>now + JwtLifetimeDays</c>.
+    /// </summary>
+    public string Sign(PlayerId playerId, AgentTokenId tokenId, DateTime nowUtc)
+    {
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _issuer,
+            Audience = _audience,
+            IssuedAt = nowUtc,
+            NotBefore = nowUtc,
+            Expires = nowUtc.Add(_lifetime),
+            SigningCredentials = _signing,
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = playerId.Value.ToString(),
+                ["jti"] = tokenId.Value.ToString(),
+            },
+        };
+        return Handler.CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// Validate signature + issuer + audience + lifetime (30s clock skew).
+    /// Returns the carried <c>sub</c>/<c>jti</c> on success. Never throws —
+    /// a malformed/expired/forged token returns <c>false</c> so the caller can
+    /// fall through to the legacy <c>eafg_*</c> path during the hybrid window.
+    /// </summary>
+    public async Task<AgentTokenJwtResult> ValidateAsync(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return AgentTokenJwtResult.Invalid;
+
+        var result = await Handler.ValidateTokenAsync(token, new TokenValidationParameters
+        {
+            ValidIssuer = _issuer,
+            ValidAudience = _audience,
+            IssuerSigningKey = _key,
+            ValidateIssuerSigningKey = true,
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromSeconds(30),
+        }).ConfigureAwait(false);
+
+        if (!result.IsValid) return AgentTokenJwtResult.Invalid;
+
+        if (!result.Claims.TryGetValue("sub", out var sub) ||
+            !result.Claims.TryGetValue("jti", out var jti) ||
+            !Guid.TryParse(sub?.ToString(), out var playerId) ||
+            !Guid.TryParse(jti?.ToString(), out var tokenId))
+        {
+            return AgentTokenJwtResult.Invalid;
+        }
+
+        return new AgentTokenJwtResult(true, new PlayerId(playerId), new AgentTokenId(tokenId));
+    }
+}
+
+/// <summary>Outcome of <see cref="AgentTokenJwt.ValidateAsync"/>.</summary>
+public readonly record struct AgentTokenJwtResult(bool IsValid, PlayerId PlayerId, AgentTokenId TokenId)
+{
+    public static readonly AgentTokenJwtResult Invalid = new(false, default, default);
+}

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/AuthOptions.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/AuthOptions.cs
@@ -20,4 +20,40 @@ public sealed class AuthOptions
 
     /// <summary>Display name used when seeding the dev player.</summary>
     public string DevPlayerDisplayName { get; set; } = "Dev Player";
+
+    // ---- JWT/HMAC agent-token auth (ADR-0027 / phase 5c3) -------------------
+
+    /// <summary>
+    /// HMAC-SHA256 signing key shared between the Auth API (mints) and the
+    /// game APIs (verify locally, no DB hit). ≥256-bit secret. Flows via the
+    /// <c>Auth__JwtSigningKey</c> env var — baked into <c>stack.env</c> as a
+    /// Fallout <c>[Secret]</c> in prod, injected by the AppHost in local dev.
+    /// Empty means "dev fallback key" (logged, dev-only — never ship empty).
+    /// </summary>
+    public string JwtSigningKey { get; set; } = "";
+
+    /// <summary>JWT <c>iss</c> claim. Game APIs validate against this.</summary>
+    public string JwtIssuer { get; set; } = "erp-for-factory.games/auth";
+
+    /// <summary>JWT <c>aud</c> claim. Game APIs validate against this.</summary>
+    public string JwtAudience { get; set; } = "erp-for-factory.games/agents";
+
+    /// <summary>
+    /// Token lifetime in days (ADR-0027 §1). Long-lived — agents re-pair on
+    /// expiry. Default 365.
+    /// </summary>
+    public int JwtLifetimeDays { get; set; } = 365;
+
+    /// <summary>
+    /// Dev-only fallback signing key used when <see cref="JwtSigningKey"/> is
+    /// blank, so a fresh checkout + the test suite work without configuration.
+    /// 256 bits of fixed bytes — NOT a secret, never used in prod (prod sets
+    /// JwtSigningKey via stack.env). Mirrors the DevPlayerId dev-shortcut.
+    /// </summary>
+    public const string DevFallbackSigningKey =
+        "erp-for-factory-games-dev-only-hs256-signing-key-do-not-ship-0001";
+
+    /// <summary>The effective key: configured value, or the dev fallback.</summary>
+    public string EffectiveJwtSigningKey =>
+        string.IsNullOrWhiteSpace(JwtSigningKey) ? DevFallbackSigningKey : JwtSigningKey;
 }

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/Erp.Presentation.Api.Common.csproj
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/Erp.Presentation.Api.Common.csproj
@@ -18,6 +18,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <!-- HS256 agent JWT mint/verify (ADR-0027 / 5c3). JsonWebTokenHandler +
+         SymmetricSecurityKey/SigningCredentials (via transitive
+         Microsoft.IdentityModel.Tokens). Not in the ASP.NET shared framework. -->
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/HybridAgentTokenAuthenticator.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/HybridAgentTokenAuthenticator.cs
@@ -1,0 +1,80 @@
+using Erp.Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Erp.Presentation.Api.Common;
+
+/// <summary>
+/// Hybrid agent-token authenticator for the ADR-0027 rollout window. Accepts
+/// either:
+/// <list type="bullet">
+///   <item>a <b>JWT</b> (HS256, verified locally via <see cref="AgentTokenJwt"/>
+///         — no DB round-trip), or</item>
+///   <item>a legacy opaque <c>eafg_*</c> token (validated by the hash-based
+///         <see cref="AgentTokenAuthenticator"/>, which hits the DB).</item>
+/// </list>
+///
+/// <para>
+/// JWT is tried first because it's the steady-state path; only tokens that
+/// fail JWT validation fall through to the legacy lookup, so a real
+/// <c>eafg_*</c> token still authenticates during the deprecation window.
+/// The two paths are logged separately (debug) so the operator can watch
+/// legacy traffic drop to zero before the legacy path is removed (a follow-up
+/// per ADR-0027 §4).
+/// </para>
+/// </summary>
+internal sealed class HybridAgentTokenAuthenticator : IAgentTokenAuthenticator
+{
+    private readonly AgentTokenJwt _jwt;
+    private readonly AgentTokenAuthenticator _legacy;
+    private readonly ILogger<HybridAgentTokenAuthenticator> _logger;
+
+    public HybridAgentTokenAuthenticator(
+        AgentTokenJwt jwt,
+        AgentTokenAuthenticator legacy,
+        ILogger<HybridAgentTokenAuthenticator> logger)
+    {
+        _jwt = jwt;
+        _legacy = legacy;
+        _logger = logger;
+    }
+
+    public async Task<AgentAuthResult> AuthenticateAsync(string? plaintextToken, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(plaintextToken))
+        {
+            return AgentAuthResult.MissingHeader();
+        }
+
+        // JWTs are three base64url segments joined by dots; the legacy format
+        // is `eafg_<base64>`. Cheap pre-check avoids running the JWT handler on
+        // an obviously-legacy token, but ValidateAsync is the real arbiter.
+        if (LooksLikeJwt(plaintextToken))
+        {
+            var jwt = await _jwt.ValidateAsync(plaintextToken).ConfigureAwait(false);
+            if (jwt.IsValid)
+            {
+                _logger.LogDebug("Agent authenticated via JWT (jti {TokenId}).", jwt.TokenId);
+                return AgentAuthResult.Ok(jwt.PlayerId, jwt.TokenId);
+            }
+            // A JWT-shaped token that fails validation (forged/expired/wrong
+            // key) is NOT retried against the legacy DB path — it can't be an
+            // eafg_ token. Reject outright.
+            _logger.LogDebug("JWT-shaped agent token failed validation.");
+            return AgentAuthResult.Unknown();
+        }
+
+        var legacy = await _legacy.AuthenticateAsync(plaintextToken, cancellationToken).ConfigureAwait(false);
+        if (legacy.IsAuthenticated)
+        {
+            _logger.LogDebug("Agent authenticated via legacy eafg_ token (jti {TokenId}).", legacy.TokenId);
+        }
+        return legacy;
+    }
+
+    public void Invalidate(AgentTokenId tokenId) => _legacy.Invalidate(tokenId);
+
+    // A compact JWT has exactly two '.' separators and starts with the
+    // base64url of `{"alg":...`, i.e. "eyJ". Legacy tokens start "eafg_".
+    private static bool LooksLikeJwt(string token) =>
+        token.StartsWith("eyJ", StringComparison.Ordinal) && token.Count(c => c == '.') == 2;
+}

--- a/src/Presentation/Api/Satisfactory.Presentation.Api/Program.cs
+++ b/src/Presentation/Api/Satisfactory.Presentation.Api/Program.cs
@@ -43,17 +43,13 @@ builder.Services.AddSingleton<IAgentUploadStatus, AgentUploadStatus>();
 builder.Services.Configure<AgentLogsOptions>(builder.Configuration.GetSection("AgentLogs"));
 builder.Services.AddSingleton<IAgentLogsStore, AgentLogsStore>();
 
-// Agent auth pipeline (ADR-0025 §3). Hash-based lookup with an
-// IMemoryCache hot-path and LastSeenUtc write-debounce. The hashing
-// algorithm itself is wired by AddErpInfrastructure (Sha256TokenHasher).
-builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection(AuthOptions.SectionName));
-builder.Services.Configure<AgentTokenAuthenticatorOptions>(
-    builder.Configuration.GetSection(AgentTokenAuthenticatorOptions.SectionName));
-builder.Services.AddMemoryCache();
-builder.Services.AddSingleton<IAgentTokenAuthenticator, AgentTokenAuthenticator>();
-// DevPlayerBootstrap moved to the Auth API in phase 5c2 — the Player + AgentToken
-// aggregate is owned there. Sat still validates tokens by hash via the shared
-// authenticator until 5c3 swaps token verification to JWT-via-HMAC.
+// Agent auth pipeline (ADR-0027 / 5c3). Hybrid authenticator: a JWT minted by
+// the Auth API is verified locally via the shared HMAC key (no DB hit), with a
+// fallback to the legacy eafg_* hash-DB lookup during the deprecation window.
+// The hashing algorithm + token repo are wired by AddErpInfrastructure.
+builder.Services.AddAgentTokenAuth(builder.Configuration);
+// DevPlayerBootstrap stays on the Auth API (phase 5c2) — the Player + AgentToken
+// aggregate is owned there.
 
 // Current-player accessor (ADR-0025 §2). v2 returns Auth:DevPlayerId; the
 // future authenticated adapter swaps this registration for an HttpContext-

--- a/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/JwtAuthTests.cs
+++ b/test/Presentation/Api/Satisfactory.Presentation.Api.Tests/JwtAuthTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Erp.Domain.Common;
+using Erp.Presentation.Api.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Satisfactory.Presentation.Api.Tests;
+
+/// <summary>
+/// ADR-0027 / phase 5c3 — JWT/HMAC agent-token auth.
+///
+/// Unit coverage for <see cref="AgentTokenJwt"/> sign/verify, plus an
+/// integration check that a JWT presented in <c>X-Agent-Token</c> authenticates
+/// against the Satisfactory API <b>without</b> any DB row — the whole point of
+/// moving game-API verification off the Auth DB.
+/// </summary>
+public sealed class JwtAuthTests : IClassFixture<AgentEndpointsTests.AgentApiFactory>
+{
+    private readonly AgentEndpointsTests.AgentApiFactory _factory;
+
+    public JwtAuthTests(AgentEndpointsTests.AgentApiFactory factory) => _factory = factory;
+
+    // A signer over default AuthOptions → uses the dev fallback key, which is
+    // exactly what the API-under-test uses when no Auth:JwtSigningKey is set.
+    private static AgentTokenJwt DevSigner(AuthOptions? options = null) =>
+        new(Options.Create(options ?? new AuthOptions()), NullLogger<AgentTokenJwt>.Instance);
+
+    [Fact]
+    public async Task Sign_then_validate_round_trips_player_and_token_ids()
+    {
+        var signer = DevSigner();
+        var playerId = new PlayerId(Guid.NewGuid());
+        var tokenId = AgentTokenId.New();
+
+        var jwt = signer.Sign(playerId, tokenId, DateTime.UtcNow);
+        var result = await signer.ValidateAsync(jwt);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(playerId, result.PlayerId);
+        Assert.Equal(tokenId, result.TokenId);
+    }
+
+    [Fact]
+    public async Task Tampered_token_is_rejected()
+    {
+        var signer = DevSigner();
+        var jwt = signer.Sign(new PlayerId(Guid.NewGuid()), AgentTokenId.New(), DateTime.UtcNow);
+
+        // Flip a character in the signature segment.
+        var tampered = jwt[..^1] + (jwt[^1] == 'A' ? 'B' : 'A');
+
+        var result = await signer.ValidateAsync(tampered);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Expired_token_is_rejected()
+    {
+        var signer = DevSigner(new AuthOptions { JwtLifetimeDays = 1 });
+        // Issue it ~400 days ago so exp (iat + 1 day) is well in the past.
+        var jwt = signer.Sign(new PlayerId(Guid.NewGuid()), AgentTokenId.New(), DateTime.UtcNow.AddDays(-400));
+
+        var result = await signer.ValidateAsync(jwt);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Token_signed_with_a_different_key_is_rejected()
+    {
+        var minter = DevSigner(new AuthOptions { JwtSigningKey = "a-completely-different-256-bit-key-aaaaaaaaaaaaaaaaaaaa" });
+        var verifier = DevSigner(new AuthOptions { JwtSigningKey = "the-other-256-bit-key-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" });
+
+        var jwt = minter.Sign(new PlayerId(Guid.NewGuid()), AgentTokenId.New(), DateTime.UtcNow);
+
+        var result = await verifier.ValidateAsync(jwt);
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Garbage_and_empty_tokens_are_rejected()
+    {
+        var signer = DevSigner();
+        Assert.False((await signer.ValidateAsync("")).IsValid);
+        Assert.False((await signer.ValidateAsync("not-a-jwt")).IsValid);
+        Assert.False((await signer.ValidateAsync("eafg_legacy-style-token")).IsValid);
+    }
+
+    [Fact]
+    public async Task Jwt_in_X_Agent_Token_authenticates_without_a_DB_row()
+    {
+        // Fresh factory — no Player, no AgentToken row anywhere. A valid JWT
+        // must still authenticate (the hybrid authenticator's JWT path never
+        // touches the DB). We assert 415 (content-type) rather than 401, which
+        // proves auth passed.
+        await using var fresh = new AgentEndpointsTests.AgentApiFactory();
+        var client = fresh.CreateClient();
+
+        var jwt = DevSigner().Sign(new PlayerId(fresh.DevPlayerId), AgentTokenId.New(), DateTime.UtcNow);
+
+        var content = new StringContent("not a save", System.Text.Encoding.UTF8, "text/plain");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/agent/savegames/satisfactory")
+        {
+            Content = content,
+        };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", jwt);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Forged_jwt_in_X_Agent_Token_is_rejected_401()
+    {
+        await using var fresh = new AgentEndpointsTests.AgentApiFactory();
+        var client = fresh.CreateClient();
+
+        // Signed with a key the API doesn't know → must 401, not 415.
+        var forged = DevSigner(new AuthOptions { JwtSigningKey = "attacker-controlled-key-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" })
+            .Sign(new PlayerId(fresh.DevPlayerId), AgentTokenId.New(), DateTime.UtcNow);
+
+        var content = new ByteArrayContent(new byte[] { 0x01 });
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/agent/savegames/satisfactory") { Content = content };
+        request.Headers.TryAddWithoutValidation("X-Agent-Token", forged);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/tools/Erp.Deploy/Deployer.cs
+++ b/tools/Erp.Deploy/Deployer.cs
@@ -11,7 +11,8 @@ public sealed record DeployRequest(
     string ConnectorToken,
     string ImageTag,
     string ComposeSourceDir,
-    bool DryRun);
+    bool DryRun,
+    string JwtSigningKey = "");
 
 public sealed record DeployResult(int ExitCode);
 
@@ -53,7 +54,7 @@ public sealed class Deployer
     {
         var remote = req.Options.Remote;
         var conn = _resolver.Resolve(remote);
-        var stackEnv = StackEnvBuilder.Build(req.ConnectorToken, req.ImageTag);
+        var stackEnv = StackEnvBuilder.Build(req.ConnectorToken, req.ImageTag, req.JwtSigningKey);
         var uploads = BuildUploads(req.ComposeSourceDir, remote.StackDir, stackEnv);
 
         // Pre-flight: complain about missing source files before touching SSH.

--- a/tools/Erp.Deploy/StackEnvBuilder.cs
+++ b/tools/Erp.Deploy/StackEnvBuilder.cs
@@ -11,11 +11,19 @@ namespace Erp.Deploy;
 // Isolating the byte production makes it trivially testable in isolation.
 public static class StackEnvBuilder
 {
-    public static byte[] Build(string connectorToken, string imageTag)
+    public static byte[] Build(string connectorToken, string imageTag, string jwtSigningKey = "")
     {
         var sb = new StringBuilder();
         sb.Append("TUNNEL_TOKEN=").Append(connectorToken).Append('\n');
         sb.Append("ERP_IMAGE_TAG=").Append(imageTag).Append('\n');
+        // Shared agent-JWT signing key (ADR-0027 / 5c3). Compose maps this to
+        // Auth__JwtSigningKey on every API container so the Auth API and the
+        // game APIs share one HMAC key. Omitted when blank so the APIs keep
+        // their dev fallback (which logs a warning) rather than an empty key.
+        if (!string.IsNullOrEmpty(jwtSigningKey))
+        {
+            sb.Append("Auth__JwtSigningKey=").Append(jwtSigningKey).Append('\n');
+        }
         return Encoding.UTF8.GetBytes(sb.ToString());
     }
 }


### PR DESCRIPTION
Implements [ADR-0027](docs/adr/0027-jwt-hmac-cross-api-auth.md) (#279). Game APIs now verify agent tokens **locally** via a shared HMAC key instead of reaching into the Auth API''s `AgentTokens` table per request — the boundary 5c2 left open.

## What landed

- **`AgentTokenJwt`** — HS256 sign/verify via `JsonWebTokenHandler`. Claims per ADR-0027 §1 (`sub`=playerId, `jti`=tokenId, `iat`/`nbf`/`exp`, `iss`, `aud`), 30s skew, never throws.
- **`HybridAgentTokenAuthenticator`** — tries JWT (verified locally, **no DB**) first; falls back to the legacy `eafg_*` hash-DB path during the deprecation window. Both paths logged separately.
- **`AddAgentTokenAuth()`** DI extension wires it across the Auth + Satisfactory APIs.
- **Auth API mint** signs a JWT and returns it; the `AgentToken` row persists for revocation/audit (`jti` = row id).
- **Shared key** `Auth:JwtSigningKey`: AppHost injects a dev key to both APIs; prod gets it as a Fallout `[Secret]` (`AuthJwtSigningKey`) → `stack.env`. Empty → logged dev fallback.

## Wire choice (vs ADR wording)

The JWT rides the existing `X-Agent-Token` header as an opaque string → **zero agent change** (a JWT is just a longer token), and verification fits the existing `IAgentTokenAuthenticator` seam rather than ASP.NET `JwtBearer` middleware. Same HS256. Noted in the ADR.

## Verification

- Build green, `dotnet format` clean.
- `Satisfactory.Presentation.Api.Tests` **36/0/5** — 7 new JWT tests including a **no-DB-row auth proof** and a **forged-token → 401**; the legacy `eafg_*` integration tests still pass via the hybrid fallback.

## Deferred (on #279)

CoI API auth wiring (rides 5c5 with its endpoints), the "re-pair to upgrade" banner, the `token-format=jwt` deeplink param, operator docs — the agent already works unchanged.

> **Note on the Keycloak direction:** 5c3 is **agent/machine** auth (the headless agent → game APIs). It''s orthogonal to adopting Keycloak for **human** login (the Auth Web punch-out / OAuth). The durable win here — game APIs verify locally, never touching the Auth DB — adapts cleanly if agent tokens later move to Keycloak-issued RS256 (swap HS256-shared-key for JWKS in the same authenticator seam). Discussing the Keycloak architecture separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)