### PR TITLE
feat(0028): IAuthBackend seam in Web.Auth — hardcoded backend + cookie sign-in

### DIFF
--- a/ErpForFactoryGames.slnx
+++ b/ErpForFactoryGames.slnx
@@ -102,6 +102,9 @@
   <Folder Name="/test/Infrastructure/Persistence/Erp.Infrastructure.Persistence.Tests/">
     <Project Path="test/Infrastructure/Persistence/Erp.Infrastructure.Persistence.Tests/Erp.Infrastructure.Persistence.Tests.csproj" />
   </Folder>
+  <Folder Name="/test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/">
+    <Project Path="test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/Erp.Presentation.Web.Auth.Tests.csproj" />
+  </Folder>
   <Folder Name="/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/">
     <Project Path="test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/Satisfactory.Presentation.Web.UiTests.csproj" />
   </Folder>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/AuthLandingOptions.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/AuthLandingOptions.cs
@@ -1,0 +1,37 @@
+namespace Erp.Presentation.Web.Auth;
+
+/// <summary>
+/// Configuration for the auth landing's pluggable backend (ADR-0028 §7/§8).
+/// Bound from the <c>Auth</c> section.
+/// </summary>
+public sealed class AuthLandingOptions
+{
+    public const string SectionName = "Auth";
+
+    /// <summary>
+    /// Which <see cref="IAuthBackend"/> backs sign-in:
+    /// <list type="bullet">
+    ///   <item><c>hardcoded</c> — a single configured username/password. The
+    ///         default; lets the app run with zero IdP infrastructure.</item>
+    ///   <item><c>keycloak</c> — OIDC against Keycloak. Deferred (issue #292);
+    ///         selecting it today throws at startup with a pointer.</item>
+    /// </list>
+    /// </summary>
+    public string Backend { get; set; } = "hardcoded";
+
+    /// <summary>Credentials for the <c>hardcoded</c> backend.</summary>
+    public HardcodedCredentials Hardcoded { get; set; } = new();
+
+    public sealed class HardcodedCredentials
+    {
+        public string Username { get; set; } = "admin";
+
+        /// <summary>
+        /// Dev default so a fresh checkout can sign in. Override in production
+        /// (or switch <see cref="Backend"/> to <c>keycloak</c> once #292 lands).
+        /// </summary>
+        public string Password { get; set; } = "erp-dev";
+
+        public string DisplayName { get; set; } = "Local User";
+    }
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Account.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Account.razor
@@ -1,4 +1,5 @@
 @page "/account"
+@attribute [Authorize]
 
 <PageTitle>ERP — Account</PageTitle>
 

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Agents.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Agents.razor
@@ -1,4 +1,5 @@
 @page "/agents"
+@attribute [Authorize]
 
 <PageTitle>ERP — Agents</PageTitle>
 

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Home.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Pages/Home.razor
@@ -1,30 +1,75 @@
 @page "/"
+@inject NavigationManager Nav
 
 <PageTitle>ERP — Sign in</PageTitle>
 
-<h1>Sign in</h1>
+<AuthorizeView>
+    <Authorized>
+        <h1>Signed in</h1>
+        <MudText Class="mb-4">
+            You're signed in as <strong>@context.User.Identity?.Name</strong>.
+        </MudText>
+        <MudStack Row="true" Spacing="2" Class="mb-4">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/account">Account</MudButton>
+            <MudButton Variant="Variant.Outlined" Href="/agents">Agents</MudButton>
+        </MudStack>
+        <form method="post" action="/auth/logout">
+            <AntiforgeryToken />
+            <button type="submit" class="erp-link-button">Sign out</button>
+        </form>
+    </Authorized>
+    <NotAuthorized>
+        <h1>Sign in</h1>
 
-<MudText Class="mb-4">
-    Single account across every ERP for Factory Games planner. This is the central
-    identity punch-out — game frontends
-    (<MudLink Href="https://satisfactory.erp-for-factory.games">Satisfactory</MudLink>,
-    <MudLink Href="https://coi.erp-for-factory.games">Captain of Industry</MudLink>)
-    redirect here to sign in and manage their account, per
-    <MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/docs/adr/0026-onion-layered-src-with-product-split.md">ADR-0026</MudLink>.
-</MudText>
+        <MudText Class="mb-4">
+            Single account across every ERP for Factory Games planner. This is the central
+            identity landing — game frontends
+            (<MudLink Href="https://satisfactory.erp-for-factory.games">Satisfactory</MudLink>,
+            <MudLink Href="https://coi.erp-for-factory.games">Captain of Industry</MudLink>)
+            redirect here to sign in, per
+            <MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/blob/main/docs/adr/0028-keycloak-as-identity-provider.md">ADR-0028</MudLink>.
+        </MudText>
 
-<MudAlert Severity="Severity.Info" Class="mb-4">
-    Scaffold only. Provider sign-in (Google, Microsoft, Apple, Steam) and the
-    OAuth flow land in a later phase — this project carves out the slot they
-    wire into without touching the game frontends.
-</MudAlert>
+        @if (_showError)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-4">Invalid username or password.</MudAlert>
+        }
 
-<MudPaper Class="pa-4" Elevation="0" Outlined="true">
-    <MudText Typo="Typo.subtitle2" Class="mb-3">Sign in with</MudText>
-    <MudStack Spacing="2">
-        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Google — coming soon</MudButton>
-        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Microsoft — coming soon</MudButton>
-        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Apple — coming soon</MudButton>
-        <MudButton Variant="Variant.Outlined" Color="Color.Default" Disabled="true" FullWidth="true">Steam — coming soon</MudButton>
-    </MudStack>
-</MudPaper>
+        <MudPaper Class="pa-4 mb-4" Elevation="0" Outlined="true">
+            @* Native form POST — a static form can't SignInAsync from inside the
+               interactive circuit, so it posts to the /auth/login endpoint
+               (ADR-0028 §7). AntiforgeryToken + UseAntiforgery protect it. *@
+            <form method="post" action="/auth/login">
+                <AntiforgeryToken />
+                <input type="hidden" name="returnUrl" value="@_returnUrl" />
+                <div class="mb-3">
+                    <label for="username" class="erp-label">Username</label>
+                    <input id="username" name="username" type="text" autocomplete="username" required class="erp-input" />
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="erp-label">Password</label>
+                    <input id="password" name="password" type="password" autocomplete="current-password" required class="erp-input" />
+                </div>
+                <button type="submit" class="erp-submit">Sign in</button>
+            </form>
+        </MudPaper>
+
+        <MudAlert Severity="Severity.Info">
+            Social sign-in (Google, Microsoft, Apple, Steam) arrives when Keycloak is wired in
+            (<MudLink Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/292">#292</MudLink>).
+            Until then this landing uses the configured local credentials.
+        </MudAlert>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private bool _showError;
+    private string? _returnUrl;
+
+    protected override void OnInitialized()
+    {
+        var query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(Nav.ToAbsoluteUri(Nav.Uri).Query);
+        _showError = query.ContainsKey("error");
+        _returnUrl = query.TryGetValue("returnUrl", out var r) ? r.ToString() : null;
+    }
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Routes.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/Routes.razor
@@ -1,6 +1,12 @@
 <Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
+            <NotAuthorized>
+                <MudAlert Severity="Severity.Info" Class="ma-4">
+                    Please <MudLink Href="/">sign in</MudLink> to view this page.
+                </MudAlert>
+            </NotAuthorized>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/_Imports.razor
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Components/_Imports.razor
@@ -6,6 +6,8 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using MudBlazor
 @using Erp.Presentation.Web.Auth
 @using Erp.Presentation.Web.Auth.Components

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/HardcodedCredentialAuthBackend.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/HardcodedCredentialAuthBackend.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Erp.Presentation.Web.Auth;
+
+/// <summary>
+/// <see cref="IAuthBackend"/> backed by a single configured username/password
+/// (<c>Auth:Hardcoded:*</c>). The zero-infrastructure default so the app runs
+/// without standing up Keycloak (ADR-0028 §7). Comparison is constant-time
+/// (SHA-256 then fixed-time compare) so it doesn't leak the secret by timing.
+/// </summary>
+public sealed class HardcodedCredentialAuthBackend : IAuthBackend
+{
+    private readonly AuthLandingOptions.HardcodedCredentials _creds;
+
+    public HardcodedCredentialAuthBackend(IOptions<AuthLandingOptions> options)
+        => _creds = options.Value.Hardcoded;
+
+    public string Name => "hardcoded";
+
+    public Task<AuthBackendResult> ValidateAsync(string username, string password, CancellationToken cancellationToken = default)
+    {
+        // Evaluate both halves regardless of the first so the work — and thus
+        // the timing — doesn't depend on whether the username matched.
+        var userOk = ConstantTimeEquals(username, _creds.Username);
+        var passOk = ConstantTimeEquals(password, _creds.Password);
+
+        // Refuse to authenticate against an empty configured password — that
+        // would let anyone in if the secret was never set.
+        var ok = userOk & passOk && !string.IsNullOrEmpty(_creds.Password);
+
+        return Task.FromResult(ok
+            ? AuthBackendResult.Ok(subject: $"local:{_creds.Username}", _creds.DisplayName)
+            : AuthBackendResult.Fail());
+    }
+
+    // Hash both sides to a fixed 32-byte digest first so FixedTimeEquals gets
+    // equal-length inputs and the comparison doesn't leak length either.
+    private static bool ConstantTimeEquals(string? a, string? b)
+    {
+        Span<byte> ha = stackalloc byte[32];
+        Span<byte> hb = stackalloc byte[32];
+        SHA256.HashData(Encoding.UTF8.GetBytes(a ?? string.Empty), ha);
+        SHA256.HashData(Encoding.UTF8.GetBytes(b ?? string.Empty), hb);
+        return CryptographicOperations.FixedTimeEquals(ha, hb);
+    }
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/IAuthBackend.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/IAuthBackend.cs
@@ -1,0 +1,30 @@
+namespace Erp.Presentation.Web.Auth;
+
+/// <summary>
+/// Pluggable sign-in backend for the auth landing (ADR-0028 §7). The landing
+/// owns the UI + cookie session; the backend just answers "are these
+/// credentials valid, and who is this?". Today the only implementation is
+/// <see cref="HardcodedCredentialAuthBackend"/>; the Keycloak OIDC backend is
+/// deferred to issue #292.
+/// </summary>
+public interface IAuthBackend
+{
+    /// <summary>Short name for logging/diagnostics (e.g. <c>hardcoded</c>).</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Validate a username/password. Returns a successful result carrying a
+    /// stable subject id + display name, or <see cref="AuthBackendResult.Fail"/>.
+    /// Implementations should be constant-time w.r.t. the secret.
+    /// </summary>
+    Task<AuthBackendResult> ValidateAsync(string username, string password, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Outcome of <see cref="IAuthBackend.ValidateAsync"/>.</summary>
+public readonly record struct AuthBackendResult(bool Succeeded, string Subject, string DisplayName)
+{
+    public static AuthBackendResult Fail() => new(false, "", "");
+
+    public static AuthBackendResult Ok(string subject, string displayName) =>
+        new(true, subject, displayName);
+}

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
@@ -1,5 +1,10 @@
+using System.Security.Claims;
 using Erp.Hosting.ServiceDefaults;
+using Erp.Presentation.Web.Auth;
 using Erp.Presentation.Web.Auth.Components;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
 using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,13 +22,41 @@ builder.Services.AddOutputCache();
 
 // The auth web frontend talks to the central Auth API for player + agent-token
 // operations. Service discovery resolves "auth-api" via Aspire in dev and the
-// container name in production. No typed client yet — the scaffold has no live
-// calls; that arrives when the OAuth flow + agent-management UI land here.
+// container name in production.
 builder.Services.AddHttpClient("auth-api", client =>
 {
     // "https+http://" prefers HTTPS over HTTP — see https://aka.ms/dotnet/sdschemes
     client.BaseAddress = new("https+http://auth-api");
 });
+
+// ---- Auth landing backend (ADR-0028 §7/§8) --------------------------------
+// Pluggable sign-in: "hardcoded" (a configured username/password — the
+// zero-infra default) or "keycloak" (OIDC, deferred to #292). The landing
+// owns the cookie session; the backend just validates credentials.
+builder.Services.Configure<AuthLandingOptions>(builder.Configuration.GetSection(AuthLandingOptions.SectionName));
+
+var authBackend = builder.Configuration[$"{AuthLandingOptions.SectionName}:Backend"] ?? "hardcoded";
+if (string.Equals(authBackend, "keycloak", StringComparison.OrdinalIgnoreCase))
+{
+    // Keycloak OIDC backend is not implemented yet — see ADR-0028 §8 / issue #292.
+    // Fail fast with a clear message rather than silently doing nothing.
+    throw new NotSupportedException(
+        "Auth:Backend=keycloak is not implemented yet (deferred — see issue #292). " +
+        "Use Auth:Backend=hardcoded for now.");
+}
+builder.Services.AddSingleton<IAuthBackend, HardcodedCredentialAuthBackend>();
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/";
+        options.LogoutPath = "/auth/logout";
+        options.AccessDeniedPath = "/";
+        options.ExpireTimeSpan = TimeSpan.FromDays(7);
+        options.SlidingExpiration = true;
+    });
+builder.Services.AddAuthorization();
+builder.Services.AddCascadingAuthenticationState();
 
 var app = builder.Build();
 
@@ -36,11 +69,53 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.UseAntiforgery();
 
 app.UseOutputCache();
 
 app.MapStaticAssets();
+
+// ---- Sign-in / sign-out endpoints ------------------------------------------
+// Plain form-POST endpoints (the official Blazor Web App auth pattern): a
+// static-rendered <form> can't call SignInAsync from inside an interactive
+// circuit, so the landing posts here. Antiforgery is enforced by UseAntiforgery
+// + the <AntiforgeryToken /> in the form.
+app.MapPost("/auth/login", async (
+    HttpContext http,
+    IAuthBackend backend,
+    [FromForm] string username,
+    [FromForm] string password,
+    [FromForm] string? returnUrl) =>
+{
+    var result = await backend.ValidateAsync(username ?? string.Empty, password ?? string.Empty);
+    if (!result.Succeeded)
+    {
+        return Results.Redirect("/?error=1");
+    }
+
+    var claims = new List<Claim>
+    {
+        new(ClaimTypes.NameIdentifier, result.Subject),
+        new(ClaimTypes.Name, result.DisplayName),
+    };
+    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+    await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+
+    // Only honour local redirect targets — never an absolute/off-site URL.
+    var target = !string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+        ? returnUrl
+        : "/account";
+    return Results.Redirect(target);
+});
+
+app.MapPost("/auth/logout", async (HttpContext http) =>
+{
+    await http.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+    return Results.Redirect("/");
+});
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
@@ -48,3 +123,6 @@ app.MapRazorComponents<App>()
 app.MapDefaultEndpoints();
 
 app.Run();
+
+// Exposed for WebApplicationFactory<Program> in the tests.
+public partial class Program { }

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.json
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/appsettings.json
@@ -5,5 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Auth": {
+    "//": "Backend: 'hardcoded' (configured username/password — default, zero IdP infra) or 'keycloak' (OIDC, deferred — see #292). ADR-0028.",
+    "Backend": "hardcoded",
+    "Hardcoded": {
+      "Username": "admin",
+      "Password": "erp-dev",
+      "DisplayName": "Local User"
+    }
+  }
 }

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/wwwroot/app.css
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/wwwroot/app.css
@@ -11,3 +11,45 @@ code {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.9em;
 }
+
+/* Plain-HTML sign-in form (native POST to /auth/login). MudBlazor inputs are
+   interactive components that don't post in a native form, so the credential
+   form uses plain elements styled to sit reasonably inside the MudPaper. */
+.erp-label {
+    display: block;
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+    opacity: 0.8;
+}
+
+.erp-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    font-size: 1rem;
+}
+
+.erp-submit {
+    padding: 0.6rem 1.5rem;
+    border: none;
+    border-radius: 4px;
+    background: #594ae2; /* MudBlazor default primary */
+    color: #fff;
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.erp-submit:hover { background: #4133c9; }
+
+.erp-link-button {
+    border: none;
+    background: none;
+    color: #f64e62;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.95rem;
+}

--- a/test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/Erp.Presentation.Web.Auth.Tests.csproj
+++ b/test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/Erp.Presentation.Web.Auth.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Erp.Presentation.Web.Auth.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Presentation\Web\Erp.Presentation.Web.Auth\Erp.Presentation.Web.Auth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/HardcodedCredentialAuthBackendTests.cs
+++ b/test/Presentation/Web/Erp.Presentation.Web.Auth.Tests/HardcodedCredentialAuthBackendTests.cs
@@ -1,0 +1,60 @@
+using Erp.Presentation.Web.Auth;
+using Microsoft.Extensions.Options;
+
+namespace Erp.Presentation.Web.Auth.Tests;
+
+/// <summary>
+/// ADR-0028 §7 — the hardcoded sign-in backend. Security-relevant credential
+/// check, so it gets direct coverage (right creds in, wrong creds out, no
+/// blank-password bypass).
+/// </summary>
+public sealed class HardcodedCredentialAuthBackendTests
+{
+    private static HardcodedCredentialAuthBackend Backend(string user, string pass, string display = "Local User") =>
+        new(Options.Create(new AuthLandingOptions
+        {
+            Hardcoded = new AuthLandingOptions.HardcodedCredentials
+            {
+                Username = user,
+                Password = pass,
+                DisplayName = display,
+            },
+        }));
+
+    [Fact]
+    public async Task Correct_credentials_succeed_with_subject_and_display_name()
+    {
+        var result = await Backend("admin", "s3cret", "Chris").ValidateAsync("admin", "s3cret");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("local:admin", result.Subject);
+        Assert.Equal("Chris", result.DisplayName);
+    }
+
+    [Theory]
+    [InlineData("admin", "wrong")]      // bad password
+    [InlineData("nope", "s3cret")]      // bad username
+    [InlineData("admin", "")]           // empty supplied password
+    [InlineData("", "")]                // nothing supplied
+    public async Task Wrong_credentials_fail(string user, string pass)
+    {
+        var result = await Backend("admin", "s3cret").ValidateAsync(user, pass);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task Blank_configured_password_never_authenticates()
+    {
+        // A misconfiguration (no password set) must not become an open door,
+        // even if the caller also sends a blank password.
+        var result = await Backend("admin", "").ValidateAsync("admin", "");
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task Username_match_is_case_sensitive()
+    {
+        var result = await Backend("admin", "s3cret").ValidateAsync("Admin", "s3cret");
+        Assert.False(result.Succeeded);
+    }
+}


### PR DESCRIPTION
Lands the app-side auth seam ADR-0028 calls for **before** Keycloak. `Erp.Presentation.Web.Auth` is now a real (if minimal) auth landing over a pluggable backend; the Keycloak OIDC backend stays deferred to #292.

## What landed

- **`IAuthBackend`** + `AuthBackendResult` — validate `(username, password)` → subject + display name.
- **`HardcodedCredentialAuthBackend`** — single configured credential (`Auth:Hardcoded:*`), constant-time compare (SHA-256 + `FixedTimeEquals`), refuses a blank configured password. The zero-IdP-infra default.
- **Backend toggle** `Auth:Backend`: `hardcoded` (default) or `keycloak` — the latter fails fast at startup with a pointer to #292 until that backend lands.
- **Cookie auth**: `/auth/login` + `/auth/logout` native form-POST endpoints (the official Blazor Web App pattern — a static form can''t `SignInAsync` inside the interactive circuit), local-redirect-only `returnUrl`, 7-day sliding cookie.
- **Sign-in page**: real username/password form (`AntiforgeryToken`-protected) + an `AuthorizeView` signed-in state with sign-out; `/account` + `/agents` are now `[Authorize]`; `Routes` uses `AuthorizeRouteView`.
- **New test project** `Erp.Presentation.Web.Auth.Tests` — 7 backend tests (right/wrong/blank creds, case sensitivity, no blank-password bypass).

## Verification

Build green, `dotnet format` clean, backend tests **7/0**.

> The credential **form + cookie flow** follows the standard Blazor Web App pattern; runtime browser verification (a Playwright pass over Web.Auth) isn''t wired yet — the security-critical credential check is unit-tested here, and the form/cookie wiring is the documented pattern.

Next: 5c5 (CoI API + rollout), then Keycloak (#292) if time allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)