### PR TITLE
build(deploy): auth-api container image (Dockerfile + release-images matrix)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -38,6 +38,8 @@ jobs:
             dockerfile: src/Presentation/Web/Satisfactory.Presentation.Web/Dockerfile
           - image: erp-api
             dockerfile: src/Presentation/Api/Satisfactory.Presentation.Api/Dockerfile
+          - image: erp-auth-api
+            dockerfile: src/Presentation/Api/Erp.Presentation.Api.Auth/Dockerfile
 
     steps:
       - name: Checkout

--- a/src/Presentation/Api/Erp.Presentation.Api.Auth/Dockerfile
+++ b/src/Presentation/Api/Erp.Presentation.Api.Auth/Dockerfile
@@ -1,0 +1,59 @@
+# Multi-stage build for the central Auth API (player + agent-token + JWT mint).
+# Build context = repo root:
+#   docker build -f src/Presentation/Api/Erp.Presentation.Api.Auth/Dockerfile -t erp-auth-api .
+
+ARG DOTNET_VERSION=10.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+WORKDIR /src
+
+RUN --mount=type=secret,id=github_token \
+    test -s /run/secrets/github_token \
+    || (echo "GITHUB_TOKEN secret missing. Pass: docker build --secret id=github_token,env=GITHUB_TOKEN ..." && exit 1)
+
+COPY nuget.config Directory.Build.props version.json ./
+COPY src/Presentation/Api/Erp.Presentation.Api.Auth/Erp.Presentation.Api.Auth.csproj src/Presentation/Api/Erp.Presentation.Api.Auth/
+COPY src/Presentation/Api/Erp.Presentation.Api.Common/Erp.Presentation.Api.Common.csproj src/Presentation/Api/Erp.Presentation.Api.Common/
+COPY src/Hosting/Erp.Hosting.ServiceDefaults/Erp.Hosting.ServiceDefaults.csproj src/Hosting/Erp.Hosting.ServiceDefaults/
+COPY src/Application/Erp.Application.Common/Erp.Application.Common.csproj src/Application/Erp.Application.Common/
+COPY src/Domain/Erp.Domain.Common/Erp.Domain.Common.csproj             src/Domain/Erp.Domain.Common/
+COPY src/Infrastructure/Erp.Infrastructure/Erp.Infrastructure.csproj   src/Infrastructure/Erp.Infrastructure/
+COPY src/Infrastructure/Persistence/Erp.Infrastructure.Persistence/Erp.Infrastructure.Persistence.csproj src/Infrastructure/Persistence/Erp.Infrastructure.Persistence/
+COPY src/Infrastructure/Satisfactory.Infrastructure/Satisfactory.Infrastructure.csproj src/Infrastructure/Satisfactory.Infrastructure/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet restore src/Presentation/Api/Erp.Presentation.Api.Auth/Erp.Presentation.Api.Auth.csproj
+
+COPY src/ src/
+COPY .git .git/
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    dotnet publish src/Presentation/Api/Erp.Presentation.Api.Auth/Erp.Presentation.Api.Auth.csproj \
+        --configuration Release \
+        --no-restore \
+        --output /app/publish
+
+# -----------------------------------------------------------------------------
+# Runtime
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS runtime
+WORKDIR /app
+
+# Pre-create the volume mount point with the runtime user's ownership — Docker
+# would otherwise create it root-owned and SQLite (running as `app`, uid 1654)
+# couldn't open the DB. The Auth API shares the plans DB volume with erp-api
+# (it owns the Player + AgentToken tables in the same PlanDbContext until the
+# DB split lands). Mount point exposed via compose.yml:
+#   /data  -> SQLite plans DB (ADR-0018), shared with erp-api
+RUN mkdir -p /data \
+    && chown -R app:app /data
+
+USER app
+
+COPY --from=build --chown=app:app /app/publish ./
+
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Erp.Presentation.Api.Auth.dll"]


### PR DESCRIPTION
First concrete step toward the "Satisfactory + agent" deploy — the Auth API needs to be a deployable container (token minting + `/api/me` live on it after 5c2, so the agent/live-save flow depends on it).

## What landed
- **`Erp.Presentation.Api.Auth/Dockerfile`** — mirrors the proven Sat-API multi-stage build (same restore-layer COPY set; pre-creates `/data`, which it shares with `erp-api` for the plans DB until the DB split lands). Verified locally: `dotnet publish` of the Auth API succeeds.
- **`release-images.yml`** matrix gains `erp-auth-api` → built/pushed on the next `v*` tag.

## What this does NOT do yet (remaining blockers for a working agent deploy)

1. **compose service** for `erp-auth-api` (sister repo) — share the `erp-db` volume + the `Auth__JwtSigningKey` from `stack.env` (already plumbed in 5c3) + `depends_on` ordering for migrations + `erp-web` service-discovery (`services__auth-api__http__0`).
2. **shared-DB decision** — `auth-api` + `erp-api` currently share one SQLite `PlanDbContext`. Two containers writing one SQLite file works for a single-user homelab test (WAL + ordering), but Postgres is the right production answer. Decision needed.
3. **deploy-tooling gap (the real blocker):** the agent pairs via `GET /api/me`, which moved to **auth-api**, but `IngressReconciler`/`HostnameSpec` only emit host→service rules (no `Path`), so the Cloudflare ingress **can''t express** the `/api/me`→auth-api + `/api/*`→erp-api split. There''s also an unresolved two-mechanisms question (the C# reconciler from `erp-deploy.json` vs the static `ingress.json` that `Build.cs`/`Deployer.cs` reference). This needs a tooling change + a live deploy loop to validate.

So: image is ready; the deploy wiring + that ingress-tooling gap are the next focused step (best done with a deploy loop you drive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)