### PR TITLE
feat(deploy): ingress path-split so /api/me routes to auth-api

### DIFF
--- a/deploy/erp-deploy.json
+++ b/deploy/erp-deploy.json
@@ -7,6 +7,16 @@
         "Hostnames": [
           {
             "Hostname": "satisfactory.erp-for-factory.games",
+            "Path": "/api/me",
+            "Service": "http://erp-auth-api:8080"
+          },
+          {
+            "Hostname": "satisfactory.erp-for-factory.games",
+            "Path": "/api/.*",
+            "Service": "http://erp-api:8080"
+          },
+          {
+            "Hostname": "satisfactory.erp-for-factory.games",
             "Service": "http://erp-web:8080"
           }
         ],

--- a/test/Deploy/Erp.Deploy.Tests/IngressReconcilerTests.cs
+++ b/test/Deploy/Erp.Deploy.Tests/IngressReconcilerTests.cs
@@ -1,0 +1,64 @@
+using Erp.Deploy.Configuration;
+using Erp.Deploy.Reconcile.Cloudflare;
+
+namespace Erp.Deploy.Tests;
+
+/// <summary>
+/// Covers the path-aware ingress rule build (ADR-0027 / 5c2 routing split):
+/// /api/me → auth-api, /api/* → erp-api, bare hostname → erp-web, catch-all last.
+/// Order is load-bearing — Cloudflare evaluates rules top-down.
+/// </summary>
+public sealed class IngressReconcilerTests
+{
+    [Fact]
+    public void BuildTarget_preserves_order_emits_paths_and_appends_catchall()
+    {
+        var spec = new TunnelSpec
+        {
+            Name = "erp",
+            Catchall = "http_status:404",
+            Hostnames =
+            {
+                new HostnameSpec { Hostname = "satisfactory.erp-for-factory.games", Path = "/api/me", Service = "http://erp-auth-api:8080" },
+                new HostnameSpec { Hostname = "satisfactory.erp-for-factory.games", Path = "/api/.*", Service = "http://erp-api:8080" },
+                new HostnameSpec { Hostname = "satisfactory.erp-for-factory.games", Service = "http://erp-web:8080" },
+            },
+        };
+
+        var rules = IngressReconciler.BuildTarget(spec).Config.Ingress;
+
+        Assert.Equal(4, rules.Count);
+
+        // /api/me must come BEFORE /api/.* or Cloudflare's top-down match would
+        // send /api/me to erp-api.
+        Assert.Equal("/api/me", rules[0].Path);
+        Assert.Equal("http://erp-auth-api:8080", rules[0].Service);
+
+        Assert.Equal("/api/.*", rules[1].Path);
+        Assert.Equal("http://erp-api:8080", rules[1].Service);
+
+        // Bare hostname rule carries no path.
+        Assert.Null(rules[2].Path);
+        Assert.Equal("http://erp-web:8080", rules[2].Service);
+
+        // Catch-all is last and has neither hostname nor path.
+        Assert.Null(rules[3].Hostname);
+        Assert.Null(rules[3].Path);
+        Assert.Equal("http_status:404", rules[3].Service);
+    }
+
+    [Fact]
+    public void BuildTarget_bare_hostname_stays_pathless()
+    {
+        var spec = new TunnelSpec
+        {
+            Name = "erp",
+            Hostnames = { new HostnameSpec { Hostname = "x.example", Service = "http://erp-web:8080" } },
+        };
+
+        var rules = IngressReconciler.BuildTarget(spec).Config.Ingress;
+
+        Assert.Equal("x.example", rules[0].Hostname);
+        Assert.Null(rules[0].Path);
+    }
+}

--- a/tools/Erp.Deploy/Configuration/DeployOptions.cs
+++ b/tools/Erp.Deploy/Configuration/DeployOptions.cs
@@ -22,6 +22,17 @@ public sealed class TunnelSpec
 public sealed class HostnameSpec
 {
     public string Hostname { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional Cloudflare ingress path matcher (regex), e.g. <c>/api/me</c>.
+    /// When set the rule only matches that path on the hostname — used to split
+    /// <c>/api/me</c> (→ auth-api) from the rest of <c>/api/*</c> (→ erp-api)
+    /// per ADR-0027 / 5c2. Null matches the whole hostname. Order matters: list
+    /// more-specific path rules BEFORE the bare-hostname rule (Cloudflare
+    /// evaluates top-down).
+    /// </summary>
+    public string? Path { get; init; }
+
     public string Service { get; init; } = string.Empty;
 }
 

--- a/tools/Erp.Deploy/Erp.Deploy.csproj
+++ b/tools/Erp.Deploy/Erp.Deploy.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Erp.Deploy.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.51.1" />
     <!-- Managed SSH + SFTP. Sidesteps the remote-shell heredoc quoting that broke deploy.ps1. -->

--- a/tools/Erp.Deploy/Reconcile/Cloudflare/IngressReconciler.cs
+++ b/tools/Erp.Deploy/Reconcile/Cloudflare/IngressReconciler.cs
@@ -56,12 +56,16 @@ public sealed class IngressReconciler
             note: $"{target.Config.Ingress.Count} rules");
     }
 
-    private static CfIngressConfig BuildTarget(TunnelSpec spec)
+    // internal for unit testing — pure transform of a TunnelSpec into the
+    // ordered Cloudflare ingress rule list.
+    internal static CfIngressConfig BuildTarget(TunnelSpec spec)
     {
         var rules = new List<CfIngressRule>();
         foreach (var h in spec.Hostnames)
         {
-            rules.Add(new CfIngressRule { Hostname = h.Hostname, Service = h.Service });
+            // Path emitted only when set (CfIngressRule omits null paths), so a
+            // bare-hostname rule stays bare and a path rule narrows to it.
+            rules.Add(new CfIngressRule { Hostname = h.Hostname, Path = h.Path, Service = h.Service });
         }
         // Catch-all MUST be last. Cloudflare evaluates top-down.
         rules.Add(new CfIngressRule { Service = spec.Catchall });


### PR DESCRIPTION
Closes the deploy-tooling gap blocking the Satisfactory+agent deploy. The agent pairs via `GET /api/me` (moved to auth-api in 5c2), but `IngressReconciler` only emitted host→service rules — so a deployed agent couldn''t validate.

- `HostnameSpec.Path` (nullable regex matcher); `BuildTarget` emits it (`CfIngressRule` + the diff/format already supported `Path`). Made `BuildTarget` `internal` for testing.
- `deploy/erp-deploy.json`: ordered rules — `/api/me`→`erp-auth-api`, `/api/.*`→`erp-api`, bare host→`erp-web` (top-down, most-specific first).
- `IngressReconcilerTests` (2 tests): order, path emission, catch-all-last, bare-host-stays-pathless. `Erp.Deploy.Tests` **15/0**.

The sister-repo compose (`erp-auth-api` service + shared DB + JWT key + `services__auth-api__http__0`) + the static `ingress.json` are authored in the submodule; the deploy run is yours. Runbook in the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)