### PR TITLE
fix(deploy): docker ps status table printed the raw Go template

### DIFF
--- a/tools/Erp.Deploy/Deployer.cs
+++ b/tools/Erp.Deploy/Deployer.cs
@@ -86,7 +86,11 @@ public sealed class Deployer
         {
             $"cd '{remote.StackDir}' && docker compose --env-file stack.env pull",
             $"cd '{remote.StackDir}' && docker compose --env-file stack.env up -d",
-            $"docker ps --filter name=erp- --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'",
+            // Plain (non-interpolated) string: Docker's Go template needs literal
+            // double braces ({{.Names}}). In a C# $"" interpolated string `{{`
+            // collapses to a single `{`, so the remote `docker ps` printed the
+            // raw template instead of values. No interpolation needed here.
+            "docker ps --filter name=erp- --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'",
         };
 
         foreach (var cmd in commands)


### PR DESCRIPTION
The post-`Up` `docker ps` status readout used a C# interpolated string, so the Go-template double braces collapsed (`{{.Names}}` → `{.Names}`) and Docker printed the literal template instead of container names/status. Switched to a plain string literal so the braces survive.

Cosmetic — the deploy itself worked; surfaced during the live v1.0.25 Satisfactory + auth-api deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)