### PR TITLE
fix(web): agent-first onboarding + hydration-race fix (#260 #268 #269 #270)

### DIFF
--- a/src/Presentation/Web/Satisfactory.Presentation.Web/AgentManagementOptions.cs
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/AgentManagementOptions.cs
@@ -32,4 +32,28 @@ public sealed class AgentManagementOptions
     /// </para>
     /// </summary>
     public string PairingApiBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the catalogue is sourced from a paired agent (hosted topology)
+    /// rather than a path on the API server's own filesystem (dev / self-host).
+    ///
+    /// <para>
+    /// When <c>true</c> (the hosted default) the setup wizard leads with an
+    /// agent install + pair step and the catalogue step waits for the agent's
+    /// <c>Docs.json</c> upload — the server-local filesystem picker is hidden
+    /// because, in the hosted shape, browsing the API host's filesystem
+    /// enumerates the LXC, not the user's machine (issues #268 / #270).
+    /// </para>
+    ///
+    /// <para>
+    /// When <c>false</c> (set in <c>appsettings.Development.json</c> for the
+    /// AppHost-driven local run, where <c>Catalogue:AllowServerLocalFallback</c>
+    /// is on) the legacy filesystem-picker flow is kept — the API and the
+    /// browser are the same machine, so picking a local <c>Docs.json</c> works.
+    /// </para>
+    ///
+    /// Tracks the deployment-model decision in #267; flip to a server-reported
+    /// capability once that lands.
+    /// </summary>
+    public bool CatalogueViaAgent { get; set; } = true;
 }

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/MyAgents.razor
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/MyAgents.razor
@@ -65,7 +65,7 @@ else
             <MudButton StartIcon="@Icons.Material.Filled.Refresh"
                        Color="Color.Primary" Variant="Variant.Outlined"
                        OnClick="TriggerReIngestAsync"
-                       Disabled="_reIngestBusy || _currentPlayer is null"
+                       Disabled="!_interactive || _reIngestBusy || _currentPlayer is null"
                        data-testid="reingest-button">
                 Re-ingest catalogue
             </MudButton>
@@ -101,7 +101,7 @@ else
             <MudButton StartIcon="@Icons.Material.Filled.Add"
                        Color="Color.Primary" Variant="Variant.Filled"
                        OnClick="ShowMintDialogAsync"
-                       Disabled="_currentPlayer is null"
+                       Disabled="!_interactive || _currentPlayer is null"
                        data-testid="add-agent-button">
                 Add an agent
             </MudButton>
@@ -142,6 +142,7 @@ else
                         <MudIconButton Icon="@Icons.Material.Filled.Delete"
                                        Color="Color.Error" Size="Size.Small"
                                        OnClick="() => RevokeAsync(token)"
+                                       Disabled="!_interactive"
                                        data-testid="revoke-button"
                                        title="Revoke token" />
                     }
@@ -166,11 +167,28 @@ else
     private string? _loadError;
     private CancellationTokenSource? _pollCts;
 
+    // #260: the prerendered HTML shows the action buttons enabled, but their
+    // C# click handlers aren't wired until the InteractiveServer circuit
+    // attaches. Clicks landing in that window are silently dropped. Gate every
+    // interactive control on this flag — flipped true once the first
+    // interactive render runs (firstRender is only ever true post-hydration,
+    // never during prerender) — so a button only looks clickable once it is.
+    private bool _interactive;
+
     protected override async Task OnInitializedAsync()
     {
         if (!Options.Value.Enabled) { _loading = false; return; }
         await LoadAsync();
         StartCataloguePolling();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender && Options.Value.Enabled)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
     }
 
     private async Task LoadAsync()

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/Settings.razor
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/Settings.razor
@@ -5,6 +5,7 @@
 @inject NavigationManager Nav
 @inject SetupState SetupState
 @inject IDialogService DialogService
+@inject Microsoft.Extensions.Options.IOptions<AgentManagementOptions> Options
 @using Satisfactory.Presentation.Web.Components.Shared
 
 <PageTitle>Settings</PageTitle>
@@ -50,34 +51,49 @@ else
     }
 }
 
-<div class="mt-4">
-    <MudTextField @bind-Value="pathInput"
-                  Label="Path to the Satisfactory Docs directory or a specific locale file"
-                  Placeholder="@DocsPathPlaceholder"
-                  Variant="Variant.Outlined"
-                  Margin="Margin.Dense"
-                  HelperTextOnFocus="false"
-                  ReadOnly="true"
-                  Adornment="Adornment.End"
-                  AdornmentIcon="@Icons.Material.Filled.FolderOpen"
-                  AdornmentAriaLabel="Browse for Docs folder"
-                  OnAdornmentClick="BrowseCataloguePath"
-                  Class="mb-1" />
-    <MudText Typo="Typo.caption" Class="d-block mb-2">
-        Either point at the <code>Docs</code> folder (we'll pick <code>en-US.json</code> automatically) or pass a specific
-        <code>&lt;locale&gt;.json</code> file. Resolution order at startup:
-        <code>ERP_SATISFACTORY_DOCS_PATH</code> env var → user-saved (this form) → <code>appsettings.json</code> →
-        Steam auto-detect.
-    </MudText>
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
-               Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isApplying)">
-        @(isApplying ? "Applying..." : "Apply")
-    </MudButton>
-    @if (!string.IsNullOrEmpty(message))
-    {
-        <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
-    }
-</div>
+@if (UseAgent)
+{
+    <div class="mt-4">
+        <MudText Typo="Typo.body2">
+            In this deployment the catalogue is uploaded by your <strong>agent</strong> — it finds
+            <code>Docs.json</code> in your game install and sends it automatically. There's nothing to
+            configure here. Pair or check your agent on the
+            <MudLink Href="/settings/agents">My Agents</MudLink> page, or trigger a re-upload with
+            <strong>Re-ingest catalogue</strong> there.
+        </MudText>
+    </div>
+}
+else
+{
+    <div class="mt-4">
+        <MudTextField @bind-Value="pathInput"
+                      Label="Path to the Satisfactory Docs directory or a specific locale file"
+                      Placeholder="@DocsPathPlaceholder"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      HelperTextOnFocus="false"
+                      ReadOnly="true"
+                      Adornment="Adornment.End"
+                      AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+                      AdornmentAriaLabel="Browse for Docs folder"
+                      OnAdornmentClick="BrowseCataloguePath"
+                      Class="mb-1" />
+        <MudText Typo="Typo.caption" Class="d-block mb-2">
+            Either point at the <code>Docs</code> folder (we'll pick <code>en-US.json</code> automatically) or pass a specific
+            <code>&lt;locale&gt;.json</code> file. Resolution order at startup:
+            <code>ERP_SATISFACTORY_DOCS_PATH</code> env var → user-saved (this form) → <code>appsettings.json</code> →
+            Steam auto-detect.
+        </MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
+                   Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isApplying)">
+            @(isApplying ? "Applying..." : "Apply")
+        </MudButton>
+        @if (!string.IsNullOrEmpty(message))
+        {
+            <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
+        }
+    </div>
+}
 
 <h2 class="mt-5">Setup wizard</h2>
 <div class="mt-3">
@@ -126,12 +142,14 @@ else
     private string mapBackdrop = "terrain";
     private string? mapMessage;
 
-    // Resolved server-side, so the hint reflects the OS hosting the app — which is
-    // the same machine the user is browsing from when they run it locally.
+    private bool UseAgent => Options.Value.CatalogueViaAgent;
+
+    // #269: only shown in dev/self-host (filesystem-picker) mode. Default to the
+    // Windows install path (largest user share) — the old OperatingSystem.IsMacOS()
+    // check ran server-side and reflected the *host* OS, which is meaningless once
+    // the browser and the API aren't the same machine.
     private static string DocsPathPlaceholder =>
-        OperatingSystem.IsMacOS()
-            ? "~/Library/Application Support/CrossOver/Bottles/Steam/drive_c/Program Files (x86)/Steam/steamapps/common/Satisfactory/CommunityResources/Docs"
-            : @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
+        @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
 
     private Severity StatusSeverity => status is null
         ? Severity.Info

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/Setup.razor
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Pages/Setup.razor
@@ -3,6 +3,7 @@
 @rendermode InteractiveServer
 @inject NavigationManager Nav
 @inject SetupState SetupState
+@inject Microsoft.Extensions.Options.IOptions<AgentManagementOptions> Options
 @using Satisfactory.Presentation.Web.Components.Setup
 
 <PageTitle>Setup</PageTitle>
@@ -71,32 +72,46 @@
 </MudContainer>
 
 @code {
-    private sealed record WizardStep(string Title, bool IsRequired, RenderFragment Body);
+    // IsComplete is null for optional steps; required steps carry a predicate
+    // that gates leaving the step and finishing the wizard.
+    private sealed record WizardStep(string Title, bool IsRequired, RenderFragment Body, Func<bool>? IsComplete = null);
 
     private enum StepState { Upcoming, Current, Complete }
 
     private List<WizardStep> steps = new();
     private int current;
     private bool catalogueComplete;
+    private bool agentComplete;
 
     protected override void OnInitialized()
     {
-        steps = new List<WizardStep>
+        steps = new List<WizardStep>();
+
+        // Hosted topology (#268): the catalogue + saves arrive from a paired
+        // agent, so onboarding has to start by getting one connected. In
+        // dev/self-host this step is omitted — the API can read the local
+        // filesystem directly.
+        if (Options.Value.CatalogueViaAgent)
         {
-            new("Catalogue (required)", IsRequired: true,
-                Body: @<CataloguePathStep CompletedChanged="OnCatalogueCompletedChanged" />),
-            new("Map backdrop", IsRequired: false,
-                Body: @<MapBackdropStep />),
-            new("First save", IsRequired: false,
-                Body: @<SaveIngestStep />),
-            new("Plan storage", IsRequired: false,
-                Body: @<PersistenceProviderStep />),
-        };
+            steps.Add(new("Agent (required)", IsRequired: true,
+                Body: @<AgentSetupStep CompletedChanged="OnAgentCompletedChanged" />,
+                IsComplete: () => agentComplete));
+        }
+
+        steps.Add(new("Catalogue (required)", IsRequired: true,
+            Body: @<CataloguePathStep CompletedChanged="OnCatalogueCompletedChanged" />,
+            IsComplete: () => catalogueComplete));
+        steps.Add(new("Map backdrop", IsRequired: false,
+            Body: @<MapBackdropStep />));
+        steps.Add(new("First save", IsRequired: false,
+            Body: @<SaveIngestStep />));
+        steps.Add(new("Plan storage", IsRequired: false,
+            Body: @<PersistenceProviderStep />));
     }
 
     private bool IsLastStep => current == steps.Count - 1;
-    private bool CanLeaveCurrent => !steps[current].IsRequired || catalogueComplete;
-    private bool CanFinish => catalogueComplete;
+    private bool CanLeaveCurrent => !steps[current].IsRequired || (steps[current].IsComplete?.Invoke() ?? true);
+    private bool CanFinish => steps.Where(s => s.IsRequired).All(s => s.IsComplete?.Invoke() ?? true);
 
     private StepState StateFor(int idx) =>
         idx < current ? StepState.Complete
@@ -144,6 +159,12 @@
     private void OnCatalogueCompletedChanged(bool completed)
     {
         catalogueComplete = completed;
+        StateHasChanged();
+    }
+
+    private void OnAgentCompletedChanged(bool completed)
+    {
+        agentComplete = completed;
         StateHasChanged();
     }
 

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Setup/AgentSetupStep.razor
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Setup/AgentSetupStep.razor
@@ -1,0 +1,204 @@
+@inject AuthApiClient Auth
+@inject PlannerApiClient Api
+@inject IDialogService DialogService
+@inject Microsoft.Extensions.Options.IOptions<AgentManagementOptions> Options
+@using Satisfactory.Presentation.Web.Components.Pages
+@implements IDisposable
+
+@* Required first step in the hosted topology (#268). The hosted webapp can't
+   see the user's filesystem — the planner's catalogue and savegames arrive
+   from a headless agent the user installs on their gaming machine, which polls
+   this server outbound-only. So onboarding has to start by getting that agent
+   installed and paired; only then can the catalogue step succeed.
+
+   "Complete" means the agent has actually phoned home — either a token shows a
+   LastSeen timestamp or a catalogue has been uploaded. A minted-but-never-run
+   token is not enough; we wait for proof the bridge works. *@
+
+<MudText Typo="Typo.body2" Class="mb-3">
+    The planner reads your factory from a small <strong>agent</strong> you install on the machine
+    where you play Satisfactory. It watches your save folder and uploads the game catalogue
+    (<code>Docs.json</code>) and your saves to this server — no inbound ports, it only dials out.
+</MudText>
+
+@if (_loadError is not null)
+{
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-3" Dense="true">@_loadError</MudAlert>
+}
+else if (_currentPlayer is null)
+{
+    <MudText><em>Loading…</em></MudText>
+}
+else
+{
+    <MudAlert Severity="@StatusSeverity" Variant="Variant.Outlined" Class="mb-3" data-testid="agent-step-status">
+        <MudText Typo="Typo.subtitle2"><strong>@StatusHeadline</strong></MudText>
+        <MudText Typo="Typo.caption">@StatusDetail</MudText>
+    </MudAlert>
+
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-3">
+        <MudButton StartIcon="@Icons.Material.Filled.Add"
+                   Color="Color.Primary" Variant="Variant.Filled"
+                   OnClick="ShowMintDialogAsync"
+                   Disabled="!_interactive"
+                   data-testid="agent-step-add-button">
+            @(_activeTokenCount > 0 ? "Pair another agent" : "Pair an agent")
+        </MudButton>
+        <MudButton Href="https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/latest"
+                   Target="_blank"
+                   StartIcon="@Icons.Material.Filled.Download"
+                   Variant="Variant.Outlined">
+            Download the agent
+        </MudButton>
+    </MudStack>
+
+    <MudText Typo="Typo.caption" Class="d-block mud-text-secondary">
+        Manage paired agents any time on the <MudLink Href="/settings/agents">My Agents</MudLink> page.
+        This step completes automatically once your agent connects.
+    </MudText>
+}
+
+@code {
+    [Parameter] public EventCallback<bool> CompletedChanged { get; set; }
+
+    /// <summary>Re-checks agent connectivity while the step is open.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+
+    private CurrentPlayerView? _currentPlayer;
+    private AgentTokenView[] _tokens = [];
+    private PlayerCatalogueStatusView? _catalogueStatus;
+    private string? _loadError;
+    private CancellationTokenSource? _pollCts;
+    private bool _lastEmittedCompleted;
+
+    // Same hydration-race guard as MyAgents (#260): the prerendered button is
+    // visible but its click handler isn't wired until the circuit attaches.
+    private bool _interactive;
+
+    private int _activeTokenCount => _tokens.Count(t => t.RevokedUtc is null);
+    private bool _agentSeen => _tokens.Any(t => t.RevokedUtc is null && t.LastSeenUtc is not null);
+    private bool _catalogueUploaded => _catalogueStatus?.Catalogue is not null;
+    private bool IsComplete => _agentSeen || _catalogueUploaded;
+
+    private Severity StatusSeverity =>
+        IsComplete ? Severity.Success
+        : _activeTokenCount > 0 ? Severity.Info
+        : Severity.Warning;
+
+    private string StatusHeadline =>
+        IsComplete ? "Agent connected."
+        : _activeTokenCount > 0 ? "Agent paired — waiting for it to connect…"
+        : "No agent paired yet.";
+
+    private string StatusDetail =>
+        IsComplete
+            ? (_catalogueUploaded
+                ? "Your agent has uploaded the game catalogue. You're ready to plan."
+                : "Your agent has checked in with the server.")
+        : _activeTokenCount > 0
+            ? "Start the agent on your gaming machine with the token you minted. It checks in within a minute or two of starting."
+            : "Pair an agent below, then run it on the machine where you play.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+        StartPolling();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _interactive = true;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            _currentPlayer = await Auth.GetCurrentPlayerAsync();
+            if (_currentPlayer is null)
+            {
+                _loadError = "No player provisioned. Check Auth:DevPlayerId on the server.";
+                return;
+            }
+            _tokens = await Auth.ListAgentTokensAsync(_currentPlayer.PlayerId);
+            _catalogueStatus = await Api.GetPlayerCatalogueAsync(_currentPlayer.PlayerId);
+        }
+        catch (Exception ex)
+        {
+            _loadError = ex.Message;
+        }
+        finally
+        {
+            await EmitCompletedAsync(IsComplete);
+        }
+    }
+
+    private void StartPolling()
+    {
+        _pollCts?.Cancel();
+        _pollCts = new CancellationTokenSource();
+        _ = PollAsync(_pollCts.Token);
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(PollInterval, ct);
+                if (_currentPlayer is null) continue;
+                try
+                {
+                    _tokens = await Auth.ListAgentTokensAsync(_currentPlayer.PlayerId, ct);
+                    _catalogueStatus = await Api.GetPlayerCatalogueAsync(_currentPlayer.PlayerId, ct);
+                    await EmitCompletedAsync(IsComplete);
+                    await InvokeAsync(StateHasChanged);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch
+                {
+                    // Best-effort — next tick retries.
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task ShowMintDialogAsync()
+    {
+        if (_currentPlayer is null) return;
+        var parameters = new DialogParameters
+        {
+            { nameof(MintAgentTokenDialog.PlayerId), _currentPlayer.PlayerId },
+            { nameof(MintAgentTokenDialog.PairingApiBaseUrl), Options.Value.PairingApiBaseUrl },
+        };
+        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<MintAgentTokenDialog>("Pair an agent", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled)
+        {
+            await LoadAsync();
+        }
+    }
+
+    private async Task EmitCompletedAsync(bool completed)
+    {
+        if (completed == _lastEmittedCompleted) return;
+        _lastEmittedCompleted = completed;
+        if (CompletedChanged.HasDelegate)
+        {
+            await CompletedChanged.InvokeAsync(completed);
+        }
+    }
+
+    public void Dispose()
+    {
+        _pollCts?.Cancel();
+        _pollCts?.Dispose();
+    }
+}

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Setup/CataloguePathStep.razor
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Components/Setup/CataloguePathStep.razor
@@ -1,67 +1,141 @@
 @inject PlannerApiClient Api
+@inject AuthApiClient Auth
 @inject IDialogService DialogService
+@inject Microsoft.Extensions.Options.IOptions<AgentManagementOptions> Options
 @using Satisfactory.Presentation.Web.Components.Shared
+@implements IDisposable
 
-@* Required step: points the planner at a Docs.json so the recipe graph can load.
-   Mirrors the catalogue section of Settings.razor so users see the same UX
-   whether they're onboarding or reconfiguring later. *@
+@* Required step: gets a Docs.json catalogue in front of the planner so the
+   recipe graph can load.
 
-<MudText Typo="Typo.body2" Class="mb-3">
-    The planner walks the recipe graph from Satisfactory's <code>Docs.json</code>.
-    Point us at the file or its containing <code>Docs</code> directory.
-</MudText>
+   Two shapes (issues #268 / #269 / #270):
+     • Hosted (CatalogueViaAgent=true) — the catalogue is uploaded by the
+       user's paired agent. We can't browse the user's filesystem from the
+       server (that would enumerate the LXC), so this step just reflects the
+       per-player upload status and completes when the agent's Docs.json lands.
+     • Dev / self-host (CatalogueViaAgent=false) — the API and the browser are
+       the same machine, so the legacy filesystem picker is offered. *@
 
-@if (status is null)
+@if (UseAgent)
 {
-    <MudText><em>Loading status...</em></MudText>
+    <MudText Typo="Typo.body2" Class="mb-3">
+        The planner walks the recipe graph from Satisfactory's <code>Docs.json</code>. Your
+        <strong>agent</strong> finds it in your game install and uploads it automatically —
+        nothing to pick here. This step completes once the upload arrives.
+    </MudText>
+
+    @if (agentStatus is null)
+    {
+        <MudText><em>Loading status…</em></MudText>
+    }
+    else
+    {
+        <MudAlert Severity="@AgentSeverity" Variant="Variant.Outlined" Class="mb-3" data-testid="catalogue-agent-status">
+            <MudText Typo="Typo.subtitle2"><strong>@AgentHeadline</strong></MudText>
+            @if (agentStatus.Catalogue is { } cat)
+            {
+                <MudText Typo="Typo.caption">
+                    Hash <code>@cat.DocsHash[..Math.Min(12, cat.DocsHash.Length)]</code> ·
+                    @($"{cat.SizeBytes / 1024:N0}") KB ·
+                    uploaded @cat.UploadedUtc.ToString("u")
+                </MudText>
+            }
+            else if (agentStatus.ReIngestRequested)
+            {
+                <MudText Typo="Typo.caption">Re-ingest queued — your agent will upload on its next check-in (~1 min).</MudText>
+            }
+            else
+            {
+                <MudText Typo="Typo.caption">
+                    Waiting for your agent to upload <code>Docs.json</code>. Make sure it's paired and running on your game machine.
+                </MudText>
+            }
+        </MudAlert>
+
+        <MudText Typo="Typo.caption" Class="d-block mud-text-secondary">
+            Not connected yet? Pair or check your agent on the
+            <MudLink Href="/settings/agents">My Agents</MudLink> page.
+        </MudText>
+    }
 }
 else
 {
-    <MudAlert Severity="@StatusSeverity" Variant="Variant.Outlined" Class="mb-3">
-        <MudText Typo="Typo.subtitle2"><strong>@StatusHeadline</strong></MudText>
-        @if (!string.IsNullOrEmpty(status.Source))
-        {
-            <MudText Typo="Typo.caption">Source: <code>@status.Source</code></MudText>
-        }
-        @if (status.IsLoaded)
-        {
-            <MudText Typo="Typo.caption">
-                @status.ItemCount items · @status.BuildingCount buildings · @status.RecipeCount recipes
-            </MudText>
-        }
-    </MudAlert>
-}
+    <MudText Typo="Typo.body2" Class="mb-3">
+        The planner walks the recipe graph from Satisfactory's <code>Docs.json</code>.
+        Point us at the file or its containing <code>Docs</code> directory.
+    </MudText>
 
-<MudTextField @bind-Value="pathInput"
-              Label="Path to the Satisfactory Docs directory or a specific locale file"
-              Placeholder="@DocsPathPlaceholder"
-              Variant="Variant.Outlined"
-              Margin="Margin.Dense"
-              ReadOnly="true"
-              Adornment="Adornment.End"
-              AdornmentIcon="@Icons.Material.Filled.FolderOpen"
-              AdornmentAriaLabel="Browse for Docs folder"
-              OnAdornmentClick="Browse"
-              Class="mb-2" />
+    @if (status is null)
+    {
+        <MudText><em>Loading status...</em></MudText>
+    }
+    else
+    {
+        <MudAlert Severity="@StatusSeverity" Variant="Variant.Outlined" Class="mb-3">
+            <MudText Typo="Typo.subtitle2"><strong>@StatusHeadline</strong></MudText>
+            @if (!string.IsNullOrEmpty(status.Source))
+            {
+                <MudText Typo="Typo.caption">Source: <code>@status.Source</code></MudText>
+            }
+            @if (status.IsLoaded)
+            {
+                <MudText Typo="Typo.caption">
+                    @status.ItemCount items · @status.BuildingCount buildings · @status.RecipeCount recipes
+                </MudText>
+            }
+        </MudAlert>
+    }
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
-           Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isApplying)">
-    @(isApplying ? "Loading..." : "Load catalogue")
-</MudButton>
-@if (!string.IsNullOrEmpty(message))
-{
-    <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
+    <MudTextField @bind-Value="pathInput"
+                  Label="Path to the Satisfactory Docs directory or a specific locale file"
+                  Placeholder="@DocsPathPlaceholder"
+                  Variant="Variant.Outlined"
+                  Margin="Margin.Dense"
+                  ReadOnly="true"
+                  Adornment="Adornment.End"
+                  AdornmentIcon="@Icons.Material.Filled.FolderOpen"
+                  AdornmentAriaLabel="Browse for Docs folder"
+                  OnAdornmentClick="Browse"
+                  Class="mb-2" />
+
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
+               Disabled="@(string.IsNullOrWhiteSpace(pathInput) || isApplying)">
+        @(isApplying ? "Loading..." : "Load catalogue")
+    </MudButton>
+    @if (!string.IsNullOrEmpty(message))
+    {
+        <MudText HtmlTag="span" Color="@(messageIsError ? Color.Error : Color.Success)" Class="ms-3">@message</MudText>
+    }
 }
 
 @code {
     [Parameter] public EventCallback<bool> CompletedChanged { get; set; }
 
+    private bool UseAgent => Options.Value.CatalogueViaAgent;
+
+    // ---- Agent-upload mode state -------------------------------------------
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(5);
+    private CurrentPlayerView? _currentPlayer;
+    private PlayerCatalogueStatusView? agentStatus;
+    private CancellationTokenSource? _pollCts;
+
+    // ---- Dev filesystem-picker mode state ----------------------------------
     private CatalogueStatusView? status;
     private string? pathInput;
     private string? message;
     private bool messageIsError;
     private bool isApplying;
+
     private bool lastEmittedCompleted;
+
+    private Severity AgentSeverity =>
+        agentStatus?.Catalogue is not null ? Severity.Success
+        : agentStatus?.ReIngestRequested == true ? Severity.Info
+        : Severity.Warning;
+
+    private string AgentHeadline =>
+        agentStatus?.Catalogue is not null ? "Catalogue uploaded by your agent."
+        : "No catalogue uploaded yet.";
 
     private Severity StatusSeverity => status is null
         ? Severity.Info
@@ -72,22 +146,84 @@ else
         : status.IsLoaded ? "Catalogue loaded."
         : "No catalogue loaded yet.";
 
-    // Same OS-aware placeholder as Settings.razor — keeps onboarding friendly on
-    // mac (CrossOver bottle path) without forcing Windows defaults on everyone.
+    // #269: with no agent OS reported to the server, default the hint to the
+    // Windows install path (largest user share) rather than the webapp host's
+    // OS — which in the hosted shape is always Linux and so was always wrong.
+    // Only shown in dev/self-host (filesystem-picker) mode.
     private static string DocsPathPlaceholder =>
-        OperatingSystem.IsMacOS()
-            ? "~/Library/Application Support/CrossOver/Bottles/Steam/drive_c/Program Files (x86)/Steam/steamapps/common/Satisfactory/CommunityResources/Docs"
-            : @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
+        @"C:\Program Files (x86)\Steam\steamapps\common\Satisfactory\CommunityResources\Docs";
 
     protected override async Task OnInitializedAsync()
     {
-        status = await Api.GetCatalogueStatusAsync();
-        if (status is { IsLoaded: true, Source: { } source } && source != "(empty)")
+        if (UseAgent)
         {
-            pathInput = source;
+            await LoadAgentStatusAsync();
+            StartPolling();
         }
-        await EmitCompletedAsync(status?.IsLoaded ?? false);
+        else
+        {
+            status = await Api.GetCatalogueStatusAsync();
+            if (status is { IsLoaded: true, Source: { } source } && source != "(empty)")
+            {
+                pathInput = source;
+            }
+            await EmitCompletedAsync(status?.IsLoaded ?? false);
+        }
     }
+
+    // ===== Agent-upload mode =================================================
+
+    private async Task LoadAgentStatusAsync()
+    {
+        try
+        {
+            _currentPlayer ??= await Auth.GetCurrentPlayerAsync();
+            if (_currentPlayer is null) return;
+            agentStatus = await Api.GetPlayerCatalogueAsync(_currentPlayer.PlayerId);
+        }
+        catch
+        {
+            // Best-effort; the poll loop retries.
+        }
+        finally
+        {
+            await EmitCompletedAsync(agentStatus?.Catalogue is not null);
+        }
+    }
+
+    private void StartPolling()
+    {
+        _pollCts?.Cancel();
+        _pollCts = new CancellationTokenSource();
+        _ = PollAsync(_pollCts.Token);
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(PollInterval, ct);
+                if (_currentPlayer is null)
+                {
+                    try { _currentPlayer = await Auth.GetCurrentPlayerAsync(ct); } catch { }
+                    continue;
+                }
+                try
+                {
+                    agentStatus = await Api.GetPlayerCatalogueAsync(_currentPlayer.PlayerId, ct);
+                    await EmitCompletedAsync(agentStatus?.Catalogue is not null);
+                    await InvokeAsync(StateHasChanged);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch { /* retry next tick */ }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    // ===== Dev filesystem-picker mode ========================================
 
     private async Task Browse()
     {
@@ -140,6 +276,8 @@ else
         }
     }
 
+    // ===== Shared ============================================================
+
     private async Task EmitCompletedAsync(bool completed)
     {
         if (completed == lastEmittedCompleted) return;
@@ -148,5 +286,11 @@ else
         {
             await CompletedChanged.InvokeAsync(completed);
         }
+    }
+
+    public void Dispose()
+    {
+        _pollCts?.Cancel();
+        _pollCts?.Dispose();
     }
 }

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/appsettings.Development.json
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AgentManagement": {
+    "CatalogueViaAgent": false
   }
 }

--- a/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
+++ b/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
@@ -45,13 +45,16 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
         await page.GotoAsync($"{fixture.WebFrontendUrl.TrimEnd('/')}/settings/agents");
 
         // ToBeEnabledAsync (not just ToBeVisibleAsync) — the button is
-        // visible during prerender but disabled until hydration completes.
+        // visible during prerender but disabled until the InteractiveServer
+        // circuit attaches and OnAfterRender flips _interactive (#260). On a
+        // cold CI runner the circuit attach can take well over 15s, so wait
+        // generously: this is exactly the post-hydration window the fix gates.
         var addButton = page.Locator("[data-testid='add-agent-button']");
-        await Expect(addButton).ToBeEnabledAsync(new() { Timeout = 15_000 });
+        await Expect(addButton).ToBeEnabledAsync(new() { Timeout = 60_000 });
         await addButton.ClickAsync();
 
         var mintButton = page.Locator("[data-testid='mint-button']");
-        await Expect(mintButton).ToBeVisibleAsync();
+        await Expect(mintButton).ToBeVisibleAsync(new() { Timeout = 15_000 });
         await mintButton.ClickAsync();
 
         // The reveal phase's "Save this token now" warning is the cheapest
@@ -71,7 +74,8 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
 
         // Close the dialog; the table should now include the new row.
         await page.Locator("[data-testid='close-button']").ClickAsync();
-        await Expect(page.Locator("[data-testid='agent-tokens-table'] tbody tr")).ToHaveCountAsync(1);
+        await Expect(page.Locator("[data-testid='agent-tokens-table'] tbody tr"))
+            .ToHaveCountAsync(1, new() { Timeout = 15_000 });
     }
 
     [Fact]

--- a/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
+++ b/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
@@ -31,10 +31,12 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
         Assert.Empty(consoleErrors);
     }
 
-    // Skipped pending #260 — the Add-agent button drops clicks during the
-    // Blazor interactive-hydration window. The test reproduces a real UX
-    // race; it should be re-enabled once #260 is fixed in the component.
-    [Fact(Skip = "Blocked on #260 (Blazor interactive-hydration race) — see issue.")]
+    // #260 fixed: the Add-agent button now stays disabled until the
+    // InteractiveServer circuit attaches (OnAfterRender firstRender flips
+    // _interactive), so an early click can't be dropped. Playwright's
+    // actionability check waits for the button to become enabled before
+    // clicking, so this test no longer needs an artificial delay.
+    [Fact]
     public async Task Mint_flow_displays_plaintext_token_once()
     {
         var context = await fixture.NewContextAsync();
@@ -42,8 +44,10 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
 
         await page.GotoAsync($"{fixture.WebFrontendUrl.TrimEnd('/')}/settings/agents");
 
+        // ToBeEnabledAsync (not just ToBeVisibleAsync) — the button is
+        // visible during prerender but disabled until hydration completes.
         var addButton = page.Locator("[data-testid='add-agent-button']");
-        await Expect(addButton).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await Expect(addButton).ToBeEnabledAsync(new() { Timeout = 15_000 });
         await addButton.ClickAsync();
 
         var mintButton = page.Locator("[data-testid='mint-button']");
@@ -58,8 +62,11 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
         var revealWarning = page.GetByText("Save this token now", new() { Exact = false });
         await Expect(revealWarning).ToBeVisibleAsync(new() { Timeout = 10_000 });
 
+        // ADR-0027: minting now returns a signed JWT (base64url header starts
+        // "eyJ"), not the legacy opaque eafg_ token. The auth API still accepts
+        // eafg_ during the deprecation window, but the dialog shows the JWT.
         var tokenTextarea = page.Locator("textarea")
-            .Filter(new() { HasTextRegex = new System.Text.RegularExpressions.Regex("^eafg_") });
+            .Filter(new() { HasTextRegex = new System.Text.RegularExpressions.Regex("^eyJ") });
         await Expect(tokenTextarea).ToBeVisibleAsync(new() { Timeout = 5_000 });
 
         // Close the dialog; the table should now include the new row.


### PR DESCRIPTION
## What

Makes the hosted webapp's onboarding **agent-first**, fixing four tracked bugs from a prior session. The agent already auto-uploads `Docs.json` on startup and that per-player catalogue feeds the planner (`PlayerScopedCatalogProvider`), so the lean fix is to align the UI with that reality rather than build cross-machine FS-browse plumbing.

Fixes #260, #268, #269, #270.

## Changes

- **`AgentManagementOptions.CatalogueViaAgent`** seam (default `true`; `false` in `appsettings.Development.json` so the AppHost-driven local run keeps the FS-picker flow). Tracks the #267 deployment-model decision.
- **`AgentSetupStep`** — new required first wizard step in hosted mode. Guides install + pair, polls for the agent phoning home (token `LastSeen` or a catalogue upload), completes once connected. (#268)
- **`CataloguePathStep`** is now agent-aware: hosted mode reflects per-player upload status and completes when `Docs.json` lands — no FS picker (#270). Dev mode keeps the picker.
- **`Setup.razor`** prepends the agent step and gates finish on a general per-required-step completion predicate.
- **`Settings.razor`** hides the broken FS-picker in hosted mode (points at My Agents); placeholder now defaults to the Windows install path rather than the server OS (#269 — the agent doesn't report its OS).
- **#260**: MyAgents action buttons (and the new agent step's pair button) stay disabled until `OnAfterRender(firstRender)` flips `_interactive`, so clicks can't land in the pre-hydration dead window. Un-skipped the `Mint_flow` Playwright test; updated its assertion to the JWT token format (ADR-0027), not the legacy `eafg_` prefix.

## Test plan

- `dotnet build` clean (Web + UiTests).
- `MyAgentsTests` (3/3 pass) incl. the un-skipped mint-flow test → validates #260 + JWT format.
- Post-deploy Playwright on prod: `/setup` shows agent-first flow, `/settings/agents` add button works without the dead-click window, planner loads from the agent-uploaded catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)