### PR TITLE
feat(agent): WiX MSI installer for Windows (#219)

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -177,6 +177,30 @@ jobs:
             echo "tag=${latest}" >>"$GITHUB_OUTPUT"
           fi
 
+      # Windows installer (#219). Packages the already-published win-x64 output
+      # with WiX v5 into erp-agent-win-x64.msi — service + ARP + machine-wide
+      # erp-agent:// handler, declaratively (build/wix/erp-agent.wxs). Reuses
+      # `publish/win-x64` from the Publish step; no second publish.
+      - name: Build MSI (Windows)
+        if: matrix.rid == 'win-x64'
+        shell: pwsh
+        run: |
+          # MSI ProductVersion is numeric-only: strip the leading v and any
+          # prerelease / build-metadata suffix from the release tag.
+          $ver = ("${{ steps.target.outputs.tag }}" -replace '^v','') -replace '[-+].*$',''
+          $name = "erp-agent-win-x64.msi"
+          dotnet tool update --global wix --version 5.0.2
+          # Ensure the global-tools dir is on PATH for this process.
+          $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+          wix extension add -g WixToolset.Util.wixext
+          wix build build/wix/erp-agent.wxs `
+              -ext WixToolset.Util.wixext `
+              -d Version=$ver `
+              -d "PublishDir=publish/win-x64" `
+              -arch x64 `
+              -o $name
+          "MSI_NAME=$name" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - name: Attach to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,6 +212,10 @@ jobs:
           gh release view "$tag" >/dev/null 2>&1 \
             || gh release create "$tag" --title "$tag" --notes "See CHANGELOG / commit history. Container images on ghcr.io/${GITHUB_REPOSITORY_OWNER,,}."
           gh release upload "$tag" "${ARCHIVE_NAME}" --clobber
+          # win-x64 also ships the MSI (primary Windows install path, #219).
+          if [[ -n "${MSI_NAME:-}" ]]; then
+            gh release upload "$tag" "${MSI_NAME}" --clobber
+          fi
 
   # ---------------------------------------------------------------------------
   # winget — bump the ErpForFactoryGames.Agent manifest in winget-pkgs.
@@ -225,7 +253,7 @@ jobs:
           tag="${GITHUB_REF_NAME}"
           version="${tag#v}"
           echo "version=${version}" >>"$GITHUB_OUTPUT"
-          echo "url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/erp-agent-win-x64.zip" >>"$GITHUB_OUTPUT"
+          echo "url=https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/erp-agent-win-x64.msi" >>"$GITHUB_OUTPUT"
 
       - name: Submit manifest update to winget-pkgs
         env:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -24,6 +24,7 @@
     "ExecutableTarget": {
       "type": "string",
       "enum": [
+        "BuildMsi",
         "CheckMigrations",
         "Clean",
         "Compile",
@@ -111,6 +112,11 @@
   "allOf": [
     {
       "properties": {
+        "AuthJwtSigningKey": {
+          "type": "string",
+          "description": "Shared HMAC-SHA256 key for agent JWTs (ADR-0027). Set a ≥256-bit secret in production",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
         "CloudflareApiToken": {
           "type": "string",
           "description": "Cloudflare API token. Scopes: Account · Cloudflare Tunnel · Edit; Zone · DNS · Edit; Account · Account Settings · Read",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -433,6 +433,55 @@ class Build : FalloutBuild
             Log.Information("Up complete (ImageTag={ImageTag}, DryRun={DryRun}).", ImageTag, DryRun);
         });
 
+    // -------------------------------------------------------------------------
+    // Agent Windows MSI (#219). Publishes the agent self-contained for win-x64,
+    // then packages it with WiX v5 into erp-agent-win-x64.msi — service + ARP +
+    // the machine-wide erp-agent:// handler, all declaratively (see
+    // build/wix/erp-agent.wxs). Windows-only: the WiX toolset emits MSIs only
+    // on Windows, so the target is skipped elsewhere.
+    // -------------------------------------------------------------------------
+    const string WixVersion = "5.0.2";
+
+    Target BuildMsi => _ => _
+        .Description("Builds the Agent Windows installer (erp-agent-win-x64.msi) via WiX. Windows-only.")
+        .OnlyWhenStatic(() => OperatingSystem.IsWindows())
+        .DependsOn(Restore)
+        .Executes(() =>
+        {
+            var agentProject = RootDirectory / "src" / "Presentation" / "Agent"
+                / "Satisfactory.Presentation.Agent" / "Satisfactory.Presentation.Agent.csproj";
+            var publishDir = ArtifactsDirectory / "agent" / "win-x64";
+            var wxs = RootDirectory / "build" / "wix" / "erp-agent.wxs";
+            var msiOut = ArtifactsDirectory / "erp-agent-win-x64.msi";
+
+            // MSI ProductVersion must be purely numeric (major.minor.build) —
+            // SimpleVersion drops any prerelease / build-metadata suffix that
+            // SemVer2 would carry.
+            DotNet("tool restore", workingDirectory: RootDirectory, logOutput: false);
+            var version = DotNet("nbgv get-version -v SimpleVersion",
+                workingDirectory: RootDirectory, logOutput: false).Single().Text.Trim();
+
+            // Self-contained single-file publish — the flags live in the csproj;
+            // here we just pin the RID and output dir.
+            DotNet($"publish \"{agentProject}\" -c {Configuration} -r win-x64 -o \"{publishDir}\"",
+                workingDirectory: RootDirectory);
+
+            // WiX v5 as a global tool + the Util extension (service failure
+            // actions). `tool update` installs-or-updates idempotently, unlike
+            // `tool install`, which errors when wix is already present.
+            DotNet($"tool update --global wix --version {WixVersion}", logOutput: false);
+            ProcessTasks.StartProcess("wix", "extension add -g WixToolset.Util.wixext",
+                workingDirectory: RootDirectory).AssertZeroExitCode();
+
+            ProcessTasks.StartProcess("wix",
+                $"build \"{wxs}\" -ext WixToolset.Util.wixext " +
+                $"-d Version={version} -d \"PublishDir={publishDir}\" " +
+                $"-arch x64 -o \"{msiOut}\"",
+                workingDirectory: RootDirectory).AssertZeroExitCode();
+
+            Log.Information("Built MSI: {Msi} (version {Version})", msiOut, version);
+        });
+
     /// <summary>
     /// Reads the SemVer2 version from `dotnet nbgv` (a local tool restored
     /// from .config/dotnet-tools.json). Returns e.g. "0.1.5" or "0.1.5+abcd".

--- a/build/wix/README.md
+++ b/build/wix/README.md
@@ -1,0 +1,53 @@
+# WiX MSI — ERP Agent (Windows)
+
+`erp-agent.wxs` is the [WiX v5](https://wixtoolset.org/) source for the agent's
+Windows installer, `erp-agent-win-x64.msi` (#219). It replaces the portable zip
+as the primary Windows distribution.
+
+## What the MSI does (declaratively — no custom actions)
+
+- Installs `erp-agent.exe` (+ the content files the publish drops next to it)
+  to `C:\Program Files\ErpForFactoryGames\Agent\`.
+- Registers and starts the `erp-agent` Windows service (LocalSystem,
+  Automatic/delayed-start, restart-twice-on-failure).
+- Registers the machine-wide `erp-agent://` protocol handler in
+  `HKLM\Software\Classes\erp-agent`.
+- Adds a proper Add/Remove Programs entry; `MajorUpgrade` supersedes older
+  builds so `winget upgrade` and reinstalls are clean.
+
+It deliberately does **not** seed `agent.json` / guess the save folder: a
+deferred MSI action runs as SYSTEM and would resolve the wrong profile. Pairing
+(deep-link or `erp-agent --setup`) runs as the user and writes that config — see
+the agent-first onboarding (#297) and `../../INSTALL.md`.
+
+## Build (Windows only)
+
+WiX emits MSIs only on Windows. Two equivalent ways:
+
+```powershell
+# Via the Fallout target (publishes win-x64, then builds the MSI):
+./build.cmd BuildMsi
+
+# Or directly against an existing published output:
+dotnet tool update --global wix --version 5.0.2
+wix extension add -g WixToolset.Util.wixext
+wix build build/wix/erp-agent.wxs -ext WixToolset.Util.wixext `
+    -d Version=1.2.3 -d "PublishDir=<published-win-x64-dir>" `
+    -arch x64 -o erp-agent-win-x64.msi
+```
+
+`Version` must be numeric `major.minor.build` (MSI ProductVersion); the build
+derives it from `nbgv get-version -v SimpleVersion`.
+
+CI builds the same MSI in the `win-x64` leg of `release-images.yml` and attaches
+it to the GitHub Release alongside the zip.
+
+## Known follow-ups
+
+- **No embedded icon** — the agent exe ships no `<ApplicationIcon>`, so there's
+  no custom Add/Remove Programs icon yet. Add one to the agent csproj, then set
+  `ARPPRODUCTICON` here.
+- **Code signing** — the MSI is unsigned, so SmartScreen warns on first run.
+  Tracked separately (out of scope for #219).
+- **Validation** — end-to-end install/uninstall is verified on the Windows test
+  VM (#300); the build itself runs on the CI Windows runner.

--- a/build/wix/erp-agent.wxs
+++ b/build/wix/erp-agent.wxs
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  WiX v5 source for the ERP Agent Windows MSI (#219).
+
+  Design (agreed on #219, 2026-05-29):
+    * Declarative only — ZERO custom actions. A deferred custom action would
+      run as SYSTEM, so anything that resolves the *user's* profile (e.g. the
+      save-folder seed in ServiceRegistrar.SeedAgentJsonWindowsAsync) would
+      point at SYSTEM's profile and write a garbage path. So the MSI lays down
+      files + service + ARP + the protocol handler, and leaves save-folder
+      detection / agent.json / pairing to the deep-link flow that runs as the
+      user (the agent-first onboarding shipped in #297).
+    * Protocol handler in HKLM (machine-wide), not the HKCU that the CLI
+      `--install` path uses — fits the per-machine MSI model and works for
+      every user on the box.
+
+  Build (Windows only):
+    wix extension add -g WixToolset.Util.wixext
+    wix build build/wix/erp-agent.wxs -ext WixToolset.Util.wixext \
+        -d Version=<x.y.z> -d PublishDir=<published-win-x64-dir> \
+        -arch x64 -o erp-agent-win-x64.msi
+
+  The Fallout `BuildMsi` target and the release-images.yml win-x64 leg both
+  drive exactly this invocation.
+-->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+
+  <Package
+      Name="ERP for Factory Games — Agent"
+      Manufacturer="ErpForFactoryGames"
+      Version="$(var.Version)"
+      Scope="perMachine"
+      Compressed="yes"
+      UpgradeCode="E2F1A6C4-9B3D-4D8E-A1F5-2C7B9E0D4A11">
+
+    <!-- UpgradeCode above is STABLE FOREVER — never change it, or upgrades
+         from older builds stop being detected. ProductCode is auto (*) per
+         build so each version is a distinct product that MajorUpgrade
+         supersedes. -->
+    <MajorUpgrade
+        DowngradeErrorMessage="A newer version of [ProductName] is already installed. Setup will now exit." />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- C:\Program Files\ErpForFactoryGames\Agent\ -->
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="ErpForFactoryGames">
+        <Directory Id="AGENTFOLDER" Name="Agent" />
+      </Directory>
+    </StandardDirectory>
+
+    <!-- Main binary + the Windows service it backs. The single-file,
+         self-contained publish means this exe is the whole runtime. -->
+    <Component Id="AgentExe" Directory="AGENTFOLDER" Guid="*">
+      <File Id="AgentExeFile" Source="$(var.PublishDir)\erp-agent.exe" KeyPath="yes" />
+
+      <!-- Register + start the service. start=auto + DelayedAutoStart below
+           gives the "Automatic (Delayed Start)" the CLI path sets via
+           `sc … start= delayed-auto`. LocalSystem because the watcher reads a
+           machine-wide save folder; agent.json lives under %ProgramData% so
+           LocalSystem and the user resolve to the same file. -->
+      <ServiceInstall
+          Id="AgentService"
+          Name="erp-agent"
+          DisplayName="ERP for Factory Games — Agent"
+          Description="Watches the game save folder and uploads saves to the ERP planner web app. See https://github.com/ChrisonSimtian/ErpForFactoryGames"
+          Type="ownProcess"
+          Start="auto"
+          Account="LocalSystem"
+          ErrorControl="normal"
+          Vital="yes">
+        <!-- MsiServiceConfig: flips the start type to delayed-auto. -->
+        <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall="yes" />
+        <!-- Failure actions: restart twice (60s apart), then give up — parity
+             with ServiceRegistrar's `sc failure … restart/60000/restart/60000`.
+             Requires the Util extension (-ext WixToolset.Util.wixext). -->
+        <util:ServiceConfig
+            FirstFailureActionType="restart"
+            SecondFailureActionType="restart"
+            ThirdFailureActionType="none"
+            RestartServiceDelayInSeconds="60"
+            ResetPeriodInDays="1" />
+      </ServiceInstall>
+
+      <!-- Start on install, stop on uninstall/upgrade, delete on uninstall. -->
+      <ServiceControl
+          Id="AgentServiceControl"
+          Name="erp-agent"
+          Start="install"
+          Stop="both"
+          Remove="uninstall"
+          Wait="yes" />
+    </Component>
+
+    <!-- erp-agent:// protocol handler, machine-wide (HKLM). Mirrors the HKCU
+         shape ServiceRegistrar.RegisterProtocolHandlerWindows writes, so the
+         Web UI "Open in agent" deep-link launches `erp-agent --pair "<url>"`.
+         [#AgentExeFile] binds to the installed exe's full path at build time. -->
+    <Component Id="ProtocolHandler" Directory="AGENTFOLDER" Guid="*">
+      <RegistryKey Root="HKLM" Key="Software\Classes\erp-agent">
+        <RegistryValue Type="string" Value="URL:ERP Agent Protocol" />
+        <RegistryValue Name="URL Protocol" Type="string" Value="" />
+        <RegistryKey Key="DefaultIcon">
+          <RegistryValue Type="string" Value="&quot;[#AgentExeFile]&quot;,0" />
+        </RegistryKey>
+        <RegistryKey Key="shell\open\command">
+          <RegistryValue Type="string" Value="&quot;[#AgentExeFile]&quot; --pair &quot;%1&quot;" />
+        </RegistryKey>
+      </RegistryKey>
+    </Component>
+
+    <!-- Everything else the publish dropped next to the exe — appsettings.json,
+         INSTALL.md, agent.json.example. Auto-harvested so we don't enumerate
+         each one; the exe is excluded because it's its own component above.
+         TODO(#219 follow-up): add a dedicated ARPPRODUCTICON once the agent
+         csproj ships an embedded <ApplicationIcon>; today the exe has none. -->
+    <ComponentGroup Id="AgentContent" Directory="AGENTFOLDER">
+      <Files Include="$(var.PublishDir)\**" Exclude="$(var.PublishDir)\erp-agent.exe" />
+    </ComponentGroup>
+
+    <Feature Id="Main" Title="ERP for Factory Games — Agent" Level="1">
+      <ComponentRef Id="AgentExe" />
+      <ComponentRef Id="ProtocolHandler" />
+      <ComponentGroupRef Id="AgentContent" />
+    </Feature>
+
+  </Package>
+</Wix>

--- a/src/Presentation/Agent/Satisfactory.Presentation.Agent/INSTALL.md
+++ b/src/Presentation/Agent/Satisfactory.Presentation.Agent/INSTALL.md
@@ -8,23 +8,28 @@ Single-file self-contained binary — no .NET install required.
 
 ## Windows
 
-### Recommended: winget
+### Recommended: winget (MSI)
 
 ```powershell
 winget install ErpForFactoryGames.Agent
 ```
 
-Open an **elevated** PowerShell and register the service:
+That's it — no elevated `--install` step. The MSI registers the
+`erp-agent` Windows service (Automatic, delayed-start), the machine-wide
+`erp-agent://` URL protocol handler (`HKLM\Software\Classes\erp-agent`),
+and an Add/Remove Programs entry, all at install time. The service starts
+immediately; it just has nothing to upload until you pair it (next
+section).
 
-```powershell
-erp-agent --install
-```
+Prefer to double-click? Download `erp-agent-win-x64.msi` from the latest
+[GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases)
+and run it — same result as the winget command above.
 
-`--install` seeds `%ProgramData%\ErpForFactoryGames\agent.json` with
-your save folder pre-filled, grants your user write access to that
-file, and registers the `erp-agent://` URL protocol handler under
-`HKCU\Software\Classes\erp-agent` so the web UI's deep-link button can
-launch this binary.
+The agent's config lives at `%ProgramData%\ErpForFactoryGames\agent.json`.
+The MSI does **not** pre-seed it (the installer can't reliably guess your
+save folder), so a fresh install has empty config until you pair — the
+deep-link / setup flow below writes it, and the agent auto-detects the
+default save folder.
 
 ### Pair the install
 
@@ -63,13 +68,20 @@ LocalSystem and you both resolve to the same file this way.
 The service auto-starts at boot (delayed-auto), restarts on crash, and
 uploads new saves as they appear. Logs at `%ProgramData%\ErpForFactoryGames\agent-logs\`.
 
-Future agent releases pick up with `winget upgrade ErpForFactoryGames.Agent`.
+Future agent releases pick up with `winget upgrade ErpForFactoryGames.Agent`
+(the MSI's major-upgrade supersedes the old build cleanly).
 
-To remove: `erp-agent --uninstall` (elevated), then `winget uninstall ErpForFactoryGames.Agent`.
+To remove: `winget uninstall ErpForFactoryGames.Agent`, or **Add/Remove
+Programs** → *ERP for Factory Games — Agent*. Uninstall stops and deletes
+the service and removes the protocol handler; it leaves `agent.json` and
+logs under `%ProgramData%` in place.
 
-### Fallback: download the zip
+### Fallback: portable zip (advanced)
 
-If winget isn't an option (locked-down environment, older Windows):
+If the MSI isn't an option (locked-down environment, older Windows), the
+portable `erp-agent-win-x64.zip` is still published, and the binary
+self-registers via `erp-agent --install` (this path registers the
+protocol handler per-user in `HKCU` and seeds `agent.json`):
 
 1. Download `erp-agent-win-x64.zip` from the latest [GitHub Release](https://github.com/ChrisonSimtian/ErpForFactoryGames/releases).
 2. Extract somewhere stable, e.g. `C:\Program Files\ErpForFactoryGames\`.

--- a/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget-README.md
+++ b/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget-README.md
@@ -9,13 +9,12 @@ releases via `winget upgrade`.
 > so a markdown file alongside the manifests trips the scanner on the first
 > stray `:` it sees.
 
-Today this is a **portable** manifest that wraps the release `erp-agent-win-x64.zip`.
-Winget puts `erp-agent.exe` on the user's PATH; the user runs
-`erp-agent --install` from an elevated shell to register the Windows service.
-When [#219](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/219)
-lands and we ship a real MSI, this manifest flips to `InstallerType: wix` and
-service registration happens at install time — the user-facing
-`winget install ...` command stays the same.
+This is a **WiX MSI** manifest (`InstallerType: wix`) wrapping the release
+`erp-agent-win-x64.msi` (#219). The MSI registers the Windows service, the
+machine-wide `erp-agent://` handler, and an Add/Remove Programs entry at
+install time, so `winget install` needs no follow-up elevated
+`erp-agent --install` step. The MSI is built by the `Build MSI (Windows)` step
+in `release-images.yml` from `build/wix/erp-agent.wxs`.
 
 ## Files
 

--- a/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget/ErpForFactoryGames.Agent.installer.yaml
+++ b/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget/ErpForFactoryGames.Agent.installer.yaml
@@ -4,16 +4,23 @@ PackageIdentifier: ErpForFactoryGames.Agent
 PackageVersion: 0.4.45
 ReleaseDate: 2026-05-22
 
-InstallerType: zip
-NestedInstallerType: portable
-NestedInstallerFiles:
-  - RelativeFilePath: erp-agent.exe
-    PortableCommandAlias: erp-agent
+# WiX MSI (#219) — the MSI registers the Windows service, the machine-wide
+# erp-agent:// handler, and an Add/Remove Programs entry at install time, so
+# winget install needs no follow-up elevated `erp-agent --install` step.
+# Silent + interactive install both come for free from the MSI engine.
+InstallerType: wix
+InstallerSuccessCodes:
+  - 0
+  - 3010   # ERROR_SUCCESS_REBOOT_REQUIRED — harmless for a service install
+UpgradeBehavior: install   # MajorUpgrade in the .wxs supersedes the old build
 
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/download/v0.4.45/erp-agent-win-x64.zip
-    InstallerSha256: E28806764D851A1B0623DD31EECA30B750294D8B65F01E819CFFE7EBF6BE5715
+    # PackageVersion / InstallerUrl / InstallerSha256 are refreshed at
+    # submission time — the manual bootstrap (#298) and the publish-winget CI
+    # job both recompute the SHA against the released .msi.
+    InstallerUrl: https://github.com/ChrisonSimtian/ErpForFactoryGames/releases/download/v0.4.45/erp-agent-win-x64.msi
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
 
 ManifestType: installer
 ManifestVersion: 1.10.0

--- a/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget/README.md
+++ b/src/Presentation/Agent/Satisfactory.Presentation.Agent/packaging/winget/README.md
@@ -4,13 +4,12 @@ Bootstrap manifest for `ErpForFactoryGames.Agent`. Lets Windows users install
 the agent with `winget install ErpForFactoryGames.Agent` and pick up new
 releases via `winget upgrade`.
 
-Today this is a **portable** manifest that wraps the release `erp-agent-win-x64.zip`.
-Winget puts `erp-agent.exe` on the user's PATH; the user runs
-`erp-agent --install` from an elevated shell to register the Windows service.
-When [#219](https://github.com/ChrisonSimtian/ErpForFactoryGames/issues/219)
-lands and we ship a real MSI, this manifest flips to `InstallerType: wix` and
-service registration happens at install time — the user-facing
-`winget install ...` command stays the same.
+This is a **WiX MSI** manifest (`InstallerType: wix`) wrapping the release
+`erp-agent-win-x64.msi` (#219). The MSI registers the Windows service, the
+machine-wide `erp-agent://` handler, and an Add/Remove Programs entry at
+install time, so `winget install` needs no follow-up elevated
+`erp-agent --install` step. The MSI is built by the `Build MSI (Windows)` step
+in `release-images.yml` from `build/wix/erp-agent.wxs`.
 
 ## Files
 


### PR DESCRIPTION
## What

Replaces the portable zip as the **primary Windows distribution** with a declarative **WiX v5 MSI** (`erp-agent-win-x64.msi`). `winget install ErpForFactoryGames.Agent` (or a double-click) now registers everything at install time — no follow-up elevated `erp-agent --install`.

Fixes #219.

## What the MSI does (zero custom actions)

- Installs to `C:\Program Files\ErpForFactoryGames\Agent\`.
- Registers + starts the `erp-agent` service (LocalSystem, Automatic/delayed-start, restart-twice-on-failure).
- Registers the **machine-wide** `erp-agent://` handler in `HKLM\Software\Classes\erp-agent` (an upgrade over the CLI path's HKCU).
- Add/Remove Programs entry + `MajorUpgrade` → clean `winget upgrade` / reinstall.

**By design it does *not* seed `agent.json` / guess the save folder** — a deferred MSI action runs as SYSTEM and would resolve the wrong profile. Pairing (deep-link or `--setup`) runs as the user and writes that config, dovetailing with the agent-first onboarding in #297. The zip + `erp-agent --install` path stays as the advanced/locked-down fallback (per-user HKCU handler).

## Changes

- `build/wix/erp-agent.wxs` (+ `build/wix/README.md`) — the WiX source.
- `build/Build.cs` — new Windows-only `BuildMsi` Fallout target (publishes win-x64, then `wix build`).
- `.github/workflows/release-images.yml` — win-x64 leg builds + attaches the MSI (reuses the existing publish output; no second publish). Winget job URL → `.msi`.
- winget manifest → `InstallerType: wix`; READMEs de-future-tensed.
- `INSTALL.md` — MSI primary, zip demoted to fallback.

## Test plan / verification

- ✅ Fallout build project compiles; `BuildMsi` target registered (`.nuke` schema regen included).
- ✅ `release-images.yml` parses; winget manifest valid `wix` → `.msi`.
- ⏳ **Blocked on #300 (Proxmox Windows test VM):** the actual `wix build` runs on the CI Windows runner, and end-to-end install/uninstall on a clean box needs a real Windows machine. Acceptance per #219: fresh VM → double-click → service running within a minute; `winget uninstall` removes the service cleanly.

Decisions made without a Windows box to test against are commented in-code (WiX 5.0.2 pin, `SimpleVersion` for numeric ProductVersion, `<Files>` auto-harvest, global-tool PATH).

## Follow-ups (not in scope)

- **Code signing** — unsigned MSI trips SmartScreen.
- **ARP icon** — agent exe has no embedded `<ApplicationIcon>` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)