### PR TITLE
feat(auth): Keycloak follow-ups — API hardening, CoI web OIDC, auth-web front door

### DIFF
--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -7,14 +7,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 // NOT a production secret — overridden by Auth__JwtSigningKey from stack.env.
 const string devJwtSigningKey = "erp-for-factory-games-local-apphost-hs256-dev-key-0123456789ab";
 
-// Keycloak human-login standup for LOCAL DEV (ADR-0028 / #292). Brings up a
-// Keycloak container with the `erp` realm imported from ./keycloak (confidential
-// `satisfactory-web` client + a seeded dev user). The prod containers ride #281.
-//
-// Fixed dev client secret so the web frontend and the realm agree under
-// `dotnet run`. NOT a production secret — prod injects Auth__Keycloak__ClientSecret
-// from stack.env. Mirrors the devJwtSigningKey shortcut above.
+// Fixed dev client secrets so each web frontend and the realm agree under
+// `dotnet run`. NOT production secrets — prod injects Auth__Keycloak__ClientSecret
+// from stack.env per app. Mirrors the devJwtSigningKey shortcut above.
 const string devKeycloakClientSecret = "erp-for-factory-games-local-apphost-satisfactory-web-dev-secret";
+const string devCoiWebClientSecret = "erp-for-factory-games-local-apphost-coi-web-dev-secret";
+const string devAuthWebClientSecret = "erp-for-factory-games-local-apphost-auth-web-dev-secret";
 const string keycloakRealm = "erp";
 
 // Auth backend selection (ADR-0028 / #292). Defaults to `keycloak` so a plain
@@ -71,7 +69,15 @@ if (keycloak is not null)
 // endpoints + operational rollout (CNAME, compose, CI image) are deferred to
 // the full phase-5c5 work (#281); this just makes the binary symmetric.
 var coiApi = builder.AddProject<Projects.CaptainOfIndustry_Presentation_Api>("coi-api")
+    .WithEnvironment("Auth__Backend", authBackend)
     .WithHttpHealthCheck("/health");
+if (keycloak is not null)
+{
+    coiApi
+        .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithReference(keycloak)
+        .WaitFor(keycloak);
+}
 
 // ---- Optional Postgres for plan storage (ADR-0018) -------------------------
 // SQLite is the default and needs no orchestration. Uncomment the block below
@@ -101,18 +107,38 @@ if (keycloak is not null)
 // Captain of Industry presentation app — runs independently of the Satisfactory
 // frontend per ADR-0022 (isolated apps, one per supported game). Reads its
 // catalogue in-process from the extractor's JSON; no ApiService dependency in v1.
-builder.AddProject<Projects.CaptainOfIndustry_Presentation_Web>("coi-webfrontend")
-    .WithExternalHttpEndpoints()
-    .WithHttpHealthCheck("/health");
-
-// Central auth web frontend (ADR-0026 phase 5c4) — the identity punch-out the
-// game frontends redirect to for sign-in + account/agent management. Talks to
-// auth-api; deploys behind auth.erp-for-factory.games (CNAME wired in 5c5).
-// Scaffold only for now: no OAuth flow, no live Auth-API calls yet.
-builder.AddProject<Projects.Erp_Presentation_Web_Auth>("auth-webfrontend")
+var coiWebfrontend = builder.AddProject<Projects.CaptainOfIndustry_Presentation_Web>("coi-webfrontend")
     .WithExternalHttpEndpoints()
     .WithHttpHealthCheck("/health")
+    .WithEnvironment("Auth__Backend", authBackend);
+if (keycloak is not null)
+{
+    coiWebfrontend
+        .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithEnvironment("Auth__Keycloak__ClientId", "coi-web")
+        .WithEnvironment("Auth__Keycloak__ClientSecret", devCoiWebClientSecret)
+        .WithReference(keycloak)
+        .WaitFor(keycloak);
+}
+
+// Central auth web frontend (ADR-0026 phase 5c4 / ADR-0028 §7) — the identity
+// front door. Under the keycloak backend it runs the OIDC flow itself (its own
+// `auth-web` client); the hardcoded backend stays available for zero-IdP setups.
+// Talks to auth-api; deploys behind auth.erp-for-factory.games (CNAME wired in 5c5).
+var authWebfrontend = builder.AddProject<Projects.Erp_Presentation_Web_Auth>("auth-webfrontend")
+    .WithExternalHttpEndpoints()
+    .WithHttpHealthCheck("/health")
+    .WithEnvironment("Auth__Backend", authBackend)
     .WithReference(authApi)
     .WaitFor(authApi);
+if (keycloak is not null)
+{
+    authWebfrontend
+        .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithEnvironment("Auth__Keycloak__ClientId", "auth-web")
+        .WithEnvironment("Auth__Keycloak__ClientSecret", devAuthWebClientSecret)
+        .WithReference(keycloak)
+        .WaitFor(keycloak);
+}
 
 builder.Build().Run();

--- a/src/Hosting/Erp.Hosting.AppHost/keycloak/realm-erp.json
+++ b/src/Hosting/Erp.Hosting.AppHost/keycloak/realm-erp.json
@@ -25,6 +25,36 @@
       "attributes": {
         "post.logout.redirect.uris": "+"
       }
+    },
+    {
+      "clientId": "coi-web",
+      "name": "Captain of Industry Web (planner UI)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "erp-for-factory-games-local-apphost-coi-web-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      }
+    },
+    {
+      "clientId": "auth-web",
+      "name": "ERP Auth Web (identity front door)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "erp-for-factory-games-local-apphost-auth-web-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      }
     }
   ],
 

--- a/src/Presentation/Api/CaptainOfIndustry.Presentation.Api/Program.cs
+++ b/src/Presentation/Api/CaptainOfIndustry.Presentation.Api/Program.cs
@@ -1,4 +1,5 @@
 using Erp.Hosting.ServiceDefaults;
+using Erp.Presentation.Api.Common;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,9 +8,18 @@ builder.AddServiceDefaults();
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
 
+// Human-login seam (ADR-0028 §3, #292): selects the ICurrentPlayer adapter from
+// Auth:Backend and, under Keycloak, validates forwarded access tokens against
+// the realm's JWKS so this API authenticates symmetrically with the others.
+builder.Services.AddErpUserAuth(builder.Configuration);
+
 var app = builder.Build();
 
 app.UseExceptionHandler();
+
+// Always safe to run: a no-op gate under the dev backend (no scheme requires it).
+app.UseAuthentication();
+app.UseAuthorization();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/Presentation/Api/Erp.Presentation.Api.Auth/Program.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Auth/Program.cs
@@ -57,6 +57,14 @@ app.UseExceptionHandler();
 app.UseAuthentication();
 app.UseAuthorization();
 
+// FU1: gate user-facing endpoints ONLY under the keycloak backend. Under dev
+// no auth scheme is registered, so RequireAuthorization would 401 everything
+// and break the dev-player fallback path. The agent endpoints (/api/me,
+// /players/{id}/agent-tokens) validate X-Agent-Token (or have no caller auth
+// in v2) and are never gated.
+var usesKeycloak = (builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>() ?? new AuthOptions()).UsesKeycloak;
+RouteHandlerBuilder Gate(RouteHandlerBuilder b) => usesKeycloak ? b.RequireAuthorization() : b;
+
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
@@ -83,7 +91,7 @@ app.MapGet("/", () => "Auth API. Player + agent-token endpoints under /players/*
 // Production deployment must hide them behind the homelab's Web UI gate.
 // ---------------------------------------------------------------------------
 
-app.MapGet("/players/current", async (
+Gate(app.MapGet("/players/current", async (
     HttpContext http,
     IOptions<AuthOptions> authOptions,
     IPlayerRepository players,
@@ -142,7 +150,7 @@ app.MapGet("/players/current", async (
         displayName = player.DisplayName,
         createdUtc = player.CreatedUtc,
     });
-});
+}));
 
 app.MapPost("/players/{id:guid}/agent-tokens", async (
     Guid id,

--- a/src/Presentation/Api/Satisfactory.Presentation.Api/Program.cs
+++ b/src/Presentation/Api/Satisfactory.Presentation.Api/Program.cs
@@ -96,6 +96,15 @@ app.UseExceptionHandler();
 app.UseAuthentication();
 app.UseAuthorization();
 
+// FU1: gate user-facing endpoints behind authentication, but ONLY under the
+// keycloak backend. Under the dev backend no auth scheme is registered, so
+// RequireAuthorization would 401 every request and break dev runs + the test
+// suite — there the dev-player fallback (CurrentPlayerFromAuthOptions) stands
+// in. Agent (/api/agent/*), health and the public share link are never gated:
+// they authenticate via X-Agent-Token or are intentionally anonymous.
+var usesKeycloak = (builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>() ?? new AuthOptions()).UsesKeycloak;
+RouteHandlerBuilder Gate(RouteHandlerBuilder b) => usesKeycloak ? b.RequireAuthorization() : b;
+
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
@@ -103,12 +112,12 @@ if (app.Environment.IsDevelopment())
 
 app.MapGet("/", () => "API service is running. See /catalog/items, /plan, /factory/state.");
 
-app.MapGet("/catalog/items", (ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
+Gate(app.MapGet("/catalog/items", (ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
     NoCatalogueProblem.IfMissing(catalog, catOpts) ?? Results.Ok(catalog.Items
         .OrderBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
-        .Select(i => new ItemDto(i.Id.Value, i.Name))));
+        .Select(i => new ItemDto(i.Id.Value, i.Name)))));
 
-app.MapGet("/catalog/recipes", (ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
+Gate(app.MapGet("/catalog/recipes", (ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
 {
     if (NoCatalogueProblem.IfMissing(catalog, catOpts) is { } missing) return missing;
     // Per-minute amounts mirror what /plan returns and what the planner UI displays —
@@ -138,11 +147,11 @@ app.MapGet("/catalog/recipes", (ICatalogProvider catalog, IOptions<CatalogueOpti
                 r.Inputs.Select(i => ToPerMinute(i, r.Duration)).ToList(),
                 r.Outputs.Select(o => ToPerMinute(o, r.Duration)).ToList());
         }));
-});
+}));
 
-app.MapGet("/catalogue/status", (ICatalogProvider catalog) => catalog.GetStatus());
+Gate(app.MapGet("/catalogue/status", (ICatalogProvider catalog) => catalog.GetStatus()));
 
-app.MapPost("/catalogue/configure", (ConfigureCatalogueRequest request, ICatalogProvider catalog) =>
+Gate(app.MapPost("/catalogue/configure", (ConfigureCatalogueRequest request, ICatalogProvider catalog) =>
 {
     if (string.IsNullOrWhiteSpace(request.DocsPath))
         return Results.BadRequest(new { error = "DocsPath is required." });
@@ -160,33 +169,33 @@ app.MapPost("/catalogue/configure", (ConfigureCatalogueRequest request, ICatalog
     {
         return Results.Problem(title: "Failed to load catalogue", detail: ex.Message, statusCode: 422);
     }
-});
+}));
 
-app.MapGet("/factory/state", (IFactoryStateProvider provider, ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
-    NoCatalogueProblem.IfMissing(catalog, catOpts) ?? Results.Ok(FactoryStateView.From(provider, catalog)));
+Gate(app.MapGet("/factory/state", (IFactoryStateProvider provider, ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts) =>
+    NoCatalogueProblem.IfMissing(catalog, catOpts) ?? Results.Ok(FactoryStateView.From(provider, catalog))));
 
-app.MapGet("/factory/state.geojson", (IFactoryStateProvider provider, ICatalogProvider catalog, Satisfactory.Infrastructure.KnownFlora flora, IOptions<CatalogueOptions> catOpts) =>
-    NoCatalogueProblem.IfMissing(catalog, catOpts) ?? Results.Json(FactoryStateGeoJson.From(provider, catalog, flora), contentType: "application/geo+json"));
+Gate(app.MapGet("/factory/state.geojson", (IFactoryStateProvider provider, ICatalogProvider catalog, Satisfactory.Infrastructure.KnownFlora flora, IOptions<CatalogueOptions> catOpts) =>
+    NoCatalogueProblem.IfMissing(catalog, catOpts) ?? Results.Json(FactoryStateGeoJson.From(provider, catalog, flora), contentType: "application/geo+json")));
 
-app.MapGet("/factory/saves", () =>
+Gate(app.MapGet("/factory/saves", () =>
     SaveFileResolver.EnumerateDetectedSaves()
         .Select(f => new DetectedSaveView(f.FullName, f.Name, f.LastWriteTimeUtc, f.Length))
-        .ToList());
+        .ToList()));
 
 // Active factory bottleneck alerts (#116). Read by the ADA agent so she leads
 // with active alerts on each user turn. Empty list when nothing's flagged.
 // Writes happen post-ingest via the analysis service.
-app.MapGet("/factory/alerts", async (IFactoryAlertRepository repo, CancellationToken ct) =>
+Gate(app.MapGet("/factory/alerts", async (IFactoryAlertRepository repo, CancellationToken ct) =>
 {
     var alerts = await repo.ListActiveAsync(ct);
     return Results.Ok(alerts.Select(FactoryAlertView.From).ToList());
-});
+}));
 
 // Manual dismissal (#116, phase C). Marks an alert as dismissed; subsequent
 // analysis passes that re-detect the same condition will create a *new* alert
 // rather than re-fire the dismissed one. Idempotent — re-dismissing an
 // already-dismissed alert is a 204, not an error.
-app.MapPost("/factory/alerts/{id:guid}/dismiss", async (
+Gate(app.MapPost("/factory/alerts/{id:guid}/dismiss", async (
     Guid id, IFactoryAlertRepository repo, TimeProvider clock, CancellationToken ct) =>
 {
     var alert = await repo.GetAsync(id, ct);
@@ -195,7 +204,7 @@ app.MapPost("/factory/alerts/{id:guid}/dismiss", async (
     alert.Dismiss(clock.GetUtcNow().UtcDateTime);
     await repo.SaveChangesAsync(ct);
     return Results.NoContent();
-});
+}));
 
 // Backing endpoint for the in-app filesystem picker (issue #84). Lists the
 // directory at `path` so the Blazor `PathPickerDialog` can render breadcrumbs +
@@ -207,7 +216,7 @@ app.MapPost("/factory/alerts/{id:guid}/dismiss", async (
 // smart starting directory when the caller hasn't given an explicit `path` —
 // the picker can land the user inside Satisfactory's Docs/SaveGames folder
 // instead of making them click through ~/Library/... by hand.
-app.MapGet("/fs/browse", (string? path, string? filter, string? purpose) =>
+Gate(app.MapGet("/fs/browse", (string? path, string? filter, string? purpose) =>
 {
     var startPath = ResolveStartPath(path, purpose);
 
@@ -361,9 +370,9 @@ app.MapGet("/fs/browse", (string? path, string? filter, string? purpose) =>
             .Select(e => e.StartsWith('.') ? e : "." + e)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
-});
+}));
 
-app.MapPost("/factory/ingest", async (
+Gate(app.MapPost("/factory/ingest", async (
     IngestSaveRequest request, IMessageBus bus, IFactoryStateProvider provider,
     ICatalogProvider catalog, FactoryAlertAnalysisService alertAnalysis,
     IOptions<CatalogueOptions> catOpts,
@@ -405,7 +414,7 @@ app.MapPost("/factory/ingest", async (
     {
         return Results.Problem(title: "Failed to parse save", detail: ex.Message, statusCode: 422);
     }
-});
+}));
 
 // ----- Manual node overrides (#42 Option B) ---------------------------------
 // User-curated resource + purity for individual BP_ResourceNode_C actors.
@@ -416,7 +425,7 @@ app.MapPost("/factory/ingest", async (
 // override survives across saves of the same world), and refreshes parsed
 // state so callers see the change immediately.
 
-app.MapPut("/factory/node-override", (
+Gate(app.MapPut("/factory/node-override", (
     NodeOverrideRequest request,
     Satisfactory.Infrastructure.ManualNodeOverrides overrides,
     IFactoryStateProvider provider) =>
@@ -436,9 +445,9 @@ app.MapPut("/factory/node-override", (
     overrides.Upsert(node.Position, request.Resource, purity);
     provider.Refresh();
     return Results.NoContent();
-});
+}));
 
-app.MapDelete("/factory/node-override", (
+Gate(app.MapDelete("/factory/node-override", (
     string reference,
     Satisfactory.Infrastructure.ManualNodeOverrides overrides,
     IFactoryStateProvider provider) =>
@@ -454,9 +463,9 @@ app.MapDelete("/factory/node-override", (
     var removed = overrides.Delete(node.Position);
     if (removed) provider.Refresh();
     return Results.NoContent();
-});
+}));
 
-app.MapPost("/plan", async (PlanRequest request, IMessageBus bus, ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts, ILoggerFactory loggerFactory) =>
+Gate(app.MapPost("/plan", async (PlanRequest request, IMessageBus bus, ICatalogProvider catalog, IOptions<CatalogueOptions> catOpts, ILoggerFactory loggerFactory) =>
 {
     if (NoCatalogueProblem.IfMissing(catalog, catOpts) is { } missing) return missing;
 
@@ -481,7 +490,7 @@ app.MapPost("/plan", async (PlanRequest request, IMessageBus bus, ICatalogProvid
         query.Targets.Count, plan.Steps.Count, plan.MissingInputs.Count, sw.ElapsedMilliseconds);
 
     return Results.Ok(PlanDto.From(plan, catalog));
-});
+}));
 
 // ---- Saved plans (ADR-0018, issue #77) -------------------------------------
 // Persist the user's planner inputs (targets + available resources) so they
@@ -489,19 +498,19 @@ app.MapPost("/plan", async (PlanRequest request, IMessageBus bus, ICatalogProvid
 // function of (catalogue, targets, available) and re-running the planner on
 // load keeps results valid across catalogue updates.
 
-app.MapGet("/plans", async (IPlanRepository repo, CancellationToken ct) =>
+Gate(app.MapGet("/plans", async (IPlanRepository repo, CancellationToken ct) =>
 {
     var plans = await repo.ListAsync(ct);
     return Results.Ok(plans.Select(SavedPlanSummaryDto.From).ToList());
-});
+}));
 
-app.MapGet("/plans/{id:guid}", async (Guid id, IPlanRepository repo, CancellationToken ct) =>
+Gate(app.MapGet("/plans/{id:guid}", async (Guid id, IPlanRepository repo, CancellationToken ct) =>
 {
     var plan = await repo.GetAsync(id, ct);
     return plan is null ? Results.NotFound() : Results.Ok(SavedPlanDto.From(plan));
-});
+}));
 
-app.MapPost("/plans", async (SavePlanRequest request, IPlanRepository repo, TimeProvider clock, CancellationToken ct) =>
+Gate(app.MapPost("/plans", async (SavePlanRequest request, IPlanRepository repo, TimeProvider clock, CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(request.Name))
         return Results.BadRequest(new { error = "Name is required." });
@@ -518,9 +527,9 @@ app.MapPost("/plans", async (SavePlanRequest request, IPlanRepository repo, Time
     await repo.AddAsync(plan, ct);
     await repo.SaveChangesAsync(ct);
     return Results.Created($"/plans/{plan.Id}", SavedPlanDto.From(plan));
-});
+}));
 
-app.MapPut("/plans/{id:guid}", async (Guid id, SavePlanRequest request, IPlanRepository repo, TimeProvider clock, CancellationToken ct) =>
+Gate(app.MapPut("/plans/{id:guid}", async (Guid id, SavePlanRequest request, IPlanRepository repo, TimeProvider clock, CancellationToken ct) =>
 {
     if (string.IsNullOrWhiteSpace(request.Name))
         return Results.BadRequest(new { error = "Name is required." });
@@ -538,19 +547,19 @@ app.MapPut("/plans/{id:guid}", async (Guid id, SavePlanRequest request, IPlanRep
     await repo.UpdateAsync(existing, ct);
     await repo.SaveChangesAsync(ct);
     return Results.Ok(SavedPlanDto.From(existing));
-});
+}));
 
-app.MapDelete("/plans/{id:guid}", async (Guid id, IPlanRepository repo, CancellationToken ct) =>
+Gate(app.MapDelete("/plans/{id:guid}", async (Guid id, IPlanRepository repo, CancellationToken ct) =>
 {
     var removed = await repo.DeleteAsync(id, ct);
     if (!removed) return Results.NotFound();
     await repo.SaveChangesAsync(ct);
     return Results.NoContent();
-});
+}));
 
 // ----- Share links (#80) ----------------------------------------------------
 
-app.MapPost("/plans/{id:guid}/share", async (
+Gate(app.MapPost("/plans/{id:guid}/share", async (
     Guid id,
     IPlanRepository plans,
     IPlanShareRepository shares,
@@ -568,9 +577,9 @@ app.MapPost("/plans/{id:guid}/share", async (
 
     var baseUrl = $"{http.Scheme}://{http.Host}";
     return Results.Ok(new ShareTokenView(token, $"{baseUrl}/plans/shared/{token}", entity.CreatedUtc, entity.ExpiresUtc));
-});
+}));
 
-app.MapDelete("/plans/{id:guid}/share/{token}", async (
+Gate(app.MapDelete("/plans/{id:guid}/share/{token}", async (
     Guid id,
     string token,
     IPlanShareRepository shares,
@@ -583,8 +592,10 @@ app.MapDelete("/plans/{id:guid}/share/{token}", async (
     entity.Revoke(clock.GetUtcNow().UtcDateTime);
     await shares.SaveChangesAsync(ct);
     return Results.NoContent();
-});
+}));
 
+// Public share link (#80): intentionally ANONYMOUS — anyone with the opaque
+// token can read the shared plan, even under the keycloak backend. NOT gated.
 app.MapGet("/plans/shared/{token}", async (
     string token,
     IPlanRepository plans,
@@ -986,7 +997,7 @@ app.MapPost("/api/agent/catalogue/satisfactory", async (
 // endpoints — gated by the Web UI being on the homelab-internal LAN).
 // ---------------------------------------------------------------------------
 
-app.MapPost("/players/{id:guid}/re-ingest-catalogue", async (
+Gate(app.MapPost("/players/{id:guid}/re-ingest-catalogue", async (
     Guid id,
     IPlayerRepository players,
     TimeProvider clock,
@@ -1003,9 +1014,9 @@ app.MapPost("/players/{id:guid}/re-ingest-catalogue", async (
         reIngestRequested = true,
         reIngestRequestedUtc = player.ReIngestRequestedUtc,
     });
-});
+}));
 
-app.MapGet("/players/{id:guid}/catalogue/satisfactory", async (
+Gate(app.MapGet("/players/{id:guid}/catalogue/satisfactory", async (
     Guid id,
     IPlayerRepository players,
     IPlayerCatalogueRepository catalogues,
@@ -1029,7 +1040,7 @@ app.MapGet("/players/{id:guid}/catalogue/satisfactory", async (
             uploadedUtc = row.UploadedUtc,
         },
     });
-});
+}));
 
 app.MapDefaultEndpoints();
 

--- a/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/CaptainOfIndustry.Presentation.Web.csproj
+++ b/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/CaptainOfIndustry.Presentation.Web.csproj
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <!-- Keycloak OIDC login (ADR-0028 §3, #292): AddKeycloakOpenIdConnect resolves
+         the realm authority via Aspire service discovery. Version tracks the
+         AppHost's Aspire SDK (13.2.4). -->
+    <PackageReference Include="Aspire.Keycloak.Authentication" Version="13.2.4-preview.1.26224.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/Program.cs
+++ b/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/Program.cs
@@ -3,8 +3,11 @@ using CaptainOfIndustry.Infrastructure;
 using Erp.Hosting.ServiceDefaults;
 using Erp.Application.Common;
 using Erp.Application.Common.Queries.PlanProduction;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +18,45 @@ builder.Services.AddMudServices();
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+// ---- Human login (ADR-0028 §3, issue #292) --------------------------------
+// Auth:Backend selects login: "keycloak" (OIDC against the Keycloak realm) or
+// "dev" (default — no login). Unlike the Satisfactory app, the CoI app reads
+// its catalogue + plans in-process (ADR-0022) and makes no outbound API calls,
+// so there's no per-user token to forward: login + cookie + the
+// RequireAuthorization gate is the whole story here.
+var useKeycloak = string.Equals(
+    builder.Configuration["Auth:Backend"], "keycloak", StringComparison.OrdinalIgnoreCase);
+
+if (useKeycloak)
+{
+    var realm = builder.Configuration["Auth:Keycloak:Realm"] ?? "erp";
+
+    builder.Services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+        })
+        .AddCookie()
+        .AddKeycloakOpenIdConnect("keycloak", realm, oidc =>
+        {
+            oidc.ClientId = builder.Configuration["Auth:Keycloak:ClientId"] ?? "coi-web";
+            oidc.ClientSecret = builder.Configuration["Auth:Keycloak:ClientSecret"];
+            oidc.ResponseType = OpenIdConnectResponseType.Code;
+            oidc.Scope.Clear();
+            oidc.Scope.Add("openid");
+            oidc.Scope.Add("profile");
+            oidc.Scope.Add("email");
+            oidc.SaveTokens = true;
+            oidc.MapInboundClaims = false;
+            oidc.TokenValidationParameters.NameClaimType = "preferred_username";
+            // Keycloak runs behind plain HTTP locally (Aspire / compose network).
+            oidc.RequireHttpsMetadata = false;
+        });
+
+    builder.Services.AddAuthorization();
+    builder.Services.AddCascadingAuthenticationState();
+}
 
 // CoI catalogue runs in-process: the Blazor app reads the extractor's JSON
 // directly via JsonCoiCatalogProvider. No ApiService hop in v1 — per ADR-0022
@@ -39,6 +81,15 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+// Auth middleware runs before antiforgery + endpoints (ADR-0028 #292). Only
+// wired under the Keycloak backend; the dev backend registers no auth services.
+if (useKeycloak)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
 app.UseAntiforgery();
 app.MapStaticAssets();
 
@@ -71,8 +122,33 @@ else
     app.Logger.LogInformation(".assets/ folder not found — item icons will be missing (run tools/Download-CoiIcons.ps1).");
 }
 
-app.MapRazorComponents<App>()
+var razorComponents = app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+if (useKeycloak)
+{
+    // Gate the whole app behind sign-in: an anonymous request triggers the OIDC
+    // challenge (redirect to Keycloak). /health, /alive, and the login/logout
+    // endpoints are separate and stay anonymous.
+    razorComponents.RequireAuthorization();
+
+    // OIDC challenge/sign-out endpoints (the Blazor Web App auth pattern): the
+    // handshake must happen on a plain HTTP endpoint, outside the SignalR circuit.
+    app.MapGet("/authentication/login", (string? returnUrl) =>
+        Results.Challenge(
+            new Microsoft.AspNetCore.Authentication.AuthenticationProperties
+            {
+                RedirectUri = string.IsNullOrEmpty(returnUrl) || !Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+                    ? "/"
+                    : returnUrl,
+            },
+            [OpenIdConnectDefaults.AuthenticationScheme]));
+
+    app.MapPost("/authentication/logout", () =>
+        Results.SignOut(
+            new Microsoft.AspNetCore.Authentication.AuthenticationProperties { RedirectUri = "/" },
+            [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
+}
 
 app.MapDefaultEndpoints();
 

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Erp.Presentation.Web.Auth.csproj
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Erp.Presentation.Web.Auth.csproj
@@ -15,6 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <!-- Keycloak OIDC front-door (ADR-0028 §7, FU3 / #292): when Auth:Backend=keycloak
+         the auth-web landing becomes the branded OIDC front door. AddKeycloakOpenIdConnect
+         resolves the realm authority via Aspire service discovery. Version tracks the
+         AppHost's Aspire SDK (13.2.4), matching Satisfactory.Presentation.Web. -->
+    <PackageReference Include="Aspire.Keycloak.Authentication" Version="13.2.4-preview.1.26224.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
@@ -4,7 +4,9 @@ using Erp.Presentation.Web.Auth;
 using Erp.Presentation.Web.Auth.Components;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -31,32 +33,67 @@ builder.Services.AddHttpClient("auth-api", client =>
 
 // ---- Auth landing backend (ADR-0028 §7/§8) --------------------------------
 // Pluggable sign-in: "hardcoded" (a configured username/password — the
-// zero-infra default) or "keycloak" (OIDC, deferred to #292). The landing
-// owns the cookie session; the backend just validates credentials.
+// zero-infra default) or "keycloak" (OIDC against the Keycloak realm — FU3).
+// Under "hardcoded" the landing owns the cookie session and the backend just
+// validates credentials. Under "keycloak" this app is the `auth-web`
+// confidential OIDC client and becomes the branded front door (ADR-0028 §7).
 builder.Services.Configure<AuthLandingOptions>(builder.Configuration.GetSection(AuthLandingOptions.SectionName));
 
 var authBackend = builder.Configuration[$"{AuthLandingOptions.SectionName}:Backend"] ?? "hardcoded";
-if (string.Equals(authBackend, "keycloak", StringComparison.OrdinalIgnoreCase))
-{
-    // Keycloak OIDC backend is not implemented yet — see ADR-0028 §8 / issue #292.
-    // Fail fast with a clear message rather than silently doing nothing.
-    throw new NotSupportedException(
-        "Auth:Backend=keycloak is not implemented yet (deferred — see issue #292). " +
-        "Use Auth:Backend=hardcoded for now.");
-}
-builder.Services.AddSingleton<IAuthBackend, HardcodedCredentialAuthBackend>();
+var useKeycloak = string.Equals(authBackend, "keycloak", StringComparison.OrdinalIgnoreCase);
 
-builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-    .AddCookie(options =>
-    {
-        options.LoginPath = "/";
-        options.LogoutPath = "/auth/logout";
-        options.AccessDeniedPath = "/";
-        options.ExpireTimeSpan = TimeSpan.FromDays(7);
-        options.SlidingExpiration = true;
-    });
-builder.Services.AddAuthorization();
-builder.Services.AddCascadingAuthenticationState();
+if (useKeycloak)
+{
+    // Keycloak OIDC front door (ADR-0028 §7, FU3 / #292): cookie session backed
+    // by an OIDC challenge against the Keycloak realm. No IAuthBackend / form-POST
+    // here — sign-in is driven through /authentication/login below.
+    var realm = builder.Configuration["Auth:Keycloak:Realm"] ?? "erp";
+
+    builder.Services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+        })
+        .AddCookie()
+        .AddKeycloakOpenIdConnect("keycloak", realm, oidc =>
+        {
+            oidc.ClientId = builder.Configuration["Auth:Keycloak:ClientId"] ?? "auth-web";
+            oidc.ClientSecret = builder.Configuration["Auth:Keycloak:ClientSecret"];
+            oidc.ResponseType = OpenIdConnectResponseType.Code;
+            oidc.Scope.Clear();
+            oidc.Scope.Add("openid");
+            oidc.Scope.Add("profile");
+            oidc.Scope.Add("email");
+            // SaveTokens keeps the issued tokens on the cookie; keep the raw OIDC
+            // claim names so downstream reads "sub".
+            oidc.SaveTokens = true;
+            oidc.MapInboundClaims = false;
+            oidc.TokenValidationParameters.NameClaimType = "preferred_username";
+            // Keycloak runs behind plain HTTP locally (Aspire / compose network).
+            oidc.RequireHttpsMetadata = false;
+        });
+
+    builder.Services.AddAuthorization();
+    builder.Services.AddCascadingAuthenticationState();
+}
+else
+{
+    // Hardcoded backend (the zero-infra default): the landing owns the cookie
+    // session and the form-POST /auth/login flow validates against IAuthBackend.
+    builder.Services.AddSingleton<IAuthBackend, HardcodedCredentialAuthBackend>();
+
+    builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+        .AddCookie(options =>
+        {
+            options.LoginPath = "/";
+            options.LogoutPath = "/auth/logout";
+            options.AccessDeniedPath = "/";
+            options.ExpireTimeSpan = TimeSpan.FromDays(7);
+            options.SlidingExpiration = true;
+        });
+    builder.Services.AddAuthorization();
+    builder.Services.AddCascadingAuthenticationState();
+}
 
 var app = builder.Build();
 
@@ -79,46 +116,79 @@ app.UseOutputCache();
 app.MapStaticAssets();
 
 // ---- Sign-in / sign-out endpoints ------------------------------------------
-// Plain form-POST endpoints (the official Blazor Web App auth pattern): a
-// static-rendered <form> can't call SignInAsync from inside an interactive
-// circuit, so the landing posts here. Antiforgery is enforced by UseAntiforgery
-// + the <AntiforgeryToken /> in the form.
-app.MapPost("/auth/login", async (
-    HttpContext http,
-    IAuthBackend backend,
-    [FromForm] string username,
-    [FromForm] string password,
-    [FromForm] string? returnUrl) =>
+// Hardcoded-backend only: plain form-POST endpoints (the official Blazor Web App
+// auth pattern) — a static-rendered <form> can't call SignInAsync from inside an
+// interactive circuit, so the landing posts here. Antiforgery is enforced by
+// UseAntiforgery + the <AntiforgeryToken /> in the form. These take IAuthBackend,
+// which is only registered under the hardcoded backend, so they MUST NOT be
+// mapped under keycloak (minimal APIs would otherwise infer `backend` as a JSON
+// body and fail at startup against the [FromForm] params). Keycloak sign-in goes
+// through the /authentication/login OIDC endpoint below instead.
+if (!useKeycloak)
 {
-    var result = await backend.ValidateAsync(username ?? string.Empty, password ?? string.Empty);
-    if (!result.Succeeded)
+    app.MapPost("/auth/login", async (
+        HttpContext http,
+        IAuthBackend backend,
+        [FromForm] string username,
+        [FromForm] string password,
+        [FromForm] string? returnUrl) =>
     {
-        return Results.Redirect("/?error=1");
-    }
+        var result = await backend.ValidateAsync(username ?? string.Empty, password ?? string.Empty);
+        if (!result.Succeeded)
+        {
+            return Results.Redirect("/?error=1");
+        }
 
-    var claims = new List<Claim>
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, result.Subject),
+            new(ClaimTypes.Name, result.DisplayName),
+        };
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+
+        // Only honour local redirect targets — never an absolute/off-site URL.
+        var target = !string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+            ? returnUrl
+            : "/account";
+        return Results.Redirect(target);
+    });
+
+    app.MapPost("/auth/logout", async (HttpContext http) =>
     {
-        new(ClaimTypes.NameIdentifier, result.Subject),
-        new(ClaimTypes.Name, result.DisplayName),
-    };
-    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
-    await http.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+        await http.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Results.Redirect("/");
+    });
+}
 
-    // Only honour local redirect targets — never an absolute/off-site URL.
-    var target = !string.IsNullOrEmpty(returnUrl) && Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
-        ? returnUrl
-        : "/account";
-    return Results.Redirect(target);
-});
-
-app.MapPost("/auth/logout", async (HttpContext http) =>
-{
-    await http.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    return Results.Redirect("/");
-});
-
-app.MapRazorComponents<App>()
+var razorComponents = app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
+
+if (useKeycloak)
+{
+    // Gate the whole landing behind sign-in: an anonymous request triggers the
+    // OIDC challenge (redirect to Keycloak). /health, /alive and the login/logout
+    // endpoints stay anonymous. The landing UI drives users to /authentication/login.
+    razorComponents.RequireAuthorization();
+
+    // OIDC challenge/sign-out endpoints (the Blazor Web App auth pattern): the
+    // handshake must happen on a plain HTTP endpoint, outside the SignalR circuit.
+    app.MapGet("/authentication/login", (string? returnUrl) =>
+        Results.Challenge(
+            new AuthenticationProperties
+            {
+                RedirectUri = string.IsNullOrEmpty(returnUrl) || !Uri.IsWellFormedUriString(returnUrl, UriKind.Relative)
+                    ? "/"
+                    : returnUrl,
+            },
+            [OpenIdConnectDefaults.AuthenticationScheme]));
+
+    app.MapPost("/authentication/logout", () =>
+        // Sign out of both the local cookie and Keycloak.
+        Results.SignOut(
+            new AuthenticationProperties { RedirectUri = "/" },
+            [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
+}
 
 app.MapDefaultEndpoints();
 


### PR DESCRIPTION
**Stacked on #302** (base = `feat/keycloak-human-login-292`). Three independent follow-ups to the Keycloak core, fanned out and integrated.

### FU1 — API authorization hardening
Under `Auth:Backend=keycloak`, user-facing endpoints on the Satisfactory API + auth-api now `RequireAuthorization()` — a clean 401 instead of silently falling back to the dev player. Gating is conditional on `AuthOptions.UsesKeycloak` (local `Gate()` helper), so the dev backend + test suite stay open. **Left anonymous:** agent endpoints (`/api/agent/*`, `/api/me`, `/players/{id}/agent-tokens`), health, and public share links (`/plans/shared/{token}`).

### FU2 — Captain of Industry web OIDC
`coi-web` is now its own OIDC client (login + cookie + gate + cascading auth state). CoI web reads its catalogue in-process (ADR-0022), so no token forwarding is needed. `coi-api` gains `AddErpUserAuth` + auth middleware for symmetric Keycloak validation.

### FU3 — auth-web Keycloak front door (ADR-0028 §7)
`Erp.Presentation.Web.Auth`'s `Backend=keycloak` branch now runs the real OIDC flow (`auth-web` client) instead of throwing. The hardcoded backend is unchanged and remains the default. **Bug fixed during e2e:** the form-POST `/auth/login` endpoints (which take `IAuthBackend`) are now mapped only under the hardcoded backend — mapping them under keycloak made minimal APIs infer a JSON body and crash at startup.

### Integration
`AppHost` wires `coi-web`/`coi-api`/`auth-web` Keycloak env + references; `realm-erp.json` adds the `coi-web` + `auth-web` confidential clients.

### Verification
Live e2e (Aspire + Keycloak 26.5, realm imports all 3 clients): Satisfactory happy path intact under gating (Planner loads via forwarded token); CoI web and auth-web both log in via Keycloak and land authenticated ("Signed in as chris"). Full solution builds; **API tests 41/41 + auth-web 7/7 green.**

#4 (social brokers + Steam bridge) tracked separately in #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)