### PR TITLE
fix(web-tests): stop the /setup redirect race breaking MyAgents UI tests

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -111,6 +111,11 @@
   "allOf": [
     {
       "properties": {
+        "AuthJwtSigningKey": {
+          "type": "string",
+          "description": "Shared HMAC-SHA256 key for agent JWTs (ADR-0027). Set a ≥256-bit secret in production",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
         "CloudflareApiToken": {
           "type": "string",
           "description": "Cloudflare API token. Scopes: Account · Cloudflare Tunnel · Edit; Zone · DNS · Edit; Account · Account Settings · Read",

--- a/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
+++ b/test/Presentation/Web/Satisfactory.Presentation.Web.UiTests/MyAgentsTests.cs
@@ -19,6 +19,11 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
         var consoleErrors = new List<string>();
         page.Console += (_, msg) => { if (msg.Type == "error") consoleErrors.Add(msg.Text); };
 
+        // Skip the first-load setup redirect (see Mint_flow for the rationale)
+        // so the page settles on /settings/agents instead of bouncing to /setup.
+        await context.AddInitScriptAsync(
+            "window.localStorage.setItem('erp-setup-dismissed', 'true');");
+
         var response = await page.GotoAsync($"{fixture.WebFrontendUrl.TrimEnd('/')}/settings/agents");
 
         Assert.NotNull(response);
@@ -41,6 +46,13 @@ public class MyAgentsTests(AspireAppFixture fixture) : IClassFixture<AspireAppFi
     {
         var context = await fixture.NewContextAsync();
         var page = await context.NewPageAsync();
+
+        // Skip the first-load setup redirect — MainLayout sends unconfigured
+        // users to /setup before the circuit settles, which detaches this page's
+        // controls mid-test (the agent step lives in the wizard). A returning
+        // user who has dismissed the wizard is the right precondition here.
+        await context.AddInitScriptAsync(
+            "window.localStorage.setItem('erp-setup-dismissed', 'true');");
 
         await page.GotoAsync($"{fixture.WebFrontendUrl.TrimEnd('/')}/settings/agents");
 


### PR DESCRIPTION
The UI suite has carried one red test since #297 (agent-first onboarding). When
`MainLayout` started redirecting unconfigured users to `/setup`, `MyAgentsTests`
— which navigates straight to `/settings/agents` — began getting bounced
mid-render: the add-agent button briefly enabled, then the redirect detached it.
`Mint_flow_displays_plaintext_token_once` flaked accordingly (`button "disabled"`
or `element detached from the DOM`, depending on timing). It fails on `main`
today and was knowingly merged red with #297.

## Fix
Apply the convention already used by `DrawerToggleTests` and a `SmokeTest`: seed
`localStorage['erp-setup-dismissed'] = true` via an init script before
navigating, so the page settles on `/settings/agents`. That's the correct
precondition for the scenario under test — a returning user managing their
agents, not a first-run user who belongs in the wizard. **No production code
changes**; test-only.

## Verification
Full UI suite **14/14 green** locally (was 13/14). `dotnet format` clean.

Surfaced while getting the Keycloak PRs (#302, #304) green — the redirect race
is independent of Keycloak.