### PR TITLE
feat(auth): Steam sign-in via the steam-oidc bridge (local dev, #303)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ test/ui-tests/
 *.db-shm
 *.db-wal
 
+# Keycloak persisted DB (AppHost WithDataBindMount, #303) — local-dev state,
+# holds brokered identities across restarts; never committed
+keycloak-data/
+
 # Planner scratch snapshot (Steam ID + local save path inside) — dev-only
 factory_state.json
 

--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -51,8 +51,17 @@ var useKeycloak = string.Equals(authBackend, "keycloak", StringComparison.Ordina
 // Keycloak container with the `erp` realm imported from ./keycloak (confidential
 // `satisfactory-web` client + a seeded dev user). The prod containers ride #281.
 // Only stood up under the keycloak backend — null on the dev path.
+//
+// WithDataBindMount persists Keycloak's DB to ./keycloak-data (gitignored) so
+// brokered identities (e.g. a Steam-linked user) survive a restart — handy when
+// iterating on the Steam login round-trip (#303) without re-doing first-broker
+// -login each time. Trade-off: the realm is imported only when it doesn't yet
+// exist, so edits to realm-erp.json won't apply while the volume persists —
+// delete ./keycloak-data to force a clean re-import.
 IResourceBuilder<KeycloakResource>? keycloak = useKeycloak
-    ? builder.AddKeycloak("keycloak", port: keycloakHostPort).WithRealmImport("./keycloak")
+    ? builder.AddKeycloak("keycloak", port: keycloakHostPort)
+        .WithRealmImport("./keycloak")
+        .WithDataBindMount("./keycloak-data")
     : null;
 
 // Steam→OIDC bridge (ADR-0028 §4 / #303). Steam speaks legacy OpenID 2.0 which

--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -23,6 +23,14 @@ const string keycloakRealm = "erp";
 // internal container-network address — so it has to be a fixed, known value.
 const int keycloakHostPort = 8088;
 
+// Browser-facing Keycloak authority, pinned to the fixed HTTP host port so the
+// origin the web frontends redirect the browser to is deterministic (#303).
+// Aspire's `keycloak` service reference otherwise resolves Keycloak's dynamic
+// HTTPS endpoint, and the Steam broker callback Keycloak derives from that
+// origin never matches the steam-oidc bridge's pinned redirect_uri allow-list.
+// The web apps apply this via Auth:Keycloak:Authority when present.
+var keycloakBrowserAuthority = $"http://localhost:{keycloakHostPort}/realms/{keycloakRealm}";
+
 // Steam sign-in (ADR-0028 §4 / #303). Opt-in: only when a Steam Web API key is
 // supplied via the STEAM_API_KEY env var do we stand up the byo-software
 // Steam→OIDC bridge that Keycloak brokers. Keyless `dotnet run` is unchanged —
@@ -89,6 +97,7 @@ if (keycloak is not null)
 {
     authApi
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }
@@ -105,6 +114,7 @@ if (keycloak is not null)
 {
     apiService
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }
@@ -121,6 +131,7 @@ if (keycloak is not null)
 {
     coiApi
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }
@@ -146,6 +157,7 @@ if (keycloak is not null)
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
         .WithEnvironment("Auth__Keycloak__ClientId", "satisfactory-web")
         .WithEnvironment("Auth__Keycloak__ClientSecret", devKeycloakClientSecret)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }
@@ -163,6 +175,7 @@ if (keycloak is not null)
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
         .WithEnvironment("Auth__Keycloak__ClientId", "coi-web")
         .WithEnvironment("Auth__Keycloak__ClientSecret", devCoiWebClientSecret)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }
@@ -183,6 +196,7 @@ if (keycloak is not null)
         .WithEnvironment("Auth__Keycloak__Realm", keycloakRealm)
         .WithEnvironment("Auth__Keycloak__ClientId", "auth-web")
         .WithEnvironment("Auth__Keycloak__ClientSecret", devAuthWebClientSecret)
+        .WithEnvironment("Auth__Keycloak__Authority", keycloakBrowserAuthority)
         .WithReference(keycloak)
         .WaitFor(keycloak);
 }

--- a/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
+++ b/src/Hosting/Erp.Hosting.AppHost/AppHost.cs
@@ -13,7 +13,22 @@ const string devJwtSigningKey = "erp-for-factory-games-local-apphost-hs256-dev-k
 const string devKeycloakClientSecret = "erp-for-factory-games-local-apphost-satisfactory-web-dev-secret";
 const string devCoiWebClientSecret = "erp-for-factory-games-local-apphost-coi-web-dev-secret";
 const string devAuthWebClientSecret = "erp-for-factory-games-local-apphost-auth-web-dev-secret";
+// Shared between the steam-oidc bridge's OpenId__ClientSecret and the realm's
+// `steam` broker config (realm-erp.json). NOT a production secret.
+const string devSteamBrokerClientSecret = "erp-for-factory-games-local-apphost-steam-broker-dev-secret";
 const string keycloakRealm = "erp";
+// Pinned Keycloak host port so the browser-facing login URL is deterministic.
+// The Steam bridge must allow Keycloak's broker callback as a redirect_uri, and
+// that callback is browser-derived (http://localhost:<this>/...), NOT the
+// internal container-network address — so it has to be a fixed, known value.
+const int keycloakHostPort = 8088;
+
+// Steam sign-in (ADR-0028 §4 / #303). Opt-in: only when a Steam Web API key is
+// supplied via the STEAM_API_KEY env var do we stand up the byo-software
+// Steam→OIDC bridge that Keycloak brokers. Keyless `dotnet run` is unchanged —
+// the realm still advertises a "Sign in with Steam" button, but it only works
+// once the bridge is running (Steam is prod/opt-in per ADR-0028).
+var steamApiKey = builder.Configuration["STEAM_API_KEY"];
 
 // Auth backend selection (ADR-0028 / #292). Defaults to `keycloak` so a plain
 // `dotnet run` gives the full human-login experience (Keycloak container + OIDC
@@ -29,8 +44,39 @@ var useKeycloak = string.Equals(authBackend, "keycloak", StringComparison.Ordina
 // `satisfactory-web` client + a seeded dev user). The prod containers ride #281.
 // Only stood up under the keycloak backend — null on the dev path.
 IResourceBuilder<KeycloakResource>? keycloak = useKeycloak
-    ? builder.AddKeycloak("keycloak").WithRealmImport("./keycloak")
+    ? builder.AddKeycloak("keycloak", port: keycloakHostPort).WithRealmImport("./keycloak")
     : null;
+
+// Steam→OIDC bridge (ADR-0028 §4 / #303). Steam speaks legacy OpenID 2.0 which
+// Keycloak dropped, so this small .NET container presents Steam as a standard
+// OIDC provider and Keycloak brokers it (the `steam` IdP in realm-erp.json).
+//
+// Dual URL on purpose: the browser reaches the bridge at the pinned host port
+// (http://localhost:8099 — used for the authorization redirect + Steam return,
+// and baked into the realm's authorizationUrl/issuer), while Keycloak reaches it
+// server-side over the Aspire container network as http://steam-oidc:8080 (the
+// realm's tokenUrl/jwksUrl). OpenId__RedirectUri points back at Keycloak's own
+// broker endpoint, tracked via an endpoint reference so it follows Keycloak's
+// dynamic host port. No keycloak.WaitFor here — the bridge is only needed when a
+// human clicks "Sign in with Steam", long after startup; coupling Keycloak's
+// boot to it would needlessly gate username/password login too.
+if (keycloak is not null && !string.IsNullOrWhiteSpace(steamApiKey))
+{
+    // Plain string (not a ReferenceExpression) — the browser-derived callback URL.
+    var steamBrokerRedirectUri = $"http://localhost:{keycloakHostPort}/realms/{keycloakRealm}/broker/steam/endpoint";
+    builder.AddContainer("steam-oidc", "ghcr.io/byo-software/steam-openid-connect-provider")
+        .WithHttpEndpoint(port: 8099, targetPort: 8080, name: "http")
+        .WithEnvironment("ASPNETCORE_URLS", "http://+:8080")
+        .WithEnvironment("Steam__ApplicationKey", steamApiKey)
+        .WithEnvironment("OpenId__ClientId", "steam-broker")
+        .WithEnvironment("OpenId__ClientSecret", devSteamBrokerClientSecret)
+        .WithEnvironment("OpenId__ClientName", "ERP Keycloak")
+        .WithEnvironment("Hosting__PublicOrigin", "http://localhost:8099")
+        // Browser-facing Keycloak broker callback (NOT the internal container URL):
+        // IdentityServer4 validates this against the redirect_uri Keycloak sends,
+        // which the browser derives from the pinned host port above.
+        .WithEnvironment("OpenId__RedirectUri", steamBrokerRedirectUri);
+}
 
 // Auth API owns player + agent-token aggregate per ADR-0026. Phase 5c2
 // landed the /players/* + /api/me endpoints + DevPlayerBootstrap here; 5c3

--- a/src/Hosting/Erp.Hosting.AppHost/keycloak/README.md
+++ b/src/Hosting/Erp.Hosting.AppHost/keycloak/README.md
@@ -1,0 +1,48 @@
+# Keycloak realm (`erp`)
+
+`realm-erp.json` is the versioned realm imported on Keycloak startup
+(`WithRealmImport("./keycloak")` in `AppHost.cs`, ADR-0028 §3/§6). It defines the
+confidential clients (`satisfactory-web`, `coi-web`, `auth-web`), a seeded dev
+user (`chris` / `chris`), and the `steam` identity-provider broker.
+
+## Steam sign-in (local dev, ADR-0028 §4 / #303)
+
+Steam speaks legacy OpenID 2.0, which Keycloak dropped, so Keycloak brokers the
+[`byo-software/steam-openid-connect-provider`](https://github.com/byo-software/steam-openid-connect-provider)
+bridge (the `steam-oidc` container) as a generic OIDC IdP.
+
+**Opt-in:** the bridge only starts when a Steam Web API key is supplied. Without
+one, the realm still shows a "Sign in with Steam" button but it won't complete —
+local dev otherwise uses username/password.
+
+```bash
+export STEAM_API_KEY=<your Steam Web API key>   # https://steamcommunity.com/dev/apikey
+dotnet run --project src/Hosting/Erp.Hosting.AppHost
+```
+
+Then open the Satisfactory web app → it redirects to Keycloak → **Sign in with
+Steam** → Steam login → back to the app, authenticated (a `Player` is
+JIT-provisioned from the brokered identity).
+
+### Pinned ports (why they're fixed, not dynamic)
+
+The broker config in `realm-erp.json` and the bridge's allowed redirect URI are
+static, so the URLs they reference must be deterministic:
+
+- **`steam-oidc` → `http://localhost:8099`** — the browser-facing bridge origin
+  (`Hosting__PublicOrigin`, and the realm's `authorizationUrl`/`issuer`).
+- **`keycloak` → `http://localhost:8088`** — the browser-facing Keycloak origin;
+  the bridge allows `…:8088/realms/erp/broker/steam/endpoint` as Keycloak's
+  broker callback (IdentityServer4 validates the redirect_uri the browser sends).
+
+Dual-URL by design: Keycloak reaches the bridge **server-side** over the Aspire
+container network as `http://steam-oidc:8080` (the realm's `tokenUrl`/`jwksUrl`),
+while the **browser** uses `localhost:8099`. The bridge's issuer is set to the
+browser origin so the two stay consistent.
+
+## Production
+
+The prod containers (`keycloak`, `keycloak-db`, `steam-oidc`) + the broker config
+ride the #281 operational rollout in the `Homelab.Stacks.ErpForFactoryGames` repo,
+where `Steam__ApplicationKey` flows via Bitwarden + a Fallout `[Secret]` into
+`stack.env`. Not wired here yet.

--- a/src/Hosting/Erp.Hosting.AppHost/keycloak/realm-erp.json
+++ b/src/Hosting/Erp.Hosting.AppHost/keycloak/realm-erp.json
@@ -58,6 +58,31 @@
     }
   ],
 
+  "identityProviders": [
+    {
+      "alias": "steam",
+      "displayName": "Steam",
+      "providerId": "oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "linkOnly": false,
+      "config": {
+        "clientId": "steam-broker",
+        "clientSecret": "erp-for-factory-games-local-apphost-steam-broker-dev-secret",
+        "clientAuthMethod": "client_secret_post",
+        "issuer": "http://localhost:8099",
+        "authorizationUrl": "http://localhost:8099/connect/authorize",
+        "tokenUrl": "http://steam-oidc:8080/connect/token",
+        "jwksUrl": "http://steam-oidc:8080/.well-known/openid-configuration/jwks",
+        "userInfoUrl": "http://steam-oidc:8080/connect/userinfo",
+        "useJwksUrl": "true",
+        "defaultScope": "openid profile",
+        "syncMode": "IMPORT"
+      }
+    }
+  ],
+
   "users": [
     {
       "username": "chris",

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/AuthOptions.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/AuthOptions.cs
@@ -48,6 +48,16 @@ public sealed class AuthOptions
         /// <summary>Realm the tokens are issued from.</summary>
         public string Realm { get; set; } = "erp";
 
+        /// <summary>Optional fixed token issuer/authority (e.g.
+        /// <c>http://localhost:8088/realms/erp</c>). When set, it overrides the
+        /// service-discovery-resolved authority for both metadata discovery and
+        /// issuer validation. Local dev pins this (via the AppHost) so the issuer
+        /// the APIs trust matches the fixed browser-facing origin tokens are
+        /// minted under — otherwise service discovery resolves Keycloak's dynamic
+        /// HTTPS endpoint and every Keycloak access token fails issuer validation
+        /// (#303). Empty keeps today's service-discovery behaviour.</summary>
+        public string Authority { get; set; } = "";
+
         /// <summary>Expected <c>aud</c> claim. Empty disables audience validation
         /// (the dev realm doesn't add an audience mapper — prod hardening does).</summary>
         public string Audience { get; set; } = "";

--- a/src/Presentation/Api/Erp.Presentation.Api.Common/ErpUserAuthExtensions.cs
+++ b/src/Presentation/Api/Erp.Presentation.Api.Common/ErpUserAuthExtensions.cs
@@ -54,6 +54,20 @@ public static class ErpUserAuthExtensions
                 options.MapInboundClaims = false;
                 options.TokenValidationParameters.NameClaimType = "preferred_username";
 
+                // Local-dev determinism (#303): when a fixed authority is pinned
+                // (http://localhost:8088/realms/erp), validate tokens against it
+                // instead of the service-discovery-resolved endpoint. Tokens are
+                // minted under that fixed browser-facing origin, so their `iss`
+                // is http://localhost:8088/...; without this the API trusts
+                // Keycloak's dynamic HTTPS issuer and every user token 401s.
+                if (!string.IsNullOrWhiteSpace(auth.Keycloak.Authority))
+                {
+                    var authority = auth.Keycloak.Authority.TrimEnd('/');
+                    options.Authority = authority;
+                    options.MetadataAddress = $"{authority}/.well-known/openid-configuration";
+                    options.TokenValidationParameters.ValidIssuer = authority;
+                }
+
                 if (string.IsNullOrWhiteSpace(auth.Keycloak.Audience))
                 {
                     // The dev realm doesn't attach an audience mapper; prod

--- a/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/Program.cs
+++ b/src/Presentation/Web/CaptainOfIndustry.Presentation.Web/Program.cs
@@ -52,6 +52,20 @@ if (useKeycloak)
             oidc.TokenValidationParameters.NameClaimType = "preferred_username";
             // Keycloak runs behind plain HTTP locally (Aspire / compose network).
             oidc.RequireHttpsMetadata = false;
+
+            // Local-dev determinism (#303): when the AppHost pins a browser-facing
+            // authority (http://localhost:8088), use it for both metadata discovery
+            // and the browser redirects so Keycloak emits that fixed origin
+            // everywhere — including the Steam broker callback the steam-oidc bridge
+            // validates against its pinned allow-list. Without this, the Aspire
+            // service reference resolves Keycloak's dynamic HTTPS endpoint and the
+            // broker redirect_uri never matches the bridge.
+            var pinnedAuthority = builder.Configuration["Auth:Keycloak:Authority"];
+            if (!string.IsNullOrWhiteSpace(pinnedAuthority))
+            {
+                oidc.Authority = pinnedAuthority;
+                oidc.MetadataAddress = $"{pinnedAuthority.TrimEnd('/')}/.well-known/openid-configuration";
+            }
         });
 
     builder.Services.AddAuthorization();

--- a/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
+++ b/src/Presentation/Web/Erp.Presentation.Web.Auth/Program.cs
@@ -71,6 +71,20 @@ if (useKeycloak)
             oidc.TokenValidationParameters.NameClaimType = "preferred_username";
             // Keycloak runs behind plain HTTP locally (Aspire / compose network).
             oidc.RequireHttpsMetadata = false;
+
+            // Local-dev determinism (#303): when the AppHost pins a browser-facing
+            // authority (http://localhost:8088), use it for both metadata discovery
+            // and the browser redirects so Keycloak emits that fixed origin
+            // everywhere — including the Steam broker callback the steam-oidc bridge
+            // validates against its pinned allow-list. Without this, the Aspire
+            // service reference resolves Keycloak's dynamic HTTPS endpoint and the
+            // broker redirect_uri never matches the bridge.
+            var pinnedAuthority = builder.Configuration["Auth:Keycloak:Authority"];
+            if (!string.IsNullOrWhiteSpace(pinnedAuthority))
+            {
+                oidc.Authority = pinnedAuthority;
+                oidc.MetadataAddress = $"{pinnedAuthority.TrimEnd('/')}/.well-known/openid-configuration";
+            }
         });
 
     builder.Services.AddAuthorization();

--- a/src/Presentation/Web/Satisfactory.Presentation.Web/Program.cs
+++ b/src/Presentation/Web/Satisfactory.Presentation.Web/Program.cs
@@ -64,6 +64,20 @@ if (useKeycloak)
             // Keycloak runs behind plain HTTP locally (Aspire / compose network).
             oidc.RequireHttpsMetadata = false;
 
+            // Local-dev determinism (#303): when the AppHost pins a browser-facing
+            // authority (http://localhost:8088), use it for both metadata discovery
+            // and the browser redirects so Keycloak emits that fixed origin
+            // everywhere — including the Steam broker callback the steam-oidc bridge
+            // validates against its pinned allow-list. Without this, the Aspire
+            // service reference resolves Keycloak's dynamic HTTPS endpoint and the
+            // broker redirect_uri never matches the bridge.
+            var pinnedAuthority = builder.Configuration["Auth:Keycloak:Authority"];
+            if (!string.IsNullOrWhiteSpace(pinnedAuthority))
+            {
+                oidc.Authority = pinnedAuthority;
+                oidc.MetadataAddress = $"{pinnedAuthority.TrimEnd('/')}/.well-known/openid-configuration";
+            }
+
             // Capture the access token server-side at login, keyed by sub, so the
             // circuit can forward it later (UserAccessTokenAccessor). HttpContext
             // is guaranteed in this callback.


### PR DESCRIPTION
Part of #303 — the **Steam** slice. ADR-0028 §4: Steam speaks legacy OpenID 2.0
(Keycloak dropped it), so Keycloak brokers the
[`byo-software/steam-openid-connect-provider`](https://github.com/byo-software/steam-openid-connect-provider)
bridge as a generic OIDC IdP. This adds a "Sign in with Steam" path to the
Keycloak login that #302/#304 stood up.

## What's included
- **AppHost** — opt-in `steam-oidc` container, only stood up when `STEAM_API_KEY`
  is set, so keyless `dotnet run` is unchanged. Pinned ports give the static realm
  deterministic URLs: bridge on **:8099** (browser/authz leg), Keycloak on
  **:8088** (browser/broker-callback leg). Keycloak reaches the bridge server-side
  over the Aspire network as `steam-oidc:8080`.
- **realm-erp.json** — a `steam` generic-OIDC broker. **Dual-URL by design**:
  `authorizationUrl`/`issuer` on the browser origin (`localhost:8099`),
  `tokenUrl`/`jwksUrl` on the internal `steam-oidc:8080`. The browser-facing
  `OpenId__RedirectUri` (Keycloak's callback) is hardcoded to `localhost:8088`
  because IdentityServer4 validates it against the browser-derived redirect_uri —
  the internal container URL would fail.
- **keycloak/README.md** — operator notes, the `export STEAM_API_KEY=… && dotnet
  run` flow, and why the ports are pinned.

## Live round-trip done — two bugs found & fixed (commits `04e6e4b`, `2471f7f`)
The live Steam login (real key + account) surfaced that pinning `:8088` wasn't
enough — nothing actually made the browser/APIs *use* `:8088`. Aspire's `keycloak`
service reference resolves Keycloak's dynamic **HTTPS** endpoint (`:56715`), which
broke the flow in two places:

1. **Login leg** — Keycloak derived its Steam-broker callback `redirect_uri` from
   the `:56715` origin, so the bridge rejected it (`Invalid redirect_uri`; allow
   -list is `http://localhost:8088/.../broker/steam/endpoint`) — dead end before
   ever reaching Steam.
2. **Token leg** — tokens minted under `:8088` carry `iss=http://localhost:8088/realms/erp`,
   but the APIs validate via `AddKeycloakJwtBearer` against the `:56715` issuer, so
   every Keycloak user token `401`s — `/players/current` never provisions a Player.

**Fix (`04e6e4b`):** the AppHost pins a browser-facing authority
(`http://localhost:8088/realms/erp`) and injects it as `Auth__Keycloak__Authority`
into all three web frontends and all three APIs (local-dev only; empty keeps the
service-discovery behaviour for prod). Web frontends override `oidc.Authority` +
`MetadataAddress`; APIs override the JwtBearer `Authority` + `MetadataAddress` +
`ValidIssuer` so they trust the same fixed issuer tokens are minted under.

**Dev-loop nicety (`2471f7f`):** `WithDataBindMount("./keycloak-data")` (gitignored)
persists the realm DB so brokered identities survive restarts — no re-doing
first-broker-login each pass. Caveat: realm imports only when absent, so delete
`./keycloak-data` to re-import after `realm-erp.json` edits.

## Verification
- Bridge boots and serves the expected discovery endpoints; realm imports cleanly;
  the `steam` IdP registers and the `:8088` login renders **Sign in with Steam**.
- **Live round-trip (real Steam key + account):** Satisfactory app → Keycloak
  (`:8088`) → Sign in with Steam → bridge accepts the callback → real Steam login →
  Keycloak JIT-creates the Steam-federated user (`federatedIdentities` → `steam`,
  `…/id/765611981039xxxxx`) → back to the app authenticated → profile-completion
  step (Steam supplies no email) → setup page.
- **API auth + provisioning:** `/players/current` with a `:8088`-issued token went
  `401` → `200` and JIT-provisioned a `Player` keyed by the OIDC `sub`.
- All Aspire resources healthy; **UI suite path (`Auth:Backend=dev`) unaffected** —
  the authority pin only applies under the keycloak backend.

## Out of scope (noted)
- Google / Microsoft / Apple brokers (also in #303) — later.
- Prod compose (`keycloak`/`keycloak-db`/`steam-oidc`) in the
  `Homelab.Stacks.ErpForFactoryGames` repo — rides the #281 operational rollout,
  with `Steam__ApplicationKey` via Bitwarden + a Fallout `[Secret]`. The authority
  pin is a local-dev shim; prod uses real hostnames so the issuer is already
  deterministic.